### PR TITLE
feat: per-project MCP references (Phase 4)

### DIFF
--- a/src/projects/types.rs
+++ b/src/projects/types.rs
@@ -20,9 +20,9 @@ pub struct ProjectFrontmatter {
     /// Tools to load when this project activates.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tools: Vec<String>,
-    /// MCP servers to start when this project activates.
+    /// MCP server names to resolve from `mcp.json` when this project activates.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub mcp_servers: Vec<McpServerEntry>,
+    pub mcp_servers: Vec<String>,
     /// When the project was archived (only set for archived projects).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub archived: Option<NaiveDate>,
@@ -142,6 +142,10 @@ impl std::fmt::Display for ProjectStatus {
 
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "test code uses unwrap for clarity")]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "test code uses indexing for clarity"
+)]
 mod tests {
     use super::*;
 
@@ -214,23 +218,13 @@ description: "Has MCP servers"
 status: active
 created: 2026-02-20
 mcp_servers:
-  - name: filesystem
-    command: mcp-server-filesystem
-    args:
-      - /home/user/project
+  - filesystem
+  - git
 "#;
         let fm: ProjectFrontmatter = serde_yml::from_str(yaml).unwrap();
-        assert_eq!(fm.mcp_servers.len(), 1, "should have one MCP server");
-        assert_eq!(
-            fm.mcp_servers.first().unwrap().name,
-            "filesystem",
-            "server name should match"
-        );
-        assert_eq!(
-            fm.mcp_servers.first().unwrap().args.len(),
-            1,
-            "should have one arg"
-        );
+        assert_eq!(fm.mcp_servers.len(), 2, "should have two MCP server refs");
+        assert_eq!(fm.mcp_servers[0], "filesystem", "first ref should match");
+        assert_eq!(fm.mcp_servers[1], "git", "second ref should match");
     }
 
     #[test]
@@ -259,50 +253,23 @@ mcp_servers:
     }
 
     #[test]
