### PR TITLE
feat: Phase 2 chat view with Svelte 5 components

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <title>Residuum</title>
   </head>
   <body>

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -1,2 +1,50 @@
-<h1>Residuum</h1>
-<p>Loading…</p>
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { fetchStatus } from "./lib/api";
+  import { ws } from "./lib/ws.svelte";
+  import Header from "./components/Header.svelte";
+  import Chat from "./Chat.svelte";
+
+  let mode = $state<"loading" | "setup" | "running">("loading");
+
+  onMount(async () => {
+    try {
+      const status = await fetchStatus();
+      mode = status.mode === "setup" ? "setup" : "running";
+    } catch {
+      // If status check fails, assume running (server may not support setup)
+      mode = "running";
+    }
+  });
+
+  function handleToggleVerbose() {
+    ws.setVerbose(!ws.verbose);
+  }
+</script>
+
+{#if mode === "loading"}
+  <div class="header">
+    <div class="header-brand">
+      <div class="header-icon">&#9670;</div>
+      <span class="header-title">Residuum</span>
+      <span class="header-status connecting">loading</span>
+    </div>
+  </div>
+{:else if mode === "setup"}
+  <div class="header">
+    <div class="header-brand">
+      <div class="header-icon">&#9670;</div>
+      <span class="header-title">Residuum</span>
+    </div>
+  </div>
+  <div style="flex:1;display:flex;align-items:center;justify-content:center;color:var(--text-muted);font-size:14px;">
+    Setup wizard coming in Phase 3
+  </div>
+{:else}
+  <Header
+    status={ws.status}
+    verbose={ws.verbose}
+    onToggleVerbose={handleToggleVerbose}
+  />
+  <Chat />
+{/if}

--- a/web/src/Chat.svelte
+++ b/web/src/Chat.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+  import { onMount, onDestroy } from "svelte";
+  import { ws } from "./lib/ws.svelte";
+  import { fetchChatHistory } from "./lib/api";
+  import { parseCommand } from "./lib/commands";
+  import ChatFeed from "./components/ChatFeed.svelte";
+  import ChatInput from "./components/ChatInput.svelte";
+
+  let feedIdCounter = 0;
+  function nextId(): number {
+    return --feedIdCounter; // negative IDs to avoid collision with ws module
+  }
+
+  onMount(async () => {
+    try {
+      const history = await fetchChatHistory();
+      ws.loadHistory(history);
+    } catch {
+      // history unavailable — start with empty feed
+    }
+    ws.connect();
+  });
+
+  onDestroy(() => {
+    ws.disconnect();
+  });
+
+  function handleSend(text: string) {
+    const result = parseCommand(text, {
+      connectionStatus: ws.status,
+      verbose: ws.verbose,
+      nextId,
+    });
+
+    if (result) {
+      if (result.feedItem) ws.appendFeedItem(result.feedItem);
+      if (result.wsMessage) ws.send(result.wsMessage);
+
+      // Handle verbose toggle specially
+      if (text.toLowerCase() === "/verbose") {
+        ws.setVerbose(!ws.verbose);
+      }
+      return;
+    }
+
+    ws.sendChat(text);
+  }
+</script>
+
+<div class="chat-view">
+  <ChatFeed
+    items={ws.feed}
+    isProcessing={ws.isProcessing}
+    verbose={ws.verbose}
+  />
+  <ChatInput
+    onSend={handleSend}
+    disabled={ws.status !== "connected"}
+  />
+</div>

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -1,0 +1,589 @@
+/* ── Residuum Web UI — Stone + Vein Theme ─────────────────────────────── */
+
+@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=JetBrains+Mono:wght@400;500&family=Literata:ital,opsz,wght@0,7..72,300..700;1,7..72,300..700&display=swap');
+
+:root {
+    /* Stone + Vein palette */
+    --bg-deep: #0e0e10;
+    --bg-surface: #161618;
+    --bg-raised: #1c1c1f;
+    --bg-input: #141416;
+
+    --border: #2a2a2e;
+    --border-subtle: #222225;
+
+    --text: #e8e8ea;
+    --text-muted: #9a9a9f;
+    --text-dim: #6a6a6f;
+
+    --ember: #3b8bdb;
+    --ember-bright: #5aa3f0;
+    --ember-glow: rgba(59, 139, 219, 0.15);
+    --ember-dim: #2a6cb5;
+
+    --steel: #6b7a4a;
+    --steel-dim: #7a7d6e;
+
+    --error: #c0392b;
+    --error-bg: rgba(192, 57, 43, 0.1);
+    --success: #2ecc71;
+
+    /* Card tints */
+    --card-user: rgba(107, 122, 74, 0.14);
+    --card-assistant: rgba(59, 139, 219, 0.10);
+    --card-shadow: 0 1px 4px rgba(0, 0, 0, 0.25), 0 0 1px rgba(0, 0, 0, 0.15);
+    --card-shadow-hover: 0 2px 8px rgba(0, 0, 0, 0.35), 0 0 1px rgba(0, 0, 0, 0.2);
+
+    /* Glow effects */
+    --ember-ring: 0 0 0 1px rgba(59, 139, 219, 0.2), 0 0 0 3px rgba(59, 139, 219, 0.07);
+    --input-inset: inset 0 1px 3px rgba(0, 0, 0, 0.3);
+
+    /* Typography */
+    --font-display: 'Cinzel', 'Georgia', serif;
+    --font-body: 'Literata', 'Georgia', serif;
+    --font-mono: 'JetBrains Mono', 'Fira Code', 'SF Mono', 'Cascadia Code', 'Consolas', monospace;
+
+    /* Sizing */
+    --chat-max-width: 760px;
+    --header-height: 52px;
+    --input-height: 56px;
+    --radius: 6px;
+    --radius-sm: 4px;
+
+    /* Motion */
+    --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* ── Reset ─────────────────────────────────────────────────────────────── */
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html, body {
+    height: 100%;
+    font-family: var(--font-body);
+    font-size: 15px;
+    font-weight: 400;
+    line-height: 1.6;
+    color: var(--text);
+    background: var(--bg-deep);
+    -webkit-font-smoothing: antialiased;
+}
+
+/* ── Grain texture overlay ─────────────────────────────────────────────── */
+
+body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: 9999;
+    opacity: 0.025;
+    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+    background-size: 256px 256px;
+}
+
+/* ── Layout ────────────────────────────────────────────────────────────── */
+
+#app {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+/* ── Header ────────────────────────────────────────────────────────────── */
+
+.header {
+    display: flex;
+    align-items: center;
+    height: var(--header-height);
+    padding: 0 16px;
+    border-bottom: 1px solid var(--border-subtle);
+    background: linear-gradient(180deg, #1a1a1e 0%, var(--bg-surface) 100%);
+    box-shadow: 0 1px 6px rgba(0, 0, 0, 0.3), 0 1px 0 rgba(59, 139, 219, 0.08);
+    flex-shrink: 0;
+    gap: 10px;
+    position: relative;
+    z-index: 10;
+}
+
+.header-brand {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex: 1;
+}
+
+.header-icon {
+    width: 28px;
+    height: 28px;
+    border-radius: var(--radius-sm);
+    background: var(--ember-glow);
+    border: 1px solid var(--ember-dim);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 16px;
+    color: var(--ember);
+}
+
+.header-title {
+    font-family: var(--font-display);
+    font-size: 16px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    color: var(--text);
+}
+
+.header-status {
+    font-size: 11px;
+    color: var(--text-dim);
+    padding: 2px 8px;
+    border-radius: 10px;
+    border: 1px solid var(--border-subtle);
+}
+
+.header-status.connected { color: var(--success); border-color: rgba(46, 204, 113, 0.3); }
+.header-status.disconnected { color: var(--error); border-color: rgba(192, 57, 43, 0.3); }
+.header-status.connecting { color: var(--ember); border-color: rgba(59, 139, 219, 0.3); }
+
+.header-actions {
+    display: flex;
+    gap: 6px;
+}
+
+.icon-btn {
+    width: 34px;
+    height: 34px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-subtle);
+    background: transparent;
+    color: var(--text-muted);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 16px;
+    transition: all 0.15s;
+}
+
+.icon-btn:hover {
+    background: var(--bg-raised);
+    color: var(--text);
+    border-color: var(--border);
+}
+
+.icon-btn.active {
+    background: var(--ember-glow);
+    color: var(--ember);
+    border-color: var(--ember-dim);
+}
+
+/* ── Chat view ─────────────────────────────────────────────────────────── */
+
+.chat-view {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    overflow: hidden;
+    position: relative;
+}
+
+.chat-feed {
+    flex: 1;
+    overflow-y: auto;
+    padding: 16px 16px 96px;
+    scroll-behavior: smooth;
+}
+
+.chat-feed-inner {
+    max-width: var(--chat-max-width);
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+/* ── Messages ──────────────────────────────────────────────────────────── */
+
+.msg {
+    padding: 12px 16px;
+    border-radius: var(--radius);
+    max-width: 100%;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    animation: msg-enter 0.35s var(--ease-out-expo) both;
+    position: relative;
+}
+
+@keyframes msg-enter {
+    from {
+        opacity: 0;
+        transform: translateY(6px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.msg-user {
+    background: var(--card-user);
+    border: 1px solid rgba(107, 122, 74, 0.25);
+    margin-top: 10px;
+    box-shadow: var(--card-shadow);
+    align-self: flex-end;
+    max-width: 80%;
+    border-radius: 18px 18px 4px 18px;
+}
+
+.msg-assistant {
+    background: var(--card-assistant);
+    border: 1px solid rgba(59, 139, 219, 0.18);
+    box-shadow: var(--card-shadow);
+    align-self: flex-start;
+    border-radius: 18px 18px 18px 4px;
+}
+
+.msg-system {
+    font-size: 12px;
+    color: var(--text-dim);
+    padding: 6px 14px;
+    margin-top: 8px;
+    font-style: italic;
+    border-left: 3px solid var(--border-subtle);
+}
+
+.msg-divider {
+    font-size: 11px;
+    color: var(--text-dim);
+    text-align: center;
+    padding: 4px 0;
+    margin: 12px 0;
+    border-top: 1px solid var(--border-subtle);
+    border-bottom: 1px solid var(--border-subtle);
+    letter-spacing: 0.5px;
+}
+
+.msg-error {
+    background: var(--error-bg);
+    border-left: 3px solid var(--error);
+    color: #e8a0a0;
+    margin-top: 8px;
+}
+
+.msg-notice {
+    font-size: 12px;
+    font-family: var(--font-mono);
+    color: var(--text-muted);
+    padding: 6px 14px;
+    margin-top: 8px;
+    border-left: 3px solid var(--steel-dim);
+    white-space: pre-wrap;
+}
+
+.msg-content {
+    line-height: 1.6;
+}
+
+.msg-content p { margin-bottom: 8px; }
+.msg-content p:last-child { margin-bottom: 0; }
+
+.msg-content code {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    background: var(--bg-deep);
+    padding: 1px 5px;
+    border-radius: 3px;
+    border: 1px solid var(--border-subtle);
+}
+
+.msg-content pre {
+    margin: 8px 0;
+    padding: 10px 12px;
+    background: var(--bg-deep);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-sm);
+    overflow-x: auto;
+    font-family: var(--font-mono);
+    font-size: 12.5px;
+    line-height: 1.5;
+}
+
+.msg-content pre code {
+    background: none;
+    padding: 0;
+    border: none;
+    font-size: inherit;
+}
+
+.msg-content h2,
+.msg-content h3,
+.msg-content h4 {
+    font-family: var(--font-display);
+    letter-spacing: 0.03em;
+    margin: 12px 0 6px;
+    color: var(--text);
+}
+
+.msg-content h2 { font-size: 1.15em; font-weight: 700; }
+.msg-content h3 { font-size: 1.05em; font-weight: 600; }
+.msg-content h4 { font-size: 1em; font-weight: 600; color: var(--text-muted); }
+
+.msg-content blockquote {
+    border-left: 3px solid var(--ember-dim);
+    padding: 6px 12px;
+    margin: 8px 0;
+    color: var(--text-muted);
+    background: rgba(59, 139, 219, 0.03);
+    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}
+
+.msg-content ul,
+.msg-content ol {
+    padding-left: 20px;
+    margin: 6px 0;
+}
+
+.msg-content li {
+    margin-bottom: 3px;
+}
+
+.msg-content ul li::marker {
+    color: var(--ember-dim);
+}
+
+.msg-content ol li::marker {
+    color: var(--ember-dim);
+    font-weight: 600;
+}
+
+.msg-content a {
+    color: var(--ember-bright);
+    text-decoration: none;
+    border-bottom: 1px solid transparent;
+    transition: border-color 0.15s;
+}
+
+.msg-content a:hover {
+    border-bottom-color: var(--ember-bright);
+}
+
+.msg-content hr {
+    border: none;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, var(--border), transparent);
+    margin: 12px 0;
+}
+
+/* ── Tool calls ────────────────────────────────────────────────────────── */
+
+.tool-group {
+    margin-top: 4px;
+}
+
+.tool-item {
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-sm);
+    margin-bottom: 4px;
+    overflow: hidden;
+}
+
+.tool-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    background: var(--bg-surface);
+    cursor: pointer;
+    font-size: 12px;
+    font-family: var(--font-mono);
+    color: var(--text-muted);
+    user-select: none;
+}
+
+.tool-header:hover { background: var(--bg-raised); }
+
+.tool-chevron {
+    font-size: 10px;
+    transition: transform 0.15s;
+    color: var(--text-dim);
+}
+
+.tool-item.open .tool-chevron { transform: rotate(90deg); }
+
+.tool-name { color: var(--ember); font-weight: 500; }
+
+.tool-status { margin-left: auto; font-size: 11px; }
+.tool-status.ok { color: var(--success); }
+.tool-status.err { color: var(--error); }
+
+.tool-body {
+    display: none;
+    padding: 8px 10px;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    line-height: 1.45;
+    background: var(--bg-deep);
+    max-height: 300px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    color: var(--text-muted);
+    border-top: 1px solid var(--border-subtle);
+}
+
+.tool-item.open .tool-body { display: block; }
+
+/* ── Thinking indicator (vein-pulse bars) ─────────────────────────────── */
+
+.thinking {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 14px;
+    color: var(--text-dim);
+    font-size: 13px;
+    animation: msg-enter 0.3s var(--ease-out-expo) both;
+}
+
+.thinking-bars {
+    display: flex;
+    align-items: flex-end;
+    gap: 3px;
+    height: 16px;
+}
+
+.thinking-bars span {
+    display: block;
+    width: 3px;
+    border-radius: 1.5px;
+    background: var(--ember);
+    animation: vein-pulse 1.2s ease-in-out infinite;
+}
+
+.thinking-bars span:nth-child(1) {
+    animation-delay: 0s;
+    height: 8px;
+}
+
+.thinking-bars span:nth-child(2) {
+    animation-delay: 0.15s;
+    height: 14px;
+}
+
+.thinking-bars span:nth-child(3) {
+    animation-delay: 0.3s;
+    height: 10px;
+}
+
+@keyframes vein-pulse {
+    0%, 100% {
+        opacity: 0.35;
+        height: 4px;
+        background: var(--ember-dim);
+    }
+    50% {
+        opacity: 1;
+        height: 16px;
+        background: var(--ember-bright);
+    }
+}
+
+/* ── Input area ────────────────────────────────────────────────────────── */
+
+.chat-input-area {
+    position: absolute;
+    bottom: 16px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: calc(100% - 32px);
+    max-width: var(--chat-max-width);
+    padding: 0;
+    background: transparent;
+    flex-shrink: 0;
+    z-index: 20;
+}
+
+.chat-input-wrap {
+    display: flex;
+    gap: 8px;
+    align-items: flex-end;
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: 16px;
+    padding: 8px 8px 8px 4px;
+    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(255, 255, 255, 0.03);
+}
+
+.chat-input {
+    flex: 1;
+    min-height: 44px;
+    max-height: 160px;
+    padding: 10px 14px;
+    font-family: var(--font-body);
+    font-size: 14px;
+    color: var(--text);
+    background: transparent;
+    border: none;
+    border-radius: 12px;
+    resize: none;
+    outline: none;
+    line-height: 1.5;
+    transition: background 0.2s;
+}
+
+.chat-input:focus {
+    background: rgba(255, 255, 255, 0.02);
+}
+
+.chat-input::placeholder { color: var(--text-dim); }
+
+.send-btn {
+    height: 44px;
+    padding: 0 20px;
+    font-family: var(--font-display);
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    color: var(--bg-deep);
+    background: var(--ember);
+    border: none;
+    border-radius: 12px;
+    cursor: pointer;
+    box-shadow: 0 2px 6px rgba(59, 139, 219, 0.25);
+    transition: all 0.2s var(--ease-out-expo);
+    white-space: nowrap;
+}
+
+.send-btn:hover {
+    background: var(--ember-bright);
+    box-shadow: 0 4px 12px rgba(59, 139, 219, 0.35);
+    transform: translateY(-1px);
+}
+
+.send-btn:active {
+    transform: translateY(0);
+    box-shadow: 0 1px 3px rgba(59, 139, 219, 0.2);
+}
+
+.send-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+    box-shadow: none;
+    transform: none;
+}
+
+/* ── Scrollbar ─────────────────────────────────────────────────────────── */
+
+::-webkit-scrollbar { width: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: var(--text-dim); }
+
+/* ── Responsive ────────────────────────────────────────────────────────── */
+
+@media (max-width: 600px) {
+    .chat-input-area { width: calc(100% - 16px); bottom: 8px; }
+    .chat-input-wrap { flex-direction: column; border-radius: 12px; }
+    .send-btn { width: 100%; height: 42px; }
+    .msg-user { max-width: 90%; }
+}

