### PR TITLE
feat: adapter lifecycle on token change (Phase 6)

### DIFF
--- a/src/channels/discord/mod.rs
+++ b/src/channels/discord/mod.rs
@@ -12,6 +12,7 @@ mod handler;
 mod reply;
 
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use serenity::prelude::*;
 use tokio::sync::mpsc;
@@ -30,6 +31,7 @@ pub struct DiscordChannel {
     reload_tx: tokio::sync::watch::Sender<ReloadSignal>,
     command_tx: mpsc::Sender<ServerCommand>,
     tz: chrono_tz::Tz,
+    shutdown_rx: tokio::sync::watch::Receiver<bool>,
 }
 
 impl DiscordChannel {
@@ -42,6 +44,7 @@ impl DiscordChannel {
     /// - `reload_tx`: Watch channel to trigger config reload.
     /// - `command_tx`: Channel for dispatching named server commands.
     /// - `tz`: Timezone for inbox item timestamps.
+    /// - `shutdown_rx`: Watch channel signalling graceful shutdown.
     #[must_use]
     pub(crate) fn new(
         cfg: DiscordConfig,
@@ -50,6 +53,7 @@ impl DiscordChannel {
         reload_tx: tokio::sync::watch::Sender<ReloadSignal>,
         command_tx: mpsc::Sender<ServerCommand>,
         tz: chrono_tz::Tz,
+        shutdown_rx: tokio::sync::watch::Receiver<bool>,
     ) -> Self {
         Self {
             cfg,
@@ -58,12 +62,14 @@ impl DiscordChannel {
             reload_tx,
             command_tx,
             tz,
+            shutdown_rx,
         }
     }
 
     /// Start the Discord gateway connection.
     ///
-    /// This blocks until the connection is closed or an error occurs.
+    /// This blocks until the connection is closed, a shutdown signal is
+    /// received, or an error occurs.
     ///
     /// # Errors
     /// Returns an error if the serenity client cannot be built or the connection fails.
@@ -85,6 +91,16 @@ impl DiscordChannel {
         let mut client = Client::builder(&self.cfg.token, intents)
             .event_handler(handler)
             .await?;
+
+        // Monitor shutdown signal and cleanly disconnect shards
+        let shard_manager = Arc::clone(&client.shard_manager);
+        let mut shutdown_rx = self.shutdown_rx;
+        tokio::spawn(async move {
+            if shutdown_rx.wait_for(|v| *v).await.is_ok() {
+                tracing::info!("discord adapter received shutdown signal");
+                shard_manager.shutdown_all().await;
+            }
+        });
 
         client.start().await
     }

--- a/src/channels/telegram/handler.rs
+++ b/src/channels/telegram/handler.rs
@@ -20,7 +20,8 @@ use super::reply::TelegramReplyHandle;
 /// Run the Telegram long-polling loop.
 ///
 /// Connects to the Telegram API, verifies the bot token, then enters an
-/// infinite polling loop that dispatches messages to the agent.
+/// infinite polling loop that dispatches messages to the agent. Returns
+/// cleanly when the shutdown signal fires.
 ///
 /// # Errors
 /// Returns an error if the initial `get_me` verification fails.
@@ -31,6 +32,7 @@ pub(super) async fn run_telegram_polling(
     reload_tx: tokio::sync::watch::Sender<ReloadSignal>,
     command_tx: mpsc::Sender<ServerCommand>,
     tz: chrono_tz::Tz,
+    mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
 ) -> anyhow::Result<()> {
     let bot = Bot::new(token);
     let inbox_dir = workspace_dir.join("inbox");
@@ -46,12 +48,20 @@ pub(super) async fn run_telegram_polling(
     let mut offset: i32 = 0;
 
     loop {
-        let updates = match bot.get_updates().offset(offset).timeout(30).await {
-            Ok(updates) => updates,
-            Err(e) => {
-                tracing::warn!(error = %e, "telegram polling error, retrying in 5s");
-                tokio::time::sleep(Duration::from_secs(5)).await;
-                continue;
+        let updates = tokio::select! {
+            result = bot.get_updates().offset(offset).timeout(30) => {
+                match result {
+                    Ok(updates) => updates,
+                    Err(e) => {
+                        tracing::warn!(error = %e, "telegram polling error, retrying in 5s");
+                        tokio::time::sleep(Duration::from_secs(5)).await;
+                        continue;
+                    }
+                }
+            }
+            _ = shutdown_rx.changed() => {
+                tracing::info!("telegram adapter received shutdown signal");
+                return Ok(());
             }
         };
 

--- a/src/channels/telegram/mod.rs
+++ b/src/channels/telegram/mod.rs
@@ -22,6 +22,7 @@ pub struct TelegramChannel {
     reload_tx: tokio::sync::watch::Sender<ReloadSignal>,
     command_tx: mpsc::Sender<ServerCommand>,
     tz: chrono_tz::Tz,
+    shutdown_rx: tokio::sync::watch::Receiver<bool>,
 }
 
 impl TelegramChannel {
@@ -34,6 +35,7 @@ impl TelegramChannel {
         reload_tx: tokio::sync::watch::Sender<ReloadSignal>,
         command_tx: mpsc::Sender<ServerCommand>,
         tz: chrono_tz::Tz,
+        shutdown_rx: tokio::sync::watch::Receiver<bool>,
     ) -> Self {
         Self {
             cfg,
@@ -42,12 +44,14 @@ impl TelegramChannel {
             reload_tx,
             command_tx,
             tz,
+            shutdown_rx,
         }
     }
 
     /// Start the Telegram long-polling loop.
     ///
-    /// This blocks until an error occurs or the task is cancelled.
+    /// This blocks until a shutdown signal is received, an error occurs, or the
+    /// task is cancelled.
     ///
     /// # Errors
     /// Returns an error if the bot cannot connect or polling fails fatally.
@@ -59,6 +63,7 @@ impl TelegramChannel {
             self.reload_tx,
             self.command_tx,
             self.tz,
+            self.shutdown_rx,
         )
         .await
     }

--- a/src/gateway/server/mod.rs
+++ b/src/gateway/server/mod.rs
@@ -182,7 +182,6 @@ struct GatewayRuntime {
     reload_rx: tokio::sync::watch::Receiver<ReloadSignal>,
     command_rx: mpsc::Receiver<ServerCommand>,
     /// Kept alive so the HTTP server task isn't dropped; shut down via `shutdown_tx`.
-    #[expect(dead_code, reason = "held to keep the server task alive")]
     server_handle: tokio::task::JoinHandle<()>,
     pulse_scheduler: PulseScheduler,
     /// SIGTERM signal listener for daemon stop support.
@@ -194,6 +193,15 @@ struct GatewayRuntime {
     /// Most recent reply handle from a user message. Used by wake turns to
     /// deliver responses to the channel the user last interacted from.
     last_reply: Option<Arc<dyn ReplyHandle>>,
+    // Adapter lifecycle handles
+    discord_handle: Option<tokio::task::JoinHandle<()>>,
+    telegram_handle: Option<tokio::task::JoinHandle<()>>,
+    discord_shutdown_tx: Option<tokio::sync::watch::Sender<bool>>,
+    telegram_shutdown_tx: Option<tokio::sync::watch::Sender<bool>>,
+    /// Cloned core senders for rebuilding adapters on reload.
+    inbound_tx: mpsc::Sender<RoutedMessage>,
+    reload_tx: tokio::sync::watch::Sender<ReloadSignal>,
+    command_tx: mpsc::Sender<ServerCommand>,
 }
 
 /// Apply an `ObserveAction` to the current observe deadline.
@@ -218,6 +226,37 @@ fn apply_observe_action(
     }
 }
 
+/// Build the axum `Router` for the HTTP/WS server.
+///
+/// Extracted for reuse during gateway port rebinding on config reload.
+fn build_gateway_app(
+    state: GatewayState,
+    cfg: &Config,
+    config_api_state: web::ConfigApiState,
+) -> axum::Router {
+    let webhook_router = cfg.webhook.enabled.then(|| {
+        let webhook_state = crate::channels::webhook::WebhookState {
+            inbound_tx: state.inbound_tx.clone(),
+            secret: cfg.webhook.secret.clone(),
+        };
+        axum::Router::new()
+            .route(
+                "/webhook",
+                axum::routing::post(crate::channels::webhook::webhook_handler),
+            )
+            .with_state(webhook_state)
+    });
+
+    let mut app = axum::Router::new()
+        .route("/ws", get(ws_handler))
+        .with_state(state);
+    if let Some(wh) = webhook_router {
+        app = app.merge(wh);
+    }
+    app.merge(web::config_api_router(config_api_state))
+        .fallback(web::static_handler)
+}
+
 /// Start the WebSocket gateway server and run the main event loop.
 ///
 /// Initializes all subsystems, spawns the axum WebSocket server, then enters
@@ -236,7 +275,7 @@ pub async fn run_gateway(cfg: Config) -> Result<GatewayExit, ResiduumError> {
     // Create long-lived channels via GatewayCore
     let (core, receivers) = GatewayCore::new(cfg.config_dir.clone());
 
-    // Clone senders for adapters before moving receivers into the runtime
+    // Clone senders for adapters and runtime before moving into GatewayState
     let discord_inbound_tx = core.inbound_tx.clone();
     let webhook_inbound_tx = core.inbound_tx.clone();
     let discord_reload_tx = core.reload_tx.clone();
@@ -244,6 +283,10 @@ pub async fn run_gateway(cfg: Config) -> Result<GatewayExit, ResiduumError> {
     let telegram_inbound_tx = core.inbound_tx.clone();
     let telegram_reload_tx = core.reload_tx.clone();
     let telegram_command_tx = core.command_tx.clone();
+    // Clones kept in GatewayRuntime for rebuilding adapters on reload
+    let rt_inbound_tx = core.inbound_tx.clone();
+    let rt_reload_tx = core.reload_tx.clone();
+    let rt_command_tx = core.command_tx.clone();
 
     let state = GatewayState {
         inbound_tx: core.inbound_tx,
@@ -254,38 +297,14 @@ pub async fn run_gateway(cfg: Config) -> Result<GatewayExit, ResiduumError> {
         tz: parts.tz,
     };
 
-    let webhook_router = if cfg.webhook.enabled {
-        let webhook_state = crate::channels::webhook::WebhookState {
-            inbound_tx: webhook_inbound_tx,
-            secret: cfg.webhook.secret.clone(),
-        };
-        Some(
-            axum::Router::new()
-                .route(
-                    "/webhook",
-                    axum::routing::post(crate::channels::webhook::webhook_handler),
-                )
-                .with_state(webhook_state),
-        )
-    } else {
-        drop(webhook_inbound_tx);
-        None
+    drop(webhook_inbound_tx);
+    let config_api_state = web::ConfigApiState {
+        config_dir: cfg.config_dir.clone(),
+        memory_dir: Some(parts.layout.memory_dir()),
+        reload_tx: Some(core.reload_tx.clone()),
+        setup_done: None,
     };
-
-    let mut app = axum::Router::new()
-        .route("/ws", get(ws_handler))
-        .with_state(state);
-    if let Some(wh) = webhook_router {
-        app = app.merge(wh);
-    }
-    app = app
-        .merge(web::config_api_router(web::ConfigApiState {
-            config_dir: cfg.config_dir.clone(),
-            memory_dir: Some(parts.layout.memory_dir()),
-            reload_tx: Some(core.reload_tx.clone()),
-            setup_done: None,
-        }))
-        .fallback(web::static_handler);
+    let app = build_gateway_app(state, &cfg, config_api_state);
 
     let addr = cfg.gateway.addr();
     let listener = tokio::net::TcpListener::bind(&addr)
@@ -313,7 +332,9 @@ pub async fn run_gateway(cfg: Config) -> Result<GatewayExit, ResiduumError> {
     });
 
     // Spawn Discord adapter if configured
+    let (mut discord_handle, mut discord_shutdown_tx) = (None, None);
     if let Some(ref discord_cfg) = cfg.discord {
+        let (tx, rx) = tokio::sync::watch::channel(false);
         let discord = crate::channels::discord::DiscordChannel::new(
             discord_cfg.clone(),
             discord_inbound_tx,
@@ -321,17 +342,21 @@ pub async fn run_gateway(cfg: Config) -> Result<GatewayExit, ResiduumError> {
             discord_reload_tx,
             discord_command_tx,
             parts.tz,
+            rx,
         );
-        tokio::spawn(async move {
+        discord_handle = Some(tokio::spawn(async move {
             if let Err(e) = discord.start().await {
                 tracing::error!(error = %e, "discord channel failed");
             }
-        });
+        }));
+        discord_shutdown_tx = Some(tx);
         tracing::info!("discord channel started (DM-only mode)");
     }
 
     // Spawn Telegram adapter if configured
+    let (mut telegram_handle, mut telegram_shutdown_tx) = (None, None);
     if let Some(ref telegram_cfg) = cfg.telegram {
+        let (tx, rx) = tokio::sync::watch::channel(false);
         let telegram = crate::channels::telegram::TelegramChannel::new(
             telegram_cfg.clone(),
             telegram_inbound_tx,
@@ -339,12 +364,14 @@ pub async fn run_gateway(cfg: Config) -> Result<GatewayExit, ResiduumError> {
             telegram_reload_tx,
             telegram_command_tx,
             parts.tz,
+            rx,
         );
-        tokio::spawn(async move {
+        telegram_handle = Some(tokio::spawn(async move {
             if let Err(e) = telegram.start().await {
                 tracing::error!(error = %e, "telegram channel failed");
             }
-        });
+        }));
+        telegram_shutdown_tx = Some(tx);
         tracing::info!("telegram channel started (DM-only mode)");
     }
 
@@ -388,6 +415,13 @@ pub async fn run_gateway(cfg: Config) -> Result<GatewayExit, ResiduumError> {
         shutdown_tx: core.shutdown_tx,
         config_dir: core.config_dir.clone(),
         last_reply: None,
+        discord_handle,
+        telegram_handle,
+        discord_shutdown_tx,
+        telegram_shutdown_tx,
+        inbound_tx: rt_inbound_tx,
+        reload_tx: rt_reload_tx,
+        command_tx: rt_command_tx,
         cfg,
     };
 
@@ -893,6 +927,12 @@ async fn run_event_loop(mut rt: GatewayRuntime) -> GatewayExit {
             _ = rt.sigterm.recv() => {
                 tracing::info!("received SIGTERM, shutting down");
                 rt.mcp_registry.write().await.disconnect_all().await;
+                if let Some(tx) = rt.discord_shutdown_tx.take() {
+                    tx.send(true).ok();
+                }
+                if let Some(tx) = rt.telegram_shutdown_tx.take() {
+                    tx.send(true).ok();
+                }
                 rt.shutdown_tx.send(true).ok();
                 break;
             }

--- a/src/gateway/server/reload.rs
+++ b/src/gateway/server/reload.rs
@@ -2,6 +2,8 @@
 
 use std::sync::Arc;
 
+use tokio::time::Duration;
+
 use crate::config::Config;
 use crate::gateway::protocol::ServerMessage;
 use crate::models::CompletionOptions;
@@ -208,34 +210,145 @@ pub(super) async fn handle_root_reload(rt: &mut GatewayRuntime) {
         tracing::info!("memory thresholds updated");
     }
 
-    // ── Gateway bind/port (deferred to Phase 6) ─────────────────────────
+    // ── Gateway bind/port ─────────────────────────────────────────────
     if diff.gateway_changed {
-        rt.broadcast_tx
-            .send(ServerMessage::Notice {
-                message: "gateway bind/port changed — restart required to take effect".to_string(),
-            })
-            .ok();
-        tracing::warn!("gateway bind/port changed, restart required");
+        let new_addr = new_cfg.gateway.addr();
+        match tokio::net::TcpListener::bind(&new_addr).await {
+            Ok(listener) => {
+                // Shut down the old HTTP server
+                rt.shutdown_tx.send(true).ok();
+
+                // New shutdown channel for the replacement server
+                let (new_shutdown_tx, mut new_shutdown_rx) = tokio::sync::watch::channel(false);
+
+                let state = super::GatewayState {
+                    inbound_tx: rt.inbound_tx.clone(),
+                    broadcast_tx: rt.broadcast_tx.clone(),
+                    reload_tx: rt.reload_tx.clone(),
+                    command_tx: rt.command_tx.clone(),
+                    inbox_dir: rt.layout.inbox_dir(),
+                    tz: rt.tz,
+                };
+                let config_api_state = super::web::ConfigApiState {
+                    config_dir: rt.config_dir.clone(),
+                    memory_dir: Some(rt.layout.memory_dir()),
+                    reload_tx: Some(rt.reload_tx.clone()),
+                    setup_done: None,
+                };
+                let app = super::build_gateway_app(state, &new_cfg, config_api_state);
+
+                let new_handle = tokio::spawn(async move {
+                    if let Err(e) = axum::serve(listener, app)
+                        .with_graceful_shutdown(async move {
+                            new_shutdown_rx.wait_for(|v| *v).await.ok();
+                        })
+                        .await
+                    {
+                        tracing::error!(error = %e, "gateway server error after rebind");
+                    }
+                });
+
+                rt.server_handle = new_handle;
+                rt.shutdown_tx = new_shutdown_tx;
+                tracing::info!(addr = %new_addr, "gateway rebound to new address");
+            }
+            Err(e) => {
+                tracing::warn!(
+                    addr = %new_addr,
+                    error = %e,
+                    "failed to bind to new gateway address, keeping current server"
+                );
+                rt.broadcast_tx
+                    .send(ServerMessage::Notice {
+                        message: format!(
+                            "gateway rebind failed ({new_addr}): {e} — keeping current server"
+                        ),
+                    })
+                    .ok();
+            }
+        }
     }
 
-    // ── Discord token (deferred to Phase 6) ─────────────────────────────
+    // ── Discord token ───────────────────────────────────────────────────
     if diff.discord_changed {
-        rt.broadcast_tx
-            .send(ServerMessage::Notice {
-                message: "discord token changed — restart required to take effect".to_string(),
-            })
-            .ok();
-        tracing::warn!("discord token changed, restart required");
+        // Shut down existing adapter if running
+        if let Some(tx) = rt.discord_shutdown_tx.take() {
+            tx.send(true).ok();
+        }
+        if let Some(handle) = rt.discord_handle.take() {
+            if tokio::time::timeout(Duration::from_secs(5), handle)
+                .await
+                .is_ok()
+            {
+                tracing::info!("discord adapter stopped");
+            } else {
+                tracing::warn!("discord adapter shutdown timed out after 5s");
+            }
+        }
+
+        // Start new adapter if token is configured
+        if let Some(ref discord_cfg) = new_cfg.discord {
+            let (tx, rx) = tokio::sync::watch::channel(false);
+            let discord = crate::channels::discord::DiscordChannel::new(
+                discord_cfg.clone(),
+                rt.inbound_tx.clone(),
+                new_cfg.workspace_dir.clone(),
+                rt.reload_tx.clone(),
+                rt.command_tx.clone(),
+                rt.tz,
+                rx,
+            );
+            rt.discord_handle = Some(tokio::spawn(async move {
+                if let Err(e) = discord.start().await {
+                    tracing::error!(error = %e, "discord channel failed after reload");
+                }
+            }));
+            rt.discord_shutdown_tx = Some(tx);
+            tracing::info!("discord adapter restarted with new token");
+        } else {
+            tracing::info!("discord adapter removed from config");
+        }
     }
 
-    // ── Telegram token (deferred to Phase 6) ────────────────────────────
+    // ── Telegram token ──────────────────────────────────────────────────
     if diff.telegram_changed {
-        rt.broadcast_tx
-            .send(ServerMessage::Notice {
-                message: "telegram token changed — restart required to take effect".to_string(),
-            })
-            .ok();
-        tracing::warn!("telegram token changed, restart required");
+        // Shut down existing adapter if running
+        if let Some(tx) = rt.telegram_shutdown_tx.take() {
+            tx.send(true).ok();
+        }
+        if let Some(handle) = rt.telegram_handle.take() {
+            if tokio::time::timeout(Duration::from_secs(5), handle)
+                .await
+                .is_ok()
+            {
+                tracing::info!("telegram adapter stopped");
+            } else {
+                tracing::warn!("telegram adapter shutdown timed out after 5s");
+            }
+        }
+
+        // Start new adapter if token is configured
+        if let Some(ref telegram_cfg) = new_cfg.telegram {
+            let (tx, rx) = tokio::sync::watch::channel(false);
+            let telegram = crate::channels::telegram::TelegramChannel::new(
+                telegram_cfg.clone(),
+                rt.inbound_tx.clone(),
+                new_cfg.workspace_dir.clone(),
+                rt.reload_tx.clone(),
+                rt.command_tx.clone(),
+                rt.tz,
+                rx,
+            );
+            rt.telegram_handle = Some(tokio::spawn(async move {
+                if let Err(e) = telegram.start().await {
+                    tracing::error!(error = %e, "telegram channel failed after reload");
+                }
+            }));
+            rt.telegram_shutdown_tx = Some(tx);
+            tracing::info!("telegram adapter restarted with new token");
+        } else {
+            tracing::info!("telegram adapter removed from config");
+        }
     }
 
     // ── Pulse toggle ────────────────────────────────────────────────────
@@ -410,5 +523,47 @@ mod tests {
         assert!(summary.contains("skills"));
         assert!(summary.contains("agent"));
         assert!(summary.contains("background"));
+    }
+
+    #[test]
+    fn diff_config_detects_discord_addition() {
+        let old = test_config();
+        let mut new = old.clone();
+        new.discord = Some(DiscordConfig {
+            token: "new-token".to_string(),
+        });
+
+        let diff = diff_config(&old, &new);
+        assert!(diff.discord_changed);
+        assert!(!diff.telegram_changed);
+    }
+
+    #[test]
+    fn diff_config_detects_discord_removal() {
+        let mut old = test_config();
+        old.discord = Some(DiscordConfig {
+            token: "existing-token".to_string(),
+        });
+        let mut new = old.clone();
+        new.discord = None;
+
+        let diff = diff_config(&old, &new);
+        assert!(diff.discord_changed);
+    }
+
+    #[test]
+    fn diff_config_detects_telegram_token_change() {
+        let mut old = test_config();
+        old.telegram = Some(TelegramConfig {
+            token: "old-tg-token".to_string(),
+        });
+        let mut new = old.clone();
+        new.telegram = Some(TelegramConfig {
+            token: "new-tg-token".to_string(),
+        });
+
+        let diff = diff_config(&old, &new);
+        assert!(diff.telegram_changed);
+        assert!(!diff.discord_changed);
     }
 }


### PR DESCRIPTION
## Summary

- Discord and Telegram adapters accept `watch::Receiver<bool>` shutdown signals for graceful stop/restart on token change
- Discord: spawns a shard manager monitoring task that cleanly disconnects shards on shutdown signal
- Telegram: wraps polling loop in `tokio::select!` to exit cleanly on shutdown signal
- `GatewayRuntime` tracks adapter `JoinHandle`s and shutdown senders, plus cloned core senders for rebuilding adapters
- Gateway HTTP server rebinds on port change (try-bind-first, fallback to keeping old server)
- `handle_root_reload()` replaces Phase 5 placeholders with actual shutdown-and-restart logic for all three subsystems (gateway, Discord, Telegram)
- SIGTERM handler signals adapter shutdown before HTTP server shutdown
- Extracted `build_gateway_app()` helper for reuse during rebinding

## Test plan
- [x] All 1,091 tests pass (`cargo test --quiet`)
- [x] `cargo clippy` clean
- [x] `cargo fmt` applied
- [x] `diff_config_detects_discord_addition` — `None` → `Some(token)` detected
- [x] `diff_config_detects_discord_removal` — `Some(token)` → `None` detected
- [x] `diff_config_detects_telegram_token_change` — different tokens detected
- [ ] Manual: `residuum serve --foreground` boots without errors
- [ ] Manual: edit `config.toml` gateway port while running — verify HTTP server rebinds
- [ ] Manual: edit `config.toml` to add/change/remove Discord/Telegram tokens — verify adapter restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)