### PR TITLE
feat: workspace config loaders + hot-reload (Phase 3)

### DIFF
--- a/src/gateway/server/mod.rs
+++ b/src/gateway/server/mod.rs
@@ -11,6 +11,7 @@ mod memory;
 pub mod setup;
 mod spawn_helpers;
 mod startup;
+mod watcher;
 pub(crate) mod web;
 mod ws;
 
@@ -35,7 +36,7 @@ use crate::memory::reflector::Reflector;
 use crate::memory::search::MemoryIndex;
 use crate::memory::types::Visibility;
 use crate::memory::vector_store::VectorStore;
-use crate::models::{EmbeddingProvider, Message};
+use crate::models::{EmbeddingProvider, Message, SharedHttpClient};
 use crate::notify::router::NotificationRouter;
 use crate::notify::types::{
     BuiltinChannel, ChannelTarget, Notification, TaskSource, parse_channel_list,
@@ -67,8 +68,7 @@ pub(crate) enum ReloadSignal {
     None,
     /// Full root config reload (config.toml changed).
     Root,
-    /// Workspace-level reload (project or skill changes). Used in Phase 3+.
-    #[expect(dead_code, reason = "variant used in later reload phases")]
+    /// Workspace-level reload (mcp.json or channels.toml changed).
     Workspace,
 }
 
@@ -169,6 +169,7 @@ struct GatewayRuntime {
     skill_state: SharedSkillState,
     pulse_enabled: bool,
     notification_router: Arc<NotificationRouter>,
+    http_client: SharedHttpClient,
     background_spawner: Arc<BackgroundTaskSpawner>,
     background_result_rx: mpsc::Receiver<BackgroundResult>,
     spawn_context: Arc<SpawnContext>,
@@ -347,6 +348,13 @@ pub async fn run_gateway(cfg: Config) -> Result<GatewayExit, ResiduumError> {
     let sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
         .map_err(|e| ResiduumError::Gateway(format!("failed to register SIGTERM handler: {e}")))?;
 
+    // Spawn workspace config file watcher
+    let _watcher_handle = watcher::spawn_workspace_watcher(
+        parts.layout.mcp_json(),
+        parts.layout.channels_toml(),
+        core.reload_tx.clone(),
+    );
+
     let rt = GatewayRuntime {
         layout: parts.layout,
         tz: parts.tz,
@@ -363,6 +371,7 @@ pub async fn run_gateway(cfg: Config) -> Result<GatewayExit, ResiduumError> {
         skill_state: parts.skill_state,
         pulse_enabled: parts.pulse_enabled,
         notification_router: parts.notification_router,
+        http_client: parts.http_client,
         background_spawner: parts.background_spawner,
         background_result_rx: parts.background_result_rx,
         spawn_context: parts.spawn_context,
@@ -833,6 +842,51 @@ fn handle_root_reload(rt: &mut GatewayRuntime) {
     }
 }
 
+/// Handle a workspace config reload (mcp.json or channels.toml changed).
+async fn handle_workspace_reload(rt: &mut GatewayRuntime) {
+    tracing::info!("handling workspace config reload");
+
+    // Reload MCP servers
+    match crate::workspace::config::load_mcp_servers(&rt.layout.mcp_json()) {
+        Ok(servers) => {
+            let report = rt
+                .mcp_registry
+                .write()
+                .await
+                .reconcile_and_connect(&servers)
+                .await;
+            tracing::info!(
+                started = report.started,
+                stopped = report.stopped,
+                "MCP servers reconciled"
+            );
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to reload mcp.json, keeping current servers");
+        }
+    }
+
+    // Reload notification channels
+    match crate::workspace::config::load_channel_configs(&rt.layout.channels_toml()) {
+        Ok(configs) => {
+            let channels = crate::workspace::config::build_external_channels(
+                &configs,
+                rt.http_client.client(),
+            );
+            rt.notification_router.reload_channels(channels).await;
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to reload channels.toml, keeping current channels");
+        }
+    }
+
+    rt.broadcast_tx
+        .send(ServerMessage::Notice {
+            message: "workspace configuration reloaded".to_string(),
+        })
+        .ok();
+}
+
 /// Run the main gateway event loop.
 ///
 /// Processes inbound messages, pulse ticks, action ticks, and memory pipeline
@@ -868,7 +922,7 @@ async fn run_event_loop(mut rt: GatewayRuntime) -> GatewayExit {
                         handle_root_reload(&mut rt);
                     }
                     ReloadSignal::Workspace => {
-                        tracing::info!("workspace reload not yet implemented");
+                        handle_workspace_reload(&mut rt).await;
                     }
                 }
             }

--- a/src/gateway/server/startup.rs
+++ b/src/gateway/server/startup.rs
@@ -1,6 +1,5 @@
 //! Gateway initialization: builds all subsystems before the event loop starts.
 
-use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -26,7 +25,7 @@ use crate::models::{
     CompletionOptions, EmbeddingProvider, HttpClientConfig, SharedHttpClient,
     build_embedding_provider, build_provider_chain,
 };
-use crate::notify::channels::{InboxChannel, NotificationChannel};
+use crate::notify::channels::InboxChannel;
 use crate::notify::router::NotificationRouter;
 use crate::projects::activation::{ProjectState, SharedProjectState};
 use crate::projects::scanner::ProjectIndex;
@@ -61,6 +60,7 @@ pub(super) struct GatewayComponents {
     pub(super) embedding_provider: Option<Arc<dyn EmbeddingProvider>>,
     pub(super) pulse_enabled: bool,
     pub(super) notification_router: Arc<NotificationRouter>,
+    pub(super) http_client: SharedHttpClient,
     pub(super) background_spawner: Arc<BackgroundTaskSpawner>,
     pub(super) background_result_rx: mpsc::Receiver<BackgroundResult>,
     pub(super) spawn_context: Arc<SpawnContext>,
@@ -303,6 +303,9 @@ pub(super) async fn initialize(cfg: &Config) -> Result<GatewayComponents, Residu
         layout.background_dir(),
     ));
 
+    // Clone HTTP client for later use (channel building, reload handler)
+    let http_for_channels = http.clone();
+
     // SpawnContext for pulse/actions/on-demand background task spawning
     let spawn_context = Arc::new(SpawnContext {
         background_config: cfg.background.clone(),
@@ -319,26 +322,80 @@ pub(super) async fn initialize(cfg: &Config) -> Result<GatewayComponents, Residu
         tz,
     });
 
+    // Load workspace MCP servers
+    let mcp_registry = crate::mcp::McpRegistry::new_shared();
+    match crate::workspace::config::load_mcp_servers(&layout.mcp_json()) {
+        Ok(servers) => {
+            if !servers.is_empty() {
+                let report = mcp_registry
+                    .write()
+                    .await
+                    .reconcile_and_connect(&servers)
+                    .await;
+                tracing::info!(
+                    started = report.started,
+                    stopped = report.stopped,
+                    failures = report.failures.len(),
+                    "workspace MCP servers loaded"
+                );
+            }
+        }
+        Err(err) => {
+            eprintln!(
+                "warning: failed to load mcp.json, starting without workspace MCP servers: {err}"
+            );
+            tracing::warn!(error = %err, "workspace MCP servers degraded");
+        }
+    }
+
+    // Load workspace notification channels
+    let channel_configs = match crate::workspace::config::load_channel_configs(
+        &layout.channels_toml(),
+    ) {
+        Ok(configs) => configs,
+        Err(err) => {
+            eprintln!(
+                "warning: failed to load channels.toml, starting without external channels: {err}"
+            );
+            tracing::warn!(error = %err, "workspace channels degraded");
+            Vec::new()
+        }
+    };
+    let valid_external_channels: std::collections::HashSet<String> =
+        channel_configs.iter().map(|c| c.name.clone()).collect();
+    let external_channels = crate::workspace::config::build_external_channels(
+        &channel_configs,
+        http_for_channels.client(),
+    );
+    let inbox_channel = InboxChannel::new(layout.inbox_dir(), cfg.timezone);
+    let notification_router = Arc::new(NotificationRouter::new(
+        external_channels,
+        Some(inbox_channel),
+    ));
+
     // Tool registry — block writes to config files (user-managed)
-    let blocked: std::collections::HashSet<std::path::PathBuf> = [
+    let mut blocked_paths: Vec<std::path::PathBuf> = vec![
         cfg.config_dir.join("config.toml"),
         cfg.config_dir.join("config.example.toml"),
         cfg.config_dir.join("providers.toml"),
         cfg.config_dir.join("providers.example.toml"),
-    ]
-    .into_iter()
-    .collect();
+    ];
+    if !cfg.agent.modify_mcp {
+        blocked_paths.push(layout.mcp_json());
+    }
+    if !cfg.agent.modify_channels {
+        blocked_paths.push(layout.channels_toml());
+    }
+    let blocked: std::collections::HashSet<std::path::PathBuf> =
+        blocked_paths.into_iter().collect();
     let path_policy =
         crate::tools::PathPolicy::new_shared_with_blocked(layout.root().to_path_buf(), blocked);
     let tool_filter = crate::tools::ToolFilter::new_shared(std::collections::HashSet::new());
-    let mcp_registry = crate::mcp::McpRegistry::new_shared();
     let mut tools = ToolRegistry::new();
     let file_tracker = crate::tools::FileTracker::new_shared();
     tools.register_defaults(file_tracker, Arc::clone(&path_policy));
     tools.register_search_tool(Arc::clone(&mem.hybrid_searcher));
     tools.register_memory_get_tool(layout.episodes_dir());
-    let valid_external_channels: std::collections::HashSet<String> =
-        std::collections::HashSet::new();
     tools.register_action_tools(
         Arc::clone(&action_store),
         Arc::clone(&action_notify),
@@ -365,8 +422,6 @@ pub(super) async fn initialize(cfg: &Config) -> Result<GatewayComponents, Residu
         valid_external_channels,
     );
 
-    // Notification router (built before agent so the tool can hold a reference)
-    let notification_router = Arc::new(build_notification_router(cfg, &layout));
     tools.register_send_message_tool(Arc::clone(&notification_router), layout.inbox_dir(), tz);
 
     // Agent
@@ -433,19 +488,11 @@ pub(super) async fn initialize(cfg: &Config) -> Result<GatewayComponents, Residu
         embedding_provider: providers.embedding_provider,
         pulse_enabled: cfg.pulse_enabled,
         notification_router,
+        http_client: http_for_channels,
         background_spawner,
         background_result_rx: bg_result_rx,
         spawn_context,
     })