-    fn frontmatter_with_http_mcp_server() {
-        let yaml = r#"
-name: with-http-mcp
-description: "Has HTTP MCP server"
-status: active
-created: 2026-02-20
-mcp_servers:
-  - name: remote-api
-    command: "http://10.0.0.5:8080/mcp"
-    transport: http
-"#;
-        let fm: ProjectFrontmatter = serde_yml::from_str(yaml).unwrap();
-        assert_eq!(fm.mcp_servers.len(), 1, "should have one MCP server");
-        let server = fm.mcp_servers.first().unwrap();
-        assert_eq!(server.name, "remote-api", "server name should match");
-        assert_eq!(
-            server.command, "http://10.0.0.5:8080/mcp",
-            "URL should match"
-        );
-        assert_eq!(
-            server.transport,
-            McpTransport::Http,
-            "transport should be Http"
-        );
-    }
+    fn frontmatter_with_mcp_server_references_round_trip() {
+        let fm = ProjectFrontmatter {
+            name: "ref-test".to_string(),
+            description: "MCP ref round-trip".to_string(),
+            status: ProjectStatus::Active,
+            created: NaiveDate::from_ymd_opt(2026, 2, 20).unwrap(),
+            tools: vec![],
+            mcp_servers: vec!["filesystem".to_string(), "git".to_string()],
+            archived: None,
+        };
 
-    #[test]
-    fn frontmatter_mcp_server_transport_defaults_stdio() {
-        let yaml = r#"
-name: with-stdio-mcp
-description: "Has stdio MCP server"
-status: active
-created: 2026-02-20
-mcp_servers:
-  - name: filesystem
-    command: mcp-server-filesystem
-"#;
-        let fm: ProjectFrontmatter = serde_yml::from_str(yaml).unwrap();
-        let server = fm.mcp_servers.first().unwrap();
-        assert_eq!(
-            server.transport,
-            McpTransport::Stdio,
-            "transport should default to Stdio"
-        );
+        let yaml = serde_yml::to_string(&fm).unwrap();
+        let parsed: ProjectFrontmatter = serde_yml::from_str(&yaml).unwrap();
+
+        assert_eq!(parsed.mcp_servers.len(), 2, "should round-trip two refs");
+        assert_eq!(parsed.mcp_servers[0], "filesystem");
+        assert_eq!(parsed.mcp_servers[1], "git");
     }
 
     #[test]

--- a/src/tools/TOOLS.md
+++ b/src/tools/TOOLS.md
@@ -214,7 +214,7 @@ On success: summary string like `"Activated project '{name}'. Manifest: {N} note
 
 On error: project not found or activation failure message.
 
-**Side effects:** Updates `PathPolicy` to scope writes to the project root; activates MCP servers with reference counting (servers are shared when multiple agents activate the same project simultaneously — they are only stopped when the last agent deactivates); rescans skills to include project-scoped skills.
+**Side effects:** Updates `PathPolicy` to scope writes to the project root; resolves MCP server name references from `mcp.json` files (project-local `mcp.json` alongside `PROJECT.md` takes precedence over global `workspace/config/mcp.json`) and activates them with reference counting (servers are shared when multiple agents activate the same project simultaneously — they are only stopped when the last agent deactivates); rescans skills to include project-scoped skills.
 
 ---
 

--- a/src/tools/projects.rs
+++ b/src/tools/projects.rs
@@ -73,12 +73,29 @@ impl Tool for ProjectActivateTool {
             .ok_or_else(|| ToolError::InvalidArguments("name is required".to_string()))?;
 
         let mut state = self.state.lock().await;
+        let global_mcp = state.layout().mcp_json();
         match state.activate(name).await {
             Ok(active) => {
                 let project_root = active.project_root.clone();
                 let tools_list = active.frontmatter.tools.clone();
-                let mcp_servers = active.frontmatter.mcp_servers.clone();
                 let project_name = active.name.clone();
+                let mcp_servers = if active.frontmatter.mcp_servers.is_empty() {
+                    Vec::new()
+                } else {
+                    let project_mcp = active.project_root.join("mcp.json");
+                    match crate::workspace::config::resolve_mcp_references(
+                        &active.frontmatter.mcp_servers,
+                        &project_mcp,
+                        &global_mcp,
+                        &active.name,
+                    ) {
+                        Ok(resolved) => resolved,
+                        Err(e) => {
+                            tracing::warn!(project = %project_name, error = %e, "failed to resolve mcp server references");
+                            Vec::new()
+                        }
+                    }
+                };
                 let manifest_summary = format!(
                     "Activated project '{}'. Manifest: {} notes, {} references, {} workspace, {} skills files.",
                     active.name,

--- a/src/workspace/config.rs
+++ b/src/workspace/config.rs
@@ -34,15 +34,15 @@ struct McpServerRaw {
     transport: Option<String>,
 }
 
-/// Load MCP server definitions from a JSON file.
+/// Load MCP server definitions from a JSON file as a name → entry map.
 ///
-/// Returns an empty vec if the file does not exist.
+/// Returns an empty map if the file does not exist.
 ///
 /// # Errors
 /// Returns an error if the file exists but cannot be read or parsed.
-pub fn load_mcp_servers(path: &Path) -> Result<Vec<McpServerEntry>, ResiduumError> {
+pub fn load_mcp_servers_map(path: &Path) -> Result<HashMap<String, McpServerEntry>, ResiduumError> {
     if !path.exists() {
-        return Ok(Vec::new());
+        return Ok(HashMap::new());
     }
 
     let contents = std::fs::read_to_string(path).map_err(|e| {
@@ -67,17 +67,66 @@ pub fn load_mcp_servers(path: &Path) -> Result<Vec<McpServerEntry>, ResiduumErro
                 Some("http") => McpTransport::Http,
                 _ => McpTransport::Stdio,
             };
-            McpServerEntry {
-                name,
+            let entry = McpServerEntry {
+                name: name.clone(),
                 command: raw.command,
                 args: raw.args,
                 env: raw.env,
                 transport,
-            }
+            };
+            (name, entry)
         })
         .collect();
 
     Ok(servers)
+}
+
+/// Load MCP server definitions from a JSON file.
+///
+/// Returns an empty vec if the file does not exist.
+///
+/// # Errors
+/// Returns an error if the file exists but cannot be read or parsed.
+pub fn load_mcp_servers(path: &Path) -> Result<Vec<McpServerEntry>, ResiduumError> {
+    Ok(load_mcp_servers_map(path)?.into_values().collect())
+}
+
+/// Resolve MCP server name references against project-local and global `mcp.json` files.
+///
+/// For each reference, the project-local map is checked first, then the global map.
+/// Project-local entries override same-name global entries.
+///
+/// Returns an empty vec if `references` is empty (without loading any files).
+///
+/// # Errors
+/// Returns an error if any reference cannot be found in either map.
+pub fn resolve_mcp_references(
+    references: &[String],
+    project_mcp_json: &Path,
+    global_mcp_json: &Path,
+    project_name: &str,
+) -> Result<Vec<McpServerEntry>, ResiduumError> {
+    if references.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let local_map = load_mcp_servers_map(project_mcp_json)?;
+    let global_map = load_mcp_servers_map(global_mcp_json)?;
+
+    let mut resolved = Vec::with_capacity(references.len());
+    for name in references {
+        if let Some(entry) = local_map.get(name) {
+            resolved.push(entry.clone());
+        } else if let Some(entry) = global_map.get(name) {
+            resolved.push(entry.clone());
+        } else {
+            return Err(ResiduumError::Projects(format!(
+                "mcp server '{name}' referenced in project '{project_name}' not found in project-local or global mcp.json"
+            )));
+        }
+    }
+
+    Ok(resolved)
 }
 
 // ── Channel loader ───────────────────────────────────────────────────────────
@@ -469,5 +518,145 @@ url = "https://hooks.slack.com/services/xxx"
         assert!(channels.contains_key("my-webhook"));
         assert_eq!(channels["my-ntfy"].channel_kind(), "ntfy");
         assert_eq!(channels["my-webhook"].channel_kind(), "webhook");
+    }
+
+    // ── MCP map + resolution tests ──────────────────────────────────────
+
+    #[test]
+    fn load_mcp_servers_map_valid() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mcp.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "mcpServers": {
+                    "filesystem": {
+                        "command": "mcp-server-filesystem",
+                        "args": ["/home/user"]
+                    },
+                    "git": {
+                        "command": "mcp-git",
+                        "args": ["--repo", "."]
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let map = load_mcp_servers_map(&path).unwrap();
+        assert_eq!(map.len(), 2);
+        assert!(map.contains_key("filesystem"));
+        assert!(map.contains_key("git"));
+        assert_eq!(map["filesystem"].command, "mcp-server-filesystem");
+    }
+
+    #[test]
+    fn resolve_references_from_global_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let global = dir.path().join("global-mcp.json");
+        std::fs::write(
+            &global,
+            r#"{ "mcpServers": { "fs": { "command": "mcp-fs" } } }"#,
+        )
+        .unwrap();
+
+        let project_local = dir.path().join("nonexistent-mcp.json");
+        let refs = vec!["fs".to_string()];
+        let resolved = resolve_mcp_references(&refs, &project_local, &global, "test-proj").unwrap();
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].name, "fs");
+        assert_eq!(resolved[0].command, "mcp-fs");
+    }
+
+    #[test]
+    fn resolve_references_project_overrides_global() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let global = dir.path().join("global-mcp.json");
+        std::fs::write(
+            &global,
+            r#"{ "mcpServers": { "fs": { "command": "global-fs" } } }"#,
+        )
+        .unwrap();
+
+        let local = dir.path().join("local-mcp.json");
+        std::fs::write(
+            &local,
+            r#"{ "mcpServers": { "fs": { "command": "local-fs" } } }"#,
+        )
+        .unwrap();
+
+        let refs = vec!["fs".to_string()];
+        let resolved = resolve_mcp_references(&refs, &local, &global, "test-proj").unwrap();
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(
+            resolved[0].command, "local-fs",
+            "project-local should override global"
+        );
+    }
+
+    #[test]
+    fn resolve_references_mixed_sources() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let global = dir.path().join("global-mcp.json");
+        std::fs::write(
+            &global,
+            r#"{ "mcpServers": { "git": { "command": "mcp-git" } } }"#,
+        )
+        .unwrap();
+
+        let local = dir.path().join("local-mcp.json");
+        std::fs::write(
+            &local,
+            r#"{ "mcpServers": { "fs": { "command": "mcp-fs" } } }"#,
+        )
+        .unwrap();
+
+        let refs = vec!["fs".to_string(), "git".to_string()];
+        let resolved = resolve_mcp_references(&refs, &local, &global, "test-proj").unwrap();
+        assert_eq!(resolved.len(), 2);
+        assert_eq!(resolved[0].name, "fs", "first should come from local");
+        assert_eq!(resolved[1].name, "git", "second should come from global");
+    }
+
+    #[test]
+    fn resolve_references_not_found_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let global = dir.path().join("global-mcp.json");
+        std::fs::write(&global, r#"{ "mcpServers": {} }"#).unwrap();
+
+        let local = dir.path().join("nonexistent.json");
+        let refs = vec!["missing-server".to_string()];
+        let result = resolve_mcp_references(&refs, &local, &global, "my-project");
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("missing-server"),
+            "error should name the server: {err}"
+        );
+        assert!(
+            err.contains("my-project"),
+            "error should name the project: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_references_empty_list() {
+        let nonexistent = Path::new("/tmp/does-not-exist/mcp.json");
+        let resolved = resolve_mcp_references(&[], nonexistent, nonexistent, "test-proj").unwrap();
+        assert!(
+            resolved.is_empty(),
+            "empty references should return empty vec"
+        );
+    }
+
+    #[test]
+    fn resolve_references_missing_both_files() {
+        let local = Path::new("/tmp/no-local/mcp.json");
+        let global = Path::new("/tmp/no-global/mcp.json");
+        let refs = vec!["some-server".to_string()];
+        let result = resolve_mcp_references(&refs, local, global, "test-proj");
+        assert!(result.is_err(), "should error when server not found");
     }
 }

--- a/tests/projects_integration.rs
+++ b/tests/projects_integration.rs
@@ -693,7 +693,7 @@ mod projects_integration {
         let tz = chrono_tz::UTC;
         let mcp = McpRegistry::new_shared();
 
-        // Create a project with MCP servers in frontmatter
+        // Create a project with MCP server references in frontmatter
         let create_tool = ProjectCreateTool::new(Arc::clone(&state), tz);
         create_tool
             .execute(serde_json::json!({
@@ -703,19 +703,27 @@ mod projects_integration {
             .await
             .unwrap();
 
-        // Manually add mcp_servers to the PROJECT.md frontmatter
+        // Add mcp_servers as string references in PROJECT.md
         let project_md = layout.projects_dir().join("mcp-test/PROJECT.md");
         let content = std::fs::read_to_string(&project_md).unwrap();
         let new_content = content.replace(
             "status: active",
-            "status: active\nmcp_servers:\n  - name: filesystem\n    command: mcp-server-fs\n    args:\n      - /tmp",
+            "status: active\nmcp_servers:\n  - filesystem",
         );
         std::fs::write(&project_md, new_content).unwrap();
+
+        // Write the server definition to global mcp.json
+        let global_mcp = layout.mcp_json();
+        std::fs::write(
+            &global_mcp,
+            r#"{ "mcpServers": { "filesystem": { "command": "mcp-server-fs", "args": ["/tmp"] } } }"#,
+        )
+        .unwrap();
 
         // Rescan to pick up changes
         state.lock().await.rescan().await.unwrap();
 
-        // Activate — should reconcile and queue servers to start
+        // Activate — should resolve reference and queue server to start
         let activate_tool = ProjectActivateTool::new(
             Arc::clone(&state),
             permissive_policy(),
@@ -758,6 +766,125 @@ mod projects_integration {
             assert!(
                 r.servers().is_empty(),
                 "all MCP servers should be cleared after deactivation"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn mcp_project_local_overrides_global() {
+        let (_dir, layout, state) = setup().await;
+        let tz = chrono_tz::UTC;
+        let mcp = McpRegistry::new_shared();
+
+        // Create project with mcp_servers reference
+        let create_tool = ProjectCreateTool::new(Arc::clone(&state), tz);
+        create_tool
+            .execute(serde_json::json!({
+                "name": "Local Override",
+                "description": "tests local mcp.json precedence"
+            }))
+            .await
+            .unwrap();
+
+        let project_md = layout.projects_dir().join("local-override/PROJECT.md");
+        let content = std::fs::read_to_string(&project_md).unwrap();
+        let new_content = content.replace(
+            "status: active",
+            "status: active\nmcp_servers:\n  - myserver",
+        );
+        std::fs::write(&project_md, new_content).unwrap();
+
+        // Global mcp.json with one definition
+        let global_mcp = layout.mcp_json();
+        std::fs::write(
+            &global_mcp,
+            r#"{ "mcpServers": { "myserver": { "command": "global-cmd" } } }"#,
+        )
+        .unwrap();
+
+        // Project-local mcp.json with an overriding definition
+        let project_mcp = layout.projects_dir().join("local-override/mcp.json");
+        std::fs::write(
+            &project_mcp,
+            r#"{ "mcpServers": { "myserver": { "command": "local-cmd" } } }"#,
+        )
+        .unwrap();
+
+        state.lock().await.rescan().await.unwrap();
+
+        let activate_tool = ProjectActivateTool::new(
+            Arc::clone(&state),
+            permissive_policy(),
+            no_filter(),
+            Arc::clone(&mcp),
+            empty_skills(),
+        );
+        activate_tool
+            .execute(serde_json::json!({"name": "Local Override"}))
+            .await
+            .unwrap();
+
+        {
+            let r = mcp.read().await;
+            let servers = r.servers();
+            assert_eq!(servers.len(), 1, "should have one MCP server");
+            assert_eq!(
+                servers.first().unwrap().command,
+                "local-cmd",
+                "project-local should override global"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn mcp_reference_not_found_reports_warning() {
+        let (_dir, layout, state) = setup().await;
+        let tz = chrono_tz::UTC;
+        let mcp = McpRegistry::new_shared();
+
+        // Create project referencing a server that doesn't exist
+        let create_tool = ProjectCreateTool::new(Arc::clone(&state), tz);
+        create_tool
+            .execute(serde_json::json!({
+                "name": "Missing MCP",
+                "description": "references nonexistent server"
+            }))
+            .await
+            .unwrap();
+
+        let project_md = layout.projects_dir().join("missing-mcp/PROJECT.md");
+        let content = std::fs::read_to_string(&project_md).unwrap();
+        let new_content = content.replace(
+            "status: active",
+            "status: active\nmcp_servers:\n  - nonexistent-server",
+        );
+        std::fs::write(&project_md, new_content).unwrap();
+
+        state.lock().await.rescan().await.unwrap();
+
+        // Activate should succeed (graceful degradation) but with no MCP servers
+        let activate_tool = ProjectActivateTool::new(
+            Arc::clone(&state),
+            permissive_policy(),
+            no_filter(),
+            Arc::clone(&mcp),
+            empty_skills(),
+        );
+        let result = activate_tool
+            .execute(serde_json::json!({"name": "Missing MCP"}))
+            .await
+            .unwrap();
+        assert!(
+            !result.is_error,
+            "activation should succeed even with missing mcp ref: {}",
+            result.output
+        );
+
+        {
+            let r = mcp.read().await;
+            assert!(
+                r.servers().is_empty(),
+                "no servers should be tracked when reference is unresolved"
             );
         }
     }


### PR DESCRIPTION
## Summary
- Changed `ProjectFrontmatter.mcp_servers` from `Vec<McpServerEntry>` to `Vec<String>` — projects now reference MCP servers by name instead of inlining full definitions
- Added `load_mcp_servers_map()` and `resolve_mcp_references()` to `workspace/config.rs` — resolves name references against project-local `mcp.json` (alongside PROJECT.md) then global `workspace/config/mcp.json`
- Updated `ProjectActivateTool::execute` to resolve references at activation time, with graceful degradation (warning + no servers) on failure

## Test plan
- [x] 7 new unit tests for map loading and reference resolution (global-only, local-overrides-global, mixed sources, not-found errors, empty list, missing files)
- [x] Updated `mcp_registry_reconciles_on_activate_deactivate` integration test to use string refs + global mcp.json
- [x] New `mcp_project_local_overrides_global` integration test
- [x] New `mcp_reference_not_found_reports_warning` integration test
- [x] All 976 unit tests + integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)