--- a/web/src/components/ChatFeed.svelte
+++ b/web/src/components/ChatFeed.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  import { tick } from "svelte";
+  import type { FeedItem } from "../lib/types";
+  import MessageUser from "./MessageUser.svelte";
+  import MessageAssistant from "./MessageAssistant.svelte";
+  import MessageSystem from "./MessageSystem.svelte";
+  import MessageError from "./MessageError.svelte";
+  import MessageNotice from "./MessageNotice.svelte";
+  import MessageDivider from "./MessageDivider.svelte";
+  import ToolGroup from "./ToolGroup.svelte";
+  import ThinkingIndicator from "./ThinkingIndicator.svelte";
+
+  let { items, isProcessing, verbose }: {
+    items: FeedItem[];
+    isProcessing: boolean;
+    verbose: boolean;
+  } = $props();
+
+  let feedEl: HTMLDivElement | undefined = $state();
+
+  function scrollToBottom() {
+    if (!feedEl) return;
+    requestAnimationFrame(() => {
+      if (feedEl) feedEl.scrollTop = feedEl.scrollHeight;
+    });
+  }
+
+  $effect(() => {
+    // scroll when items change
+    items.length;
+    isProcessing;
+    tick().then(scrollToBottom);
+  });
+</script>
+
+<div class="chat-feed" bind:this={feedEl}>
+  <div class="chat-feed-inner">
+    {#each items as item (item.id)}
+      {#if item.kind === "user"}
+        <MessageUser content={item.content} />
+      {:else if item.kind === "assistant"}
+        <MessageAssistant content={item.content} />
+      {:else if item.kind === "system"}
+        <MessageSystem content={item.content} />
+      {:else if item.kind === "error"}
+        <MessageError content={item.content} />
+      {:else if item.kind === "notice"}
+        <MessageNotice content={item.content} />
+      {:else if item.kind === "divider"}
+        <MessageDivider label={item.label} />
+      {:else if item.kind === "tool-group"}
+        <ToolGroup calls={item.calls} {verbose} />
+      {:else if item.kind === "command-output"}
+        <MessageNotice content={item.content} />
+      {/if}
+    {/each}
+    {#if isProcessing}
+      <ThinkingIndicator />
+    {/if}
+  </div>
+</div>

--- a/web/src/components/ChatInput.svelte
+++ b/web/src/components/ChatInput.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  let { onSend, disabled = false }: { onSend: (text: string) => void; disabled?: boolean } = $props();
+  let value = $state("");
+  let textarea: HTMLTextAreaElement | undefined = $state();
+
+  function autoResize() {
+    if (!textarea) return;
+    textarea.style.height = "auto";
+    textarea.style.height = Math.min(textarea.scrollHeight, 160) + "px";
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      submit();
+    }
+  }
+
+  function submit() {
+    const text = value.trim();
+    if (!text || disabled) return;
+    onSend(text);
+    value = "";
+    if (textarea) textarea.style.height = "auto";
+  }
+
+  $effect(() => {
+    // trigger resize when value changes
+    value;
+    autoResize();
+  });
+</script>
+
+<div class="chat-input-area">
+  <div class="chat-input-wrap">
+    <textarea
+      bind:this={textarea}
+      bind:value
+      class="chat-input"
+      placeholder="Send a message..."
+      rows="1"
+      {disabled}
+      onkeydown={handleKeydown}
+      oninput={autoResize}
+    ></textarea>
+    <button class="send-btn" onclick={submit} disabled={disabled || !value.trim()}>
+      Send
+    </button>
+  </div>
+</div>

--- a/web/src/components/Header.svelte
+++ b/web/src/components/Header.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import type { ConnectionStatus } from "../lib/types";
+
+  let { status, verbose, onToggleVerbose }: {
+    status: ConnectionStatus;
+    verbose: boolean;
+    onToggleVerbose: () => void;
+  } = $props();
+</script>
+
+<div class="header">
+  <div class="header-brand">
+    <div class="header-icon">&#9670;</div>
+    <span class="header-title">Residuum</span>
+    <span class="header-status {status}">{status}</span>
+  </div>
+  <div class="header-actions">
+    <button
+      class="icon-btn"
+      class:active={verbose}
+      title="Toggle tool visibility"
+      onclick={onToggleVerbose}
+    >
+      &#128295;
+    </button>
+  </div>
+</div>

--- a/web/src/components/MessageAssistant.svelte
+++ b/web/src/components/MessageAssistant.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import { renderMarkdown } from "../lib/markdown";
+
+  let { content }: { content: string } = $props();
+</script>
+
+<div class="msg msg-assistant">
+  <div class="msg-content">{@html renderMarkdown(content)}</div>
+</div>

--- a/web/src/components/MessageDivider.svelte
+++ b/web/src/components/MessageDivider.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  let { label }: { label: string } = $props();
+</script>
+
+<div class="msg msg-divider">{label}</div>

--- a/web/src/components/MessageError.svelte
+++ b/web/src/components/MessageError.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  let { content }: { content: string } = $props();
+</script>
+
+<div class="msg msg-error">{content}</div>

--- a/web/src/components/MessageNotice.svelte
+++ b/web/src/components/MessageNotice.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  let { content }: { content: string } = $props();
+</script>
+
+<div class="msg msg-notice">{content}</div>

--- a/web/src/components/MessageSystem.svelte
+++ b/web/src/components/MessageSystem.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  let { content }: { content: string } = $props();
+</script>
+
+<div class="msg msg-system">{content}</div>

--- a/web/src/components/MessageUser.svelte
+++ b/web/src/components/MessageUser.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import { escapeHtml } from "../lib/markdown";
+
+  let { content }: { content: string } = $props();
+</script>
+
+<div class="msg msg-user">
+  <div class="msg-content">{@html escapeHtml(content)}</div>
+</div>

--- a/web/src/components/ThinkingIndicator.svelte
+++ b/web/src/components/ThinkingIndicator.svelte
@@ -1,0 +1,8 @@
+<div class="thinking">
+  <span class="thinking-bars">
+    <span></span>
+    <span></span>
+    <span></span>
+  </span>
+  <span>Thinking...</span>
+</div>

--- a/web/src/components/ToolGroup.svelte
+++ b/web/src/components/ToolGroup.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import type { ToolCallState } from "../lib/types";
+  import ToolItem from "./ToolItem.svelte";
+
+  let { calls, verbose }: { calls: ToolCallState[]; verbose: boolean } =
+    $props();
+</script>
+
+{#if verbose}
+  <div class="tool-group">
+    {#each calls as call (call.id)}
+      <ToolItem {call} />
+    {/each}
+  </div>
+{/if}

--- a/web/src/components/ToolItem.svelte
+++ b/web/src/components/ToolItem.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import type { ToolCallState } from "../lib/types";
+
+  let { call }: { call: ToolCallState } = $props();
+  let open = $state(false);
+</script>
+
+<div class="tool-item" class:open>
+  <div
+    class="tool-header"
+    onclick={() => (open = !open)}
+    role="button"
+    tabindex="0"
+    onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') open = !open; }}
+  >
+    <span class="tool-chevron">&#9654;</span>
+    <span class="tool-name">{call.name}</span>
+    <span
+      class="tool-status"
+      class:ok={call.status === "done"}
+      class:err={call.status === "error"}
+    >
+      {call.status === "running" ? "running..." : call.status}
+    </span>
+  </div>
+  <div class="tool-body">
+    {call.arguments}{#if call.result}{"\n"}{call.result}{/if}
+  </div>
+</div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,0 +1,15 @@
+// ── Typed fetch wrappers ─────────────────────────────────────────────
+
+import type { StatusResponse, RecentMessage } from "./types";
+
+export async function fetchStatus(): Promise<StatusResponse> {
+  const resp = await fetch("/api/status");
+  if (!resp.ok) throw new Error(`status check failed: ${resp.status}`);
+  return resp.json();
+}
+
+export async function fetchChatHistory(): Promise<RecentMessage[]> {
+  const resp = await fetch("/api/chat/history");
+  if (!resp.ok) return [];
+  return resp.json();
+}

--- a/web/src/lib/commands.ts
+++ b/web/src/lib/commands.ts
@@ -1,0 +1,144 @@
+// ── Slash command parser ─────────────────────────────────────────────
+
+import type { ClientMessage, FeedItem, ConnectionStatus } from "./types";
+
+export interface CommandResult {
+  handled: boolean;
+  feedItem?: FeedItem;
+  wsMessage?: ClientMessage;
+}
+
+interface CommandContext {
+  connectionStatus: ConnectionStatus;
+  verbose: boolean;
+  nextId: () => number;
+}
+
+const HELP_TEXT = `Available commands:
+  /help          Show this help message
+  /verbose       Toggle tool call visibility
+  /status        Show connection status
+  /observe       Trigger memory observation
+  /reflect       Trigger memory reflection
+  /context       Show current project context
+  /reload        Reload gateway configuration
+  /inbox <text>  Add a message to the inbox`;
+
+export function parseCommand(
+  input: string,
+  ctx: CommandContext,
+): CommandResult | null {
+  if (!input.startsWith("/")) return null;
+
+  const parts = input.split(/\s+/);
+  const cmd = parts[0].toLowerCase();
+  const args = parts.slice(1).join(" ");
+
+  switch (cmd) {
+    case "/help":
+      return {
+        handled: true,
+        feedItem: {
+          id: ctx.nextId(),
+          kind: "notice",
+          content: HELP_TEXT,
+        },
+      };
+
+    case "/verbose":
+      return {
+        handled: true,
+        feedItem: {
+          id: ctx.nextId(),
+          kind: "notice",
+          content: `verbose mode will be ${ctx.verbose ? "disabled" : "enabled"}`,
+        },
+      };
+
+    case "/status":
+      return {
+        handled: true,
+        feedItem: {
+          id: ctx.nextId(),
+          kind: "notice",
+          content: `connection: ${ctx.connectionStatus}\nverbose: ${ctx.verbose ? "on" : "off"}`,
+        },
+      };
+
+    case "/observe":
+      return {
+        handled: true,
+        wsMessage: { type: "server_command", name: "observe", args: args || null },
+        feedItem: {
+          id: ctx.nextId(),
+          kind: "system",
+          content: "Requesting observation...",
+        },
+      };
+
+    case "/reflect":
+      return {
+        handled: true,
+        wsMessage: { type: "server_command", name: "reflect", args: args || null },
+        feedItem: {
+          id: ctx.nextId(),
+          kind: "system",
+          content: "Requesting reflection...",
+        },
+      };
+
+    case "/context":
+      return {
+        handled: true,
+        wsMessage: { type: "server_command", name: "context", args: args || null },
+        feedItem: {
+          id: ctx.nextId(),
+          kind: "system",
+          content: "Requesting context...",
+        },
+      };
+
+    case "/reload":
+      return {
+        handled: true,
+        wsMessage: { type: "reload" },
+        feedItem: {
+          id: ctx.nextId(),
+          kind: "system",
+          content: "Requesting gateway reload...",
+        },
+      };
+
+    case "/inbox": {
+      if (!args.trim()) {
+        return {
+          handled: true,
+          feedItem: {
+            id: ctx.nextId(),
+            kind: "error",
+            content: "usage: /inbox <message>",
+          },
+        };
+      }
+      return {
+        handled: true,
+        wsMessage: { type: "inbox_add", body: args },
+        feedItem: {
+          id: ctx.nextId(),
+          kind: "notice",
+          content: `Added to inbox: ${args}`,
+        },
+      };
+    }
+
+    default:
+      return {
+        handled: true,
+        feedItem: {
+          id: ctx.nextId(),
+          kind: "error",
+          content: `unknown command: ${cmd} (try /help)`,
+        },
+      };
+  }
+}

--- a/web/src/lib/markdown.ts
+++ b/web/src/lib/markdown.ts
@@ -1,0 +1,94 @@
+// ── Markdown-to-HTML renderer ────────────────────────────────────────
+// Port of Chat.renderMarkdown() from assets/web/chat.js
+
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+export function renderMarkdown(text: string): string {
+  let html = escapeHtml(text);
+
+  // Code blocks: ```lang\n...\n```
+  html = html.replace(/```(\w*)\n([\s\S]*?)```/g, (_m, _lang, code) => {
+    return `<pre><code>${code.trim()}</code></pre>`;
+  });
+
+  // Inline code: `...`
+  html = html.replace(/`([^`]+)`/g, "<code>$1</code>");
+
+  // Bold: **...**
+  html = html.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+
+  // Italic: *...*
+  html = html.replace(
+    /(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g,
+    "<em>$1</em>",
+  );
+
+  // Links: [text](url)
+  html = html.replace(
+    /\[([^\]]+)\]\(([^)]+)\)/g,
+    '<a href="$2" target="_blank" rel="noopener">$1</a>',
+  );
+
+  // Horizontal rules: --- or *** on their own line
+  html = html.replace(/\n(---|\*\*\*)\n/g, "\n<hr>\n");
+
+  // Headings: ## through ####
+  html = html.replace(/^#### (.+)$/gm, "<h4>$1</h4>");
+  html = html.replace(/^### (.+)$/gm, "<h3>$1</h3>");
+  html = html.replace(/^## (.+)$/gm, "<h2>$1</h2>");
+
+  // Blockquotes: > text
+  html = html.replace(/^&gt; (.+)$/gm, "<blockquote>$1</blockquote>");
+  html = html.replace(/<\/blockquote>\n<blockquote>/g, "<br>");
+
+  // Unordered lists: - item
+  html = html.replace(/(^|\n)(- .+(?:\n- .+)*)/g, (_m, pre, block) => {
+    const items = block
+      .split("\n")
+      .map((line: string) => `<li>${line.replace(/^- /, "")}</li>`)
+      .join("");
+    return `${pre}<ul>${items}</ul>`;
+  });
+
+  // Ordered lists: 1. item
+  html = html.replace(
+    /(^|\n)(\d+\. .+(?:\n\d+\. .+)*)/g,
+    (_m, pre, block) => {
+      const items = block
+        .split("\n")
+        .map((line: string) => `<li>${line.replace(/^\d+\. /, "")}</li>`)
+        .join("");
+      return `${pre}<ol>${items}</ol>`;
+    },
+  );
+
+  // Line breaks (outside of pre blocks)
+  html = html.replace(/\n/g, "<br>");
+
+  // Fix line breaks inside pre that got doubled
+  html = html.replace(
+    /<pre><code>([\s\S]*?)<\/code><\/pre>/g,
+    (_m, inner) => {
+      return `<pre><code>${inner.replace(/<br>/g, "\n")}</code></pre>`;
+    },
+  );
+
+  // Clean up line breaks adjacent to block elements
+  html = html.replace(
+    /<br>(<\/?(?:h[234]|blockquote|ul|ol|li|hr|pre)>)/g,
+    "$1",
+  );
+  html = html.replace(
+    /(<\/?(?:h[234]|blockquote|ul|ol|li|hr|pre)>)<br>/g,
+    "$1",
+  );
+
+  return html;
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1,0 +1,124 @@
+// ── Protocol + UI types ──────────────────────────────────────────────
+
+// ── Client -> Server ─────────────────────────────────────────────────
+
+export type ClientMessage =
+  | { type: "send_message"; id: string; content: string }
+  | { type: "set_verbose"; enabled: boolean }
+  | { type: "ping" }
+  | { type: "reload" }
+  | { type: "server_command"; name: string; args: string | null }
+  | { type: "inbox_add"; body: string };
+
+// ── Server -> Client ─────────────────────────────────────────────────
+
+export type ServerMessage =
+  | { type: "turn_started"; reply_to: string }
+  | { type: "tool_call"; id: string; name: string; arguments: unknown }
+  | {
+      type: "tool_result";
+      tool_call_id: string;
+      name: string;
+      output: string;
+      is_error: boolean;
+    }
+  | { type: "response"; reply_to: string; content: string }
+  | { type: "system_event"; source: string; content: string }
+  | { type: "broadcast_response"; content: string }
+  | { type: "error"; reply_to: string | null; message: string }
+  | { type: "pong" }
+  | { type: "reloading" }
+  | { type: "notice"; message: string };
+
+// ── Chat history ─────────────────────────────────────────────────────
+
+export interface ToolCallRecord {
+  id: string;
+  name: string;
+  arguments: string;
+}
+
+export interface RecentMessage {
+  role: "user" | "assistant" | "tool" | "system";
+  content: string;
+  tool_calls?: ToolCallRecord[];
+  tool_call_id?: string;
+  timestamp: string;
+  project_context: string;
+  visibility: "user" | "background";
+}
+
+// ── Status API ───────────────────────────────────────────────────────
+
+export interface StatusResponse {
+  mode: "setup" | "running";
+}
+
+// ── Feed items (UI rendering) ────────────────────────────────────────
+
+export type ConnectionStatus =
+  | "connecting"
+  | "connected"
+  | "disconnected";
+
+export interface ToolCallState {
+  id: string;
+  name: string;
+  arguments: string;
+  status: "running" | "done" | "error";
+  result?: string;
+}
+
+interface FeedItemBase {
+  id: number;
+}
+
+export interface UserFeedItem extends FeedItemBase {
+  kind: "user";
+  content: string;
+}
+
+export interface AssistantFeedItem extends FeedItemBase {
+  kind: "assistant";
+  content: string;
+}
+
+export interface SystemFeedItem extends FeedItemBase {
+  kind: "system";
+  content: string;
+}
+
+export interface ErrorFeedItem extends FeedItemBase {
+  kind: "error";
+  content: string;
+}
+
+export interface NoticeFeedItem extends FeedItemBase {
+  kind: "notice";
+  content: string;
+}
+
+export interface DividerFeedItem extends FeedItemBase {
+  kind: "divider";
+  label: string;
+}
+
+export interface ToolGroupFeedItem extends FeedItemBase {
+  kind: "tool-group";
+  calls: ToolCallState[];
+}
+
+export interface CommandOutputFeedItem extends FeedItemBase {
+  kind: "command-output";
+  content: string;
+}
+
+export type FeedItem =
+  | UserFeedItem
+  | AssistantFeedItem
+  | SystemFeedItem
+  | ErrorFeedItem
+  | NoticeFeedItem
+  | DividerFeedItem
+  | ToolGroupFeedItem
+  | CommandOutputFeedItem;

--- a/web/src/lib/ws.svelte.ts
+++ b/web/src/lib/ws.svelte.ts
@@ -1,0 +1,310 @@
+// ── Reactive WebSocket connection (Svelte 5 runes) ──────────────────
+
+import type {
+  ClientMessage,
+  ServerMessage,
+  RecentMessage,
+  FeedItem,
+  ToolGroupFeedItem,
+  ToolCallState,
+  ConnectionStatus,
+} from "./types";
+
+let feedIdCounter = 0;
+function nextId(): number {
+  return ++feedIdCounter;
+}
+
+class WsConnection {
+  status = $state<ConnectionStatus>("disconnected");
+  feed = $state<FeedItem[]>([]);
+  isProcessing = $state(false);
+  verbose = $state(false);
+
+  private ws: WebSocket | null = null;
+  private msgCounter = 0;
+  private reconnectDelay = 1000;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private pingTimer: ReturnType<typeof setInterval> | null = null;
+  private pendingToolCalls = new Map<string, ToolCallState>();
+
+  constructor() {
+    try {
+      this.verbose = localStorage.getItem("residuum-verbose") === "true";
+    } catch {
+      // localStorage unavailable
+    }
+  }
+
+  connect(): void {
+    const proto = location.protocol === "https:" ? "wss:" : "ws:";
+    const url = `${proto}//${location.host}/ws`;
+
+    this.status = "connecting";
+    this.ws = new WebSocket(url);
+
+    this.ws.onopen = () => {
+      this.status = "connected";
+      this.reconnectDelay = 1000;
+      if (this.verbose) {
+        this.send({ type: "set_verbose", enabled: true });
+      }
+      this.startPing();
+    };
+
+    this.ws.onmessage = (e) => {
+      try {
+        const msg: ServerMessage = JSON.parse(e.data);
+        this.handleMessage(msg);
+      } catch {
+        // ignore unparseable frames
+      }
+    };
+
+    this.ws.onclose = () => {
+      this.status = "disconnected";
+      this.stopPing();
+      this.scheduleReconnect();
+    };
+
+    this.ws.onerror = () => {
+      this.status = "disconnected";
+    };
+  }
+
+  disconnect(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    this.stopPing();
+    if (this.ws) {
+      this.ws.onclose = null;
+      this.ws.close();
+      this.ws = null;
+    }
+    this.status = "disconnected";
+  }
+
+  send(msg: ClientMessage): void {
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify(msg));
+    }
+  }
+
+  sendChat(content: string): void {
+    this.msgCounter++;
+    const id = `web-${this.msgCounter}`;
+    this.send({ type: "send_message", id, content });
+    this.feed.push({ id: nextId(), kind: "user", content });
+    this.isProcessing = true;
+  }
+
+  setVerbose(enabled: boolean): void {
+    this.verbose = enabled;
+    try {
+      localStorage.setItem("residuum-verbose", String(enabled));
+    } catch {
+      // localStorage unavailable
+    }
+    this.send({ type: "set_verbose", enabled });
+  }
+
+  loadHistory(messages: RecentMessage[]): void {
+    if (!messages.length) return;
+
+    const toolCallItems = new Map<string, ToolCallState>();
+
+    for (const msg of messages) {
+      const content = msg.content || "";
+      switch (msg.role) {
+        case "user":
+          this.feed.push({ id: nextId(), kind: "user", content });
+          break;
+        case "assistant": {
+          if (content.trim()) {
+            this.feed.push({ id: nextId(), kind: "assistant", content });
+          }
+          if (msg.tool_calls?.length) {
+            const calls: ToolCallState[] = msg.tool_calls.map((tc) => {
+              const call: ToolCallState = {
+                id: tc.id,
+                name: tc.name,
+                arguments: tc.arguments || "",
+                status: "done",
+              };
+              toolCallItems.set(tc.id, call);
+              return call;
+            });
+            this.feed.push({ id: nextId(), kind: "tool-group", calls });
+          }
+          break;
+        }
+        case "tool": {
+          if (msg.tool_call_id) {
+            const call = toolCallItems.get(msg.tool_call_id);
+            if (call && content) {
+              call.result = (call.result ? call.result + "\n" : "") +
+                "\u2500\u2500\u2500 result \u2500\u2500\u2500\n" + content;
+            }
+            toolCallItems.delete(msg.tool_call_id);
+          }
+          break;
+        }
+        // skip system
+      }
+    }
+
+    this.feed.push({
+      id: nextId(),
+      kind: "divider",
+      label: "\u2014 session resumed \u2014",
+    });
+  }
+
+  appendFeedItem(item: FeedItem): void {
+    this.feed.push(item);
+  }
+
+  // ── Private ──────────────────────────────────────────────────────────
+
+  private handleMessage(msg: ServerMessage): void {
+    switch (msg.type) {
+      case "turn_started":
+        this.isProcessing = true;
+        break;
+
+      case "tool_call":
+        this.handleToolCall(msg);
+        break;
+
+      case "tool_result":
+        this.handleToolResult(msg);
+        break;
+
+      case "response":
+        this.isProcessing = false;
+        if (msg.content) {
+          this.feed.push({
+            id: nextId(),
+            kind: "assistant",
+            content: msg.content,
+          });
+        }
+        break;
+
+      case "broadcast_response":
+        if (msg.content) {
+          this.feed.push({
+            id: nextId(),
+            kind: "assistant",
+            content: msg.content,
+          });
+        }
+        break;
+
+      case "system_event":
+        this.feed.push({
+          id: nextId(),
+          kind: "system",
+          content: `[${msg.source}] ${msg.content}`,
+        });
+        break;
+
+      case "error":
+        this.isProcessing = false;
+        this.feed.push({
+          id: nextId(),
+          kind: "error",
+          content: msg.message,
+        });
+        break;
+
+      case "notice":
+        this.feed.push({
+          id: nextId(),
+          kind: "notice",
+          content: msg.message,
+        });
+        break;
+
+      case "reloading":
+        this.feed.push({
+          id: nextId(),
+          kind: "system",
+          content: "Gateway is reloading...",
+        });
+        break;
+
+      case "pong":
+        break;
+    }
+  }
+
+  private handleToolCall(msg: Extract<ServerMessage, { type: "tool_call" }>): void {
+    const argsText =
+      typeof msg.arguments === "string"
+        ? msg.arguments
+        : JSON.stringify(msg.arguments, null, 2);
+
+    const call: ToolCallState = {
+      id: msg.id,
+      name: msg.name,
+      arguments: argsText,
+      status: "running",
+    };
+
+    this.pendingToolCalls.set(msg.id, call);
+
+    // Find or create a tool group at the end of the feed
+    const last = this.feed[this.feed.length - 1];
+    if (last && last.kind === "tool-group") {
+      last.calls.push(call);
+    } else {
+      this.feed.push({
+        id: nextId(),
+        kind: "tool-group",
+        calls: [call],
+      });
+    }
+  }
+
+  private handleToolResult(
+    msg: Extract<ServerMessage, { type: "tool_result" }>,
+  ): void {
+    const call = this.pendingToolCalls.get(msg.tool_call_id);
+    if (call) {
+      call.status = msg.is_error ? "error" : "done";
+      if (msg.output) {
+        call.result = (call.result ? call.result + "\n" : "") +
+          "\u2500\u2500\u2500 result \u2500\u2500\u2500\n" + msg.output;
+      }
+      this.pendingToolCalls.delete(msg.tool_call_id);
+    }
+  }
+
+  private scheduleReconnect(): void {
+    if (this.reconnectTimer) return;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connect();
+    }, this.reconnectDelay);
+    this.reconnectDelay = Math.min(this.reconnectDelay * 1.5, 15000);
+  }
+
+  private startPing(): void {
+    this.stopPing();
+    this.pingTimer = setInterval(() => {
+      this.send({ type: "ping" });
+    }, 30000);
+  }
+
+  private stopPing(): void {
+    if (this.pingTimer) {
+      clearInterval(this.pingTimer);
+      this.pingTimer = null;
+    }
+  }
+}
+
+export const ws = new WsConnection();

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -1,3 +1,4 @@
+import "./app.css";
 import { mount } from "svelte";
 import App from "./App.svelte";
 


### PR DESCRIPTION
## Summary

- Add TypeScript types matching the gateway WebSocket protocol (ClientMessage, ServerMessage, FeedItem)
- Port the stone+vein CSS theme from the legacy vanilla JS UI to `app.css`
- Create a reactive WebSocket module using Svelte 5 runes (`ws.svelte.ts`) with reconnect, ping, history loading, and verbose toggle
- Port the markdown-to-HTML renderer and implement a slash command parser (`/help`, `/verbose`, `/status`, `/observe`, `/reflect`, `/context`, `/reload`, `/inbox`)
- Build 9 message/tool components and 3 composite components (ChatFeed, ChatInput, Header)
- Wire up Chat.svelte (history -> WS connect -> command dispatch) and App.svelte (status check -> mode routing)

## Test plan

- [x] `npm run build` succeeds without errors
- [x] `cargo build` succeeds (rust-embed picks up new dist/)
- [x] `cargo test --quiet` passes (pre-push hook verified)
- [x] Playwright MCP: header renders with title and connection status badge
- [x] Playwright MCP: textarea and send button are visible (disabled when disconnected)
- [x] Playwright MCP: mobile responsive layout verified at 375px width
- [ ] Full connected-mode testing (send message, receive response, slash commands) requires a configured Residuum instance

Generated with [Claude Code](https://claude.com/claude-code)