-}
-
-/// Build a `NotificationRouter` with inbox only (no external channels).
-///
-/// External channels will be loaded from workspace config in Phase 3.
-fn build_notification_router(cfg: &Config, layout: &WorkspaceLayout) -> NotificationRouter {
-    let external_channels: HashMap<String, Box<dyn NotificationChannel>> = HashMap::new();
-    let inbox_channel = InboxChannel::new(layout.inbox_dir(), cfg.timezone);
-    NotificationRouter::new(external_channels, Some(inbox_channel))
 }
 
 /// Synchronize the search index (full rebuild or incremental sync).

--- a/src/gateway/server/watcher.rs
+++ b/src/gateway/server/watcher.rs
@@ -1,0 +1,137 @@
+//! Polling-based file watcher for workspace config hot-reload.
+
+use std::path::PathBuf;
+use std::time::SystemTime;
+
+use tokio::task::JoinHandle;
+use tokio::time::{Duration, sleep};
+
+use super::ReloadSignal;
+
+/// Tracks a file's modification time for change detection.
+struct WatchedFile {
+    path: PathBuf,
+    last_mtime: Option<SystemTime>,
+}
+
+impl WatchedFile {
+    fn new(path: PathBuf) -> Self {
+        let last_mtime = std::fs::metadata(&path).and_then(|m| m.modified()).ok();
+        Self { path, last_mtime }
+    }
+
+    /// Check if the file's mtime has changed since the last check.
+    ///
+    /// Returns `true` if mtime changed (file modified, created, or deleted).
+    fn check(&mut self) -> bool {
+        let current = std::fs::metadata(&self.path)
+            .and_then(|m| m.modified())
+            .ok();
+
+        if current == self.last_mtime {
+            false
+        } else {
+            self.last_mtime = current;
+            true
+        }
+    }
+}
+
+/// Spawn a polling watcher for workspace config files.
+///
+/// Polls `mcp_path` and `channels_path` every 2 seconds. When either file's
+/// mtime changes, debounces 500ms then sends `ReloadSignal::Workspace`.
+pub(super) fn spawn_workspace_watcher(
+    mcp_path: PathBuf,
+    channels_path: PathBuf,
+    reload_tx: tokio::sync::watch::Sender<ReloadSignal>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut mcp_file = WatchedFile::new(mcp_path);
+        let mut channels_file = WatchedFile::new(channels_path);
+        let mut interval = tokio::time::interval(Duration::from_secs(2));
+
+        // Skip the first immediate tick (files were just loaded at startup)
+        interval.tick().await;
+
+        loop {
+            interval.tick().await;
+
+            let mcp_changed = mcp_file.check();
+            let channels_changed = channels_file.check();
+
+            if mcp_changed || channels_changed {
+                tracing::debug!(
+                    mcp_changed,
+                    channels_changed,
+                    "workspace config file change detected, debouncing"
+                );
+
+                // Debounce: wait 500ms for any rapid edits to settle
+                sleep(Duration::from_millis(500)).await;
+
+                // Re-check to get the settled state
+                mcp_file.check();
+                channels_file.check();
+
+                tracing::info!("sending workspace reload signal");
+                if reload_tx.send(ReloadSignal::Workspace).is_err() {
+                    tracing::debug!("reload receiver dropped, stopping workspace watcher");
+                    break;
+                }
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test code uses unwrap for clarity")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn watched_file_detects_change() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.json");
+        std::fs::write(&path, "initial").unwrap();
+
+        let mut wf = WatchedFile::new(path.clone());
+
+        // First check after construction should return false (no change)
+        assert!(!wf.check(), "no change immediately after construction");
+
+        // Force a distinct mtime by setting it to 1 second in the future
+        let future = SystemTime::now() + std::time::Duration::from_secs(2);
+        let file = std::fs::File::options().write(true).open(&path).unwrap();
+        file.set_modified(future).unwrap();
+
+        assert!(wf.check(), "should detect mtime change after modification");
+    }
+
+    #[test]
+    fn watched_file_nonexistent() {
+        let mut wf = WatchedFile::new(PathBuf::from("/tmp/nonexistent_watcher_test_file"));
+
+        // Starts with None mtime, check returns false (no change from None → None)
+        assert!(!wf.check(), "nonexistent file should return false");
+    }
+
+    #[test]
+    fn watched_file_created() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("new_file.json");
+
+        // File doesn't exist at construction time
+        let mut wf = WatchedFile::new(path.clone());
+        assert!(
+            wf.last_mtime.is_none(),
+            "should start with None when file missing"
+        );
+
+        // Create the file
+        std::fs::write(&path, "created").unwrap();
+
+        // Should detect the creation (None → Some)
+        assert!(wf.check(), "should detect file creation");
+    }
+}

--- a/src/notify/router.rs
+++ b/src/notify/router.rs
@@ -11,7 +11,7 @@ use super::types::{BuiltinChannel, ChannelTarget, Notification, RouteOutcome};
 /// (`agent_wake`, `agent_feed`) are signaled via flags on `RouteOutcome` — the
 /// gateway acts on those flags. Inbox delivery is handled directly by the router.
 pub struct NotificationRouter {
-    external_channels: HashMap<String, Box<dyn NotificationChannel>>,
+    external_channels: tokio::sync::RwLock<HashMap<String, Box<dyn NotificationChannel>>>,
     inbox_channel: Option<InboxChannel>,
 }
 
@@ -23,7 +23,7 @@ impl NotificationRouter {
         inbox_channel: Option<InboxChannel>,
     ) -> Self {
         Self {
-            external_channels,
+            external_channels: tokio::sync::RwLock::new(external_channels),
             inbox_channel,
         }
     }
@@ -32,18 +32,22 @@ impl NotificationRouter {
     #[must_use]
     pub fn empty() -> Self {
         Self {
-            external_channels: HashMap::new(),
+            external_channels: tokio::sync::RwLock::new(HashMap::new()),
             inbox_channel: None,
         }
     }
 
     /// Replace external channels in-place (e.g. after a config reload).
-    pub fn reload_channels(&mut self, new_channels: HashMap<String, Box<dyn NotificationChannel>>) {
-        let old_count = self.external_channels.len();
-        self.external_channels = new_channels;
+    pub async fn reload_channels(
+        &self,
+        new_channels: HashMap<String, Box<dyn NotificationChannel>>,
+    ) {
+        let mut guard = self.external_channels.write().await;
+        let old_count = guard.len();
+        *guard = new_channels;
         tracing::info!(
             old_count,
-            new_count = self.external_channels.len(),
+            new_count = guard.len(),
             "notification channels reloaded"
         );
     }
@@ -115,7 +119,8 @@ impl NotificationRouter {
                     }
                 }
                 ChannelTarget::External(ext_name) => {
-                    if let Some(channel) = self.external_channels.get(ext_name.as_str()) {
+                    let guard = self.external_channels.read().await;
+                    if let Some(channel) = guard.get(ext_name.as_str()) {
                         match channel.deliver(notification).await {
                             Ok(()) => {
                                 outcome.external_dispatched.push(ext_name.clone());
@@ -154,23 +159,26 @@ impl NotificationRouter {
         channel_name: &str,
         notification: &Notification,
     ) -> anyhow::Result<()> {
-        let channel = self
-            .external_channels
+        let guard = self.external_channels.read().await;
+        let channel = guard
             .get(channel_name)
             .ok_or_else(|| anyhow::anyhow!("unknown external channel: {channel_name}"))?;
         channel.deliver(notification).await
     }
 
     /// Check if a named external channel is configured.
-    #[must_use]
-    pub fn has_external_channel(&self, name: &str) -> bool {
-        self.external_channels.contains_key(name)
+    pub async fn has_external_channel(&self, name: &str) -> bool {
+        self.external_channels.read().await.contains_key(name)
     }
 
     /// List the names of all configured external channels.
-    #[must_use]
-    pub fn external_channel_names(&self) -> Vec<&str> {
-        self.external_channels.keys().map(String::as_str).collect()
+    pub async fn external_channel_names(&self) -> Vec<String> {
+        self.external_channels
+            .read()
+            .await
+            .keys()
+            .cloned()
+            .collect()
     }
 }
 
@@ -303,23 +311,23 @@ mod tests {
         assert!(outcome.external_dispatched.is_empty());
     }
 
-    #[test]
-    fn has_external_channel_empty_router() {
+    #[tokio::test]
+    async fn has_external_channel_empty_router() {
         let router = NotificationRouter::empty();
-        assert!(!router.has_external_channel("ntfy"));
+        assert!(!router.has_external_channel("ntfy").await);
     }
 
-    #[test]
-    fn external_channel_names_empty() {
+    #[tokio::test]
+    async fn external_channel_names_empty() {
         let router = NotificationRouter::empty();
-        assert!(router.external_channel_names().is_empty());
+        assert!(router.external_channel_names().await.is_empty());
     }
 
-    #[test]
-    fn reload_channels_replaces_map() {
-        let mut router = NotificationRouter::empty();
+    #[tokio::test]
+    async fn reload_channels_replaces_map() {
+        let router = NotificationRouter::empty();
         assert!(
-            router.external_channel_names().is_empty(),
+            router.external_channel_names().await.is_empty(),
             "should start empty"
         );
 
@@ -334,13 +342,13 @@ mod tests {
             Box::new(InboxChannel::new(&inbox_dir, chrono_tz::UTC)),
         );
 
-        router.reload_channels(channels);
+        router.reload_channels(channels).await;
 
-        assert!(router.has_external_channel("test-inbox"));
-        assert_eq!(router.external_channel_names().len(), 1);
+        assert!(router.has_external_channel("test-inbox").await);
+        assert_eq!(router.external_channel_names().await.len(), 1);
 
         // Replace with empty map
-        router.reload_channels(HashMap::new());
-        assert!(router.external_channel_names().is_empty());
+        router.reload_channels(HashMap::new()).await;
+        assert!(router.external_channel_names().await.is_empty());
     }
 }

--- a/src/tools/send_message.rs
+++ b/src/tools/send_message.rs
@@ -106,8 +106,8 @@ impl Tool for SendMessageTool {
                 ))
             }
             ChannelTarget::External(ext_name) => {
-                if !self.router.has_external_channel(&ext_name) {
-                    let available = self.router.external_channel_names();
+                if !self.router.has_external_channel(&ext_name).await {
+                    let available = self.router.external_channel_names().await;
                     return Ok(ToolResult::error(format!(
                         "unknown external channel '{ext_name}'; available: {}",
                         if available.is_empty() {

--- a/src/workspace/config.rs
+++ b/src/workspace/config.rs
@@ -1,0 +1,473 @@
+//! Workspace config loaders: MCP servers and notification channels.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::error::ResiduumError;
+use crate::notify::channels::NotificationChannel;
+use crate::notify::external::{NtfyChannel, WebhookChannel};
+use crate::notify::types::{ExternalChannelConfig, ExternalChannelKind};
+use crate::projects::types::{McpServerEntry, McpTransport};
+
+// ── MCP loader ───────────────────────────────────────────────────────────────
+
+/// Raw JSON structure for the MCP config file (Claude Code format).
+#[derive(Deserialize)]
+struct McpConfigFile {
+    /// Map of server name → server definition.
+    #[serde(default, rename = "mcpServers")]
+    mcp_servers: HashMap<String, McpServerRaw>,
+}
+
+/// Raw JSON server entry before conversion to `McpServerEntry`.
+#[derive(Deserialize)]
+struct McpServerRaw {
+    command: String,
+    #[serde(default)]
+    args: Vec<String>,
+    #[serde(default)]
+    env: HashMap<String, String>,
+    /// Residuum extension: `"stdio"` (default) or `"http"`.
+    #[serde(default)]
+    transport: Option<String>,
+}
+
+/// Load MCP server definitions from a JSON file.
+///
+/// Returns an empty vec if the file does not exist.
+///
+/// # Errors
+/// Returns an error if the file exists but cannot be read or parsed.
+pub fn load_mcp_servers(path: &Path) -> Result<Vec<McpServerEntry>, ResiduumError> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let contents = std::fs::read_to_string(path).map_err(|e| {
+        ResiduumError::Config(format!(
+            "failed to read mcp.json at {}: {e}",
+            path.display()
+        ))
+    })?;
+
+    let file: McpConfigFile = serde_json::from_str(&contents).map_err(|e| {
+        ResiduumError::Config(format!(
+            "failed to parse mcp.json at {}: {e}",
+            path.display()
+        ))
+    })?;
+
+    let servers = file
+        .mcp_servers
+        .into_iter()
+        .map(|(name, raw)| {
+            let transport = match raw.transport.as_deref() {
+                Some("http") => McpTransport::Http,
+                _ => McpTransport::Stdio,
+            };
+            McpServerEntry {
+                name,
+                command: raw.command,
+                args: raw.args,
+                env: raw.env,
+                transport,
+            }
+        })
+        .collect();
+
+    Ok(servers)
+}
+
+// ── Channel loader ───────────────────────────────────────────────────────────
+
+/// Raw TOML structure for the channels config file.
+#[derive(Deserialize)]
+struct ChannelsFile {
+    #[serde(default)]
+    channels: HashMap<String, ChannelEntryRaw>,
+}
+
+/// Raw TOML channel entry before conversion to `ExternalChannelConfig`.
+#[derive(Deserialize)]
+struct ChannelEntryRaw {
+    /// Channel type: `"ntfy"` or `"webhook"`.
+    #[serde(rename = "type")]
+    type_: String,
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    topic: Option<String>,
+    #[serde(default)]
+    priority: Option<String>,
+    #[serde(default)]
+    method: Option<String>,
+    #[serde(default)]
+    headers: Option<HashMap<String, String>>,
+}
+
+/// Load external channel configs from a TOML file.
+///
+/// Returns an empty vec if the file does not exist.
+///
+/// # Errors
+/// Returns an error if the file exists but cannot be read or parsed.
+pub fn load_channel_configs(path: &Path) -> Result<Vec<ExternalChannelConfig>, ResiduumError> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let contents = std::fs::read_to_string(path).map_err(|e| {
+        ResiduumError::Config(format!(
+            "failed to read channels.toml at {}: {e}",
+            path.display()
+        ))
+    })?;
+
+    // Empty file → empty vec (no channels section)
+    if contents.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let file: ChannelsFile = toml::from_str(&contents).map_err(|e| {
+        ResiduumError::Config(format!(
+            "failed to parse channels.toml at {}: {e}",
+            path.display()
+        ))
+    })?;
+
+    let configs = file
+        .channels
+        .into_iter()
+        .map(|(name, raw)| {
+            let kind = match raw.type_.as_str() {
+                "ntfy" => ExternalChannelKind::Ntfy {
+                    url: raw.url.unwrap_or_default(),
+                    topic: raw.topic.unwrap_or_default(),
+                    priority: raw.priority,
+                },
+                _ => ExternalChannelKind::Webhook {
+                    url: raw.url.unwrap_or_default(),
+                    method: raw.method,
+                    headers: raw.headers.unwrap_or_default().into_iter().collect(),
+                },
+            };
+            ExternalChannelConfig { name, kind }
+        })
+        .collect();
+
+    Ok(configs)
+}
+
+// ── Channel builder ──────────────────────────────────────────────────────────
+
+/// Build external channel implementations from configs.
+#[must_use]
+pub fn build_external_channels(
+    configs: &[ExternalChannelConfig],
+    client: &reqwest::Client,
+) -> HashMap<String, Box<dyn NotificationChannel>> {
+    let mut channels: HashMap<String, Box<dyn NotificationChannel>> = HashMap::new();
+
+    for cfg in configs {
+        let channel: Box<dyn NotificationChannel> = match &cfg.kind {
+            ExternalChannelKind::Ntfy {
+                url,
+                topic,
+                priority,
+            } => Box::new(NtfyChannel::new(
+                cfg.name.clone(),
+                client.clone(),
+                url.clone(),
+                topic.clone(),
+                priority.clone(),
+            )),
+            ExternalChannelKind::Webhook {
+                url,
+                method,
+                headers,
+            } => Box::new(WebhookChannel::new(
+                cfg.name.clone(),
+                client.clone(),
+                url.clone(),
+                method.clone(),
+                headers.clone(),
+            )),
+        };
+        channels.insert(cfg.name.clone(), channel);
+    }
+
+    channels
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test code uses unwrap for clarity")]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test code uses indexing for clarity"
+)]
+mod tests {
+    use super::*;
+
+    // ── MCP loader tests ─────────────────────────────────────────────────
+
+    #[test]
+    fn load_mcp_servers_valid_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mcp.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "mcpServers": {
+                    "filesystem": {
+                        "command": "mcp-server-filesystem",
+                        "args": ["/home/user"],
+                        "env": { "DEBUG": "1" }
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let servers = load_mcp_servers(&path).unwrap();
+        assert_eq!(servers.len(), 1);
+        let s = &servers[0];
+        assert_eq!(s.name, "filesystem");
+        assert_eq!(s.command, "mcp-server-filesystem");
+        assert_eq!(s.args, vec!["/home/user"]);
+        assert_eq!(s.env.get("DEBUG").map(String::as_str), Some("1"));
+        assert_eq!(s.transport, McpTransport::Stdio);
+    }
+
+    #[test]
+    fn load_mcp_servers_multiple_servers() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mcp.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "mcpServers": {
+                    "fs": { "command": "mcp-fs", "args": [] },
+                    "git": { "command": "mcp-git", "args": ["--repo", "."] }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let servers = load_mcp_servers(&path).unwrap();
+        assert_eq!(servers.len(), 2);
+    }
+
+    #[test]
+    fn load_mcp_servers_http_transport() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mcp.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "mcpServers": {
+                    "remote": {
+                        "command": "http://10.0.0.5:8080/mcp",
+                        "transport": "http"
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let servers = load_mcp_servers(&path).unwrap();
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].transport, McpTransport::Http);
+        assert_eq!(servers[0].command, "http://10.0.0.5:8080/mcp");
+    }
+
+    #[test]
+    fn load_mcp_servers_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mcp.json");
+        std::fs::write(&path, r#"{ "mcpServers": {} }"#).unwrap();
+
+        let servers = load_mcp_servers(&path).unwrap();
+        assert!(servers.is_empty());
+    }
+
+    #[test]
+    fn load_mcp_servers_missing_file() {
+        let path = Path::new("/tmp/nonexistent/mcp.json");
+        let servers = load_mcp_servers(path).unwrap();
+        assert!(servers.is_empty());
+    }
+
+    #[test]
+    fn load_mcp_servers_invalid_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mcp.json");
+        std::fs::write(&path, "not valid json {{{").unwrap();
+
+        let result = load_mcp_servers(&path);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("failed to parse mcp.json"), "got: {err}");
+    }
+
+    // ── Channel loader tests ─────────────────────────────────────────────
+
+    #[test]
+    fn load_channel_configs_ntfy() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("channels.toml");
+        std::fs::write(
+            &path,
+            r#"
+[channels.my-ntfy]
+type = "ntfy"
+url = "https://ntfy.sh"
+topic = "residuum"
+priority = "high"
+"#,
+        )
+        .unwrap();
+
+        let configs = load_channel_configs(&path).unwrap();
+        assert_eq!(configs.len(), 1);
+        let c = &configs[0];
+        assert_eq!(c.name, "my-ntfy");
+        let ExternalChannelKind::Ntfy {
+            url,
+            topic,
+            priority,
+        } = &c.kind
+        else {
+            unreachable!("expected Ntfy kind");
+        };
+        assert_eq!(url, "https://ntfy.sh");
+        assert_eq!(topic, "residuum");
+        assert_eq!(priority.as_deref(), Some("high"));
+    }
+
+    #[test]
+    fn load_channel_configs_webhook() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("channels.toml");
+        std::fs::write(
+            &path,
+            r#"
+[channels.ops-hook]
+type = "webhook"
+url = "https://hooks.example.com/notify"
+method = "PUT"
+
+[channels.ops-hook.headers]
+Authorization = "Bearer token123"
+"#,
+        )
+        .unwrap();
+
+        let configs = load_channel_configs(&path).unwrap();
+        assert_eq!(configs.len(), 1);
+        let c = &configs[0];
+        assert_eq!(c.name, "ops-hook");
+        let ExternalChannelKind::Webhook {
+            url,
+            method,
+            headers,
+        } = &c.kind
+        else {
+            unreachable!("expected Webhook kind");
+        };
+        assert_eq!(url, "https://hooks.example.com/notify");
+        assert_eq!(method.as_deref(), Some("PUT"));
+        assert!(
+            headers
+                .iter()
+                .any(|(k, v)| k == "Authorization" && v == "Bearer token123"),
+            "should have auth header"
+        );
+    }
+
+    #[test]
+    fn load_channel_configs_mixed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("channels.toml");
+        std::fs::write(
+            &path,
+            r#"
+[channels.ntfy-alerts]
+type = "ntfy"
+url = "https://ntfy.sh"
+topic = "alerts"
+
+[channels.slack-hook]
+type = "webhook"
+url = "https://hooks.slack.com/services/xxx"
+"#,
+        )
+        .unwrap();
+
+        let configs = load_channel_configs(&path).unwrap();
+        assert_eq!(configs.len(), 2);
+    }
+
+    #[test]
+    fn load_channel_configs_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("channels.toml");
+        std::fs::write(&path, "").unwrap();
+
+        let configs = load_channel_configs(&path).unwrap();
+        assert!(configs.is_empty());
+    }
+
+    #[test]
+    fn load_channel_configs_missing_file() {
+        let path = Path::new("/tmp/nonexistent/channels.toml");
+        let configs = load_channel_configs(path).unwrap();
+        assert!(configs.is_empty());
+    }
+
+    #[test]
+    fn load_channel_configs_invalid_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("channels.toml");
+        std::fs::write(&path, "not valid toml [[[").unwrap();
+
+        let result = load_channel_configs(&path);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("failed to parse channels.toml"), "got: {err}");
+    }
+
+    // ── Channel builder tests ────────────────────────────────────────────
+
+    #[test]
+    fn build_external_channels_creates_instances() {
+        let configs = vec![
+            ExternalChannelConfig {
+                name: "my-ntfy".to_string(),
+                kind: ExternalChannelKind::Ntfy {
+                    url: "https://ntfy.sh".to_string(),
+                    topic: "test".to_string(),
+                    priority: None,
+                },
+            },
+            ExternalChannelConfig {
+                name: "my-webhook".to_string(),
+                kind: ExternalChannelKind::Webhook {
+                    url: "https://hooks.example.com".to_string(),
+                    method: None,
+                    headers: Vec::new(),
+                },
+            },
+        ];
+
+        let client = reqwest::Client::new();
+        let channels = build_external_channels(&configs, &client);
+
+        assert_eq!(channels.len(), 2);
+        assert!(channels.contains_key("my-ntfy"));
+        assert!(channels.contains_key("my-webhook"));
+        assert_eq!(channels["my-ntfy"].channel_kind(), "ntfy");
+        assert_eq!(channels["my-webhook"].channel_kind(), "webhook");
+    }
+}

--- a/src/workspace/layout.rs
+++ b/src/workspace/layout.rs
@@ -183,6 +183,24 @@ impl WorkspaceLayout {
         self.root.join("CHANNELS.yml")
     }
 
+    /// Path to the workspace config directory (`root/config/`).
+    #[must_use]
+    pub fn config_dir(&self) -> PathBuf {
+        self.root.join("config")
+    }
+
+    /// Path to `config/mcp.json` — MCP server definitions.
+    #[must_use]
+    pub fn mcp_json(&self) -> PathBuf {
+        self.root.join("config/mcp.json")
+    }
+
+    /// Path to `config/channels.toml` — external notification channel definitions.
+    #[must_use]
+    pub fn channels_toml(&self) -> PathBuf {
+        self.root.join("config/channels.toml")
+    }
+
     /// Path to the background task transcript directory.
     ///
     /// Created on-demand when the first transcript is written, not at bootstrap.
@@ -217,6 +235,7 @@ impl WorkspaceLayout {
             self.archive_dir(),
             self.inbox_dir(),
             self.inbox_archive_dir(),
+            self.config_dir(),
         ]
     }
 }
@@ -303,6 +322,21 @@ mod tests {
             PathBuf::from("/tmp/ws/skills/residuum-getting-started"),
             "residuum_getting_started_skill_dir path"
         );
+        assert_eq!(
+            layout.config_dir(),
+            PathBuf::from("/tmp/ws/config"),
+            "config_dir path"
+        );
+        assert_eq!(
+            layout.mcp_json(),
+            PathBuf::from("/tmp/ws/config/mcp.json"),
+            "mcp_json path"
+        );
+        assert_eq!(
+            layout.channels_toml(),
+            PathBuf::from("/tmp/ws/config/channels.toml"),
+            "channels_toml path"
+        );
     }
 
     #[test]
@@ -334,7 +368,7 @@ mod tests {
     fn required_dirs_count() {
         let layout = WorkspaceLayout::new("/tmp/ws");
         let dirs = layout.required_dirs();
-        assert_eq!(dirs.len(), 10, "should have all required directories");
+        assert_eq!(dirs.len(), 11, "should have all required directories");
         assert!(
             dirs.contains(&PathBuf::from("/tmp/ws")),
             "root should be included"
@@ -346,6 +380,10 @@ mod tests {
         assert!(
             dirs.contains(&PathBuf::from("/tmp/ws/archive/inbox")),
             "inbox archive should be included"
+        );
+        assert!(
+            dirs.contains(&PathBuf::from("/tmp/ws/config")),
+            "config should be included"
         );
     }
 }

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -1,5 +1,6 @@
 //! Workspace management: directory layout, identity files, and bootstrapping.
 
 pub mod bootstrap;
+pub mod config;
 pub mod identity;
 pub mod layout;


### PR DESCRIPTION
## Summary

- **Workspace config loaders**: New `src/workspace/config.rs` module loads MCP server definitions from `config/mcp.json` (Claude Code format) and notification channel configs from `config/channels.toml` at startup
- **Hot-reload via file watcher**: Polling-based watcher (`src/gateway/server/watcher.rs`) monitors both files every 2s with 500ms debounce, triggering `ReloadSignal::Workspace` on changes
- **Interior mutability for NotificationRouter**: `external_channels` wrapped in `tokio::sync::RwLock` so channels can be reloaded without `&mut self` — `reload_channels`, `has_external_channel`, and `external_channel_names` are now async
- **Startup integration**: MCP servers are reconciled and channels are built from workspace config at boot; `valid_external_channels` populated from loaded configs; workspace config files added to blocked paths based on `agent.modify_mcp`/`agent.modify_channels` gates
- **Workspace reload handler**: `handle_workspace_reload` re-loads both files and reconciles MCP servers + reloads channels in-place, replacing the Phase 2 placeholder

### Files changed
- `src/workspace/config.rs` — new: MCP loader, channel loader, channel builder (13 tests)
- `src/gateway/server/watcher.rs` — new: polling file watcher (3 tests)
- `src/workspace/layout.rs` — `config_dir()`, `mcp_json()`, `channels_toml()` path helpers
- `src/workspace/mod.rs` — register `pub mod config`
- `src/notify/router.rs` — `RwLock` interior mutability
- `src/tools/send_message.rs` — `.await` on async router methods
- `src/gateway/server/startup.rs` — load workspace config, remove `build_notification_router`, pass `http_client`
- `src/gateway/server/mod.rs` — `handle_workspace_reload`, spawn watcher, `http_client` in runtime

## Test plan

- [x] All 970+ unit tests pass
- [x] Clippy clean (pedantic)
- [x] Pre-commit and pre-push hooks pass
- [ ] Manual: `residuum serve --foreground` boots with MCP servers from `mcp.json`
- [ ] Manual: edit `config/mcp.json` at runtime → MCP reconciliation logged
- [ ] Manual: edit `config/channels.toml` at runtime → channel reload logged
- [ ] Manual: external channels available in `send_message` tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)