### PR TITLE
Apply reviewed Jules session improvements

### DIFF
--- a/assets/web/chat.js
+++ b/assets/web/chat.js
@@ -384,7 +384,7 @@ const Chat = {
 
         // Code blocks: ```lang\n...\n```
         html = html.replace(/```(\w*)\n([\s\S]*?)```/g, (_m, _lang, code) => {
-            return `<pre><code>${code}</code></pre>`;
+            return `<pre><code>${code.trim()}</code></pre>`;
         });
 
         // Inline code: `...`

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -295,7 +295,7 @@ impl Agent {
         let mut sys_interrupt_rx = interrupt::dead_interrupt_rx();
 
         // System turns don't inject time context (no user-facing timestamps)
-        let texts = execute_turn(
+        let mut texts = execute_turn(
             provider,
             &self.tools,
             &self.tool_filter,
@@ -311,7 +311,7 @@ impl Agent {
         )
         .await?;
 
-        let response = texts.last().cloned().unwrap_or_default();
+        let response = texts.pop().unwrap_or_default();
 
         Ok(SystemTurnResult {
             response,

--- a/src/background/subagent.rs
+++ b/src/background/subagent.rs
@@ -238,7 +238,7 @@ pub(crate) async fn execute_subagent(
         subagents: SubagentsContext::none(),
     };
 
-    let texts: Vec<String> = execute_turn(
+    let mut texts: Vec<String> = execute_turn(
         &*resources.provider,
         &resources.tools,
         &resources.tool_filter,
@@ -265,7 +265,7 @@ pub(crate) async fn execute_subagent(
     )
     .await;
 
-    let summary = texts.last().cloned().unwrap_or_default();
+    let summary = texts.pop().unwrap_or_default();
     let messages = recent_messages.messages().to_vec();
     Ok(SubAgentOutput { summary, messages })
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -295,4 +295,59 @@ main = "my-provider/claude-sonnet-4-6"
             "secret reference should resolve with real store: {result:?}"
         );
     }
+
+    #[test]
+    fn load_at_returns_error_on_invalid_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.toml");
+
+        // Write invalid TOML syntax
+        std::fs::write(&config_path, "invalid toml syntax = [").unwrap();
+
+        let result = Config::load_at(dir.path());
+
+        assert!(
+            result.is_err(),
+            "load_at should fail on invalid TOML syntax"
+        );
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, ResiduumError::Config(_)),
+            "error should be of type ResiduumError::Config, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn validate_toml_rejects_invalid_toml_syntax() {
+        let dir = tempfile::tempdir().unwrap();
+        let bad_toml = "this is not valid toml";
+        let result = Config::validate_toml(bad_toml, dir.path());
+        assert!(result.is_err(), "invalid TOML syntax should fail parse");
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("TOML parse error"),
+            "error should mention TOML parse error: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_toml_rejects_invalid_model_format() {
+        let dir = tempfile::tempdir().unwrap();
+        let bad_config = r#"
+timezone = "UTC"
+
+[models]
+main = "invalid-format"
+"#;
+        let result = Config::validate_toml(bad_config, dir.path());
+        assert!(
+            result.is_err(),
+            "missing slash in model should fail validation"
+        );
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("expected 'provider/model' format"),
+            "error should mention expected format: {err}"
+        );
+    }
 }

--- a/src/config/provider.rs
+++ b/src/config/provider.rs
@@ -11,7 +11,7 @@ use super::constants::{
 ///
 /// Every role (main, observer, reflector, pulse) gets a fully resolved
 /// `ProviderSpec` at config load time — no `Option` chains at use sites.
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct ProviderSpec {
     /// Human-readable identifier (provider entry name or implicit kind).
     pub name: String,
@@ -35,7 +35,7 @@ impl fmt::Debug for ProviderSpec {
 }
 
 /// Parsed model specification from `"provider/model"` format.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ModelSpec {
     /// The provider kind.
     pub kind: ProviderKind,

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -220,14 +220,16 @@ impl BackgroundModelsConfig {
         match tier {
             BackgroundModelTier::Small => self
                 .small
-                .clone()
-                .or_else(|| self.medium.clone())
-                .or_else(|| self.large.clone())
+                .as_ref()
+                .or(self.medium.as_ref())
+                .or(self.large.as_ref())
+                .cloned()
                 .unwrap_or_else(|| main.to_vec()),
             BackgroundModelTier::Medium => self
                 .medium
-                .clone()
-                .or_else(|| self.large.clone())
+                .as_ref()
+                .or(self.large.as_ref())
+                .cloned()
                 .unwrap_or_else(|| main.to_vec()),
             BackgroundModelTier::Large => self.large.clone().unwrap_or_else(|| main.to_vec()),
         }
@@ -309,5 +311,109 @@ mod tests {
             let s = tier.to_string();
             assert_eq!(s.parse::<BackgroundModelTier>().unwrap(), tier);
         }
+    }
+
+    #[test]
+    fn resolve_tier_tests() {
+        use super::super::provider::{ModelSpec, ProviderKind};
+
+        let p_small = ProviderSpec {
+            name: "dummy-small".to_string(),
+            model: ModelSpec {
+                kind: ProviderKind::OpenAi,
+                model: "small-model".to_string(),
+            },
+            provider_url: "http://dummy".to_string(),
+            api_key: None,
+        };
+        let p_medium = ProviderSpec {
+            name: "dummy-medium".to_string(),
+            model: ModelSpec {
+                kind: ProviderKind::OpenAi,
+                model: "medium-model".to_string(),
+            },
+            provider_url: "http://dummy".to_string(),
+            api_key: None,
+        };
+        let p_large = ProviderSpec {
+            name: "dummy-large".to_string(),
+            model: ModelSpec {
+                kind: ProviderKind::OpenAi,
+                model: "large-model".to_string(),
+            },
+            provider_url: "http://dummy".to_string(),
+            api_key: None,
+        };
+        let p_main = ProviderSpec {
+            name: "dummy-main".to_string(),
+            model: ModelSpec {
+                kind: ProviderKind::OpenAi,
+                model: "main-model".to_string(),
+            },
+            provider_url: "http://dummy".to_string(),
+            api_key: None,
+        };
+
+        let main_slice = std::slice::from_ref(&p_main);
+
+        // All present -> resolves to specific tier
+        let config_full = BackgroundModelsConfig {
+            small: Some(vec![p_small.clone()]),
+            medium: Some(vec![p_medium.clone()]),
+            large: Some(vec![p_large.clone()]),
+        };
+        assert_eq!(
+            config_full.resolve_tier(&BackgroundModelTier::Small, main_slice),
+            vec![p_small.clone()]
+        );
+        assert_eq!(
+            config_full.resolve_tier(&BackgroundModelTier::Medium, main_slice),
+            vec![p_medium.clone()]
+        );
+        assert_eq!(
+            config_full.resolve_tier(&BackgroundModelTier::Large, main_slice),
+            vec![p_large.clone()]
+        );
+
+        // Missing small -> small falls back to medium
+        let config_no_small = BackgroundModelsConfig {
+            small: None,
+            medium: Some(vec![p_medium.clone()]),
+            large: Some(vec![p_large.clone()]),
+        };
+        assert_eq!(
+            config_no_small.resolve_tier(&BackgroundModelTier::Small, main_slice),
+            vec![p_medium.clone()]
+        );
+
+        // Missing small and medium -> small and medium fall back to large
+        let config_only_large = BackgroundModelsConfig {
+            small: None,
+            medium: None,
+            large: Some(vec![p_large.clone()]),
+        };
+        assert_eq!(
+            config_only_large.resolve_tier(&BackgroundModelTier::Small, main_slice),
+            vec![p_large.clone()]
+        );
+        assert_eq!(
+            config_only_large.resolve_tier(&BackgroundModelTier::Medium, main_slice),
+            vec![p_large.clone()]
+        );
+
+        // Empty config -> all fall back to main
+        let config_empty = BackgroundModelsConfig::default();
+        assert_eq!(
+            config_empty.resolve_tier(&BackgroundModelTier::Small, main_slice),
+            vec![p_main.clone()]
+        );
+        assert_eq!(
+            config_empty.resolve_tier(&BackgroundModelTier::Medium, main_slice),
+            vec![p_main.clone()]
+        );
+        assert_eq!(
+            config_empty.resolve_tier(&BackgroundModelTier::Large, main_slice),
+            vec![p_main.clone()]
+        );
     }
 }

--- a/src/memory/vector_store.rs
+++ b/src/memory/vector_store.rs
@@ -312,18 +312,26 @@ impl VectorStore {
             return Ok(());
         }
 
-        let conn = self.lock_conn()?;
+        let mut conn = self.lock_conn()?;
+        let tx = conn.transaction().map_err(|e| {
+            ResiduumError::Memory(format!("failed to begin delete transaction: {e}"))
+        })?;
+
         for id in ids {
             // Try both tables — a given ID only exists in one
-            conn.execute("DELETE FROM obs_vectors WHERE obs_id = ?1", [id])
+            tx.execute("DELETE FROM obs_vectors WHERE obs_id = ?1", [id])
                 .map_err(|e| {
                     ResiduumError::Memory(format!("failed to delete from obs_vectors: {e}"))
                 })?;
-            conn.execute("DELETE FROM chunk_vectors WHERE chunk_id = ?1", [id])
+            tx.execute("DELETE FROM chunk_vectors WHERE chunk_id = ?1", [id])
                 .map_err(|e| {
                     ResiduumError::Memory(format!("failed to delete from chunk_vectors: {e}"))
                 })?;
         }
+
+        tx.commit().map_err(|e| {
+            ResiduumError::Memory(format!("failed to commit delete transaction: {e}"))
+        })?;
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

- **Delete transaction wrapping** — `delete_by_doc_ids` now runs in a transaction, matching the insert optimization from PR #18
- **Clone optimization** — `resolve_tier` fallback chains use `.as_ref().or().cloned()` to avoid cloning unused branches
- **PartialEq derives** — `ProviderSpec` and `ModelSpec` gain `PartialEq` for test assertions
- **New tests** — `resolve_tier` fallback behavior, `load_at` with invalid TOML, `validate_toml` with bad syntax and bad model format
- **Markdown fix** — `.trim()` on code block content in chat.js to remove trailing whitespace
- **Micro-optimization** — `.last().cloned()` replaced with `.pop()` in agent/subagent turn results

### Rejected sessions (not included)
- **Exec tool string→array** — breaks LLM agent command composition (can't use pipes, redirects, etc.)
- **Insert transaction wrapping** — already merged in PR #18
- **Criterion benchmarks** — too heavy a dependency for this project's needs
- **`repro.js` test artifact** — doesn't belong in project root

## Test plan
- [x] Pre-commit hooks pass (fmt, clippy, tests)
- [x] Pre-push hooks pass (full test suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)