### PR TITLE
feat: add update command and curate MCP catalog

### DIFF
--- a/assets/web/mcp-catalog.json
+++ b/assets/web/mcp-catalog.json
@@ -30,16 +30,6 @@
     "install_hint": "Requires Node.js 18+"
   },
   {
-    "name": "filesystem",
-    "description": "Read, write, and manage local files",
-    "command": "npx",
-    "args": ["-y", "@anthropic/mcp-server-filesystem", "/home"],
-    "env": {},
-    "category": "core",
-    "requires_input": [],
-    "install_hint": "Requires Node.js 18+. Edit args to set allowed directories."
-  },
-  {
     "name": "github",
     "description": "GitHub API access (repos, issues, PRs)",
     "command": "npx",
@@ -47,16 +37,6 @@
     "env": {"GITHUB_PERSONAL_ACCESS_TOKEN": ""},
     "category": "dev",
     "requires_input": [{"field": "env.GITHUB_PERSONAL_ACCESS_TOKEN", "label": "GitHub Personal Access Token"}],
-    "install_hint": "Requires Node.js 18+"
-  },
-  {
-    "name": "memory",
-    "description": "Persistent knowledge graph memory",
-    "command": "npx",
-    "args": ["-y", "@anthropic/mcp-server-memory"],
-    "env": {},
-    "category": "core",
-    "requires_input": [],
     "install_hint": "Requires Node.js 18+"
   },
   {
@@ -68,16 +48,6 @@
     "category": "web",
     "requires_input": [],
     "install_hint": "Requires Node.js 18+ and Chrome/Chromium"
-  },
-  {
-    "name": "sequential-thinking",
-    "description": "Step-by-step reasoning and problem decomposition",
-    "command": "npx",
-    "args": ["-y", "@anthropic/mcp-server-sequential-thinking"],
-    "env": {},
-    "category": "core",
-    "requires_input": [],
-    "install_hint": "Requires Node.js 18+"
   },
   {
     "name": "slack",

--- a/build.rs
+++ b/build.rs
@@ -5,4 +5,17 @@ fn main() {
         "web/dist/ not found — run `npm run build` in the web/ directory first"
     );
     println!("cargo:rerun-if-changed=web/dist/");
+
+    // Capture git version for the update command.
+    // Tagged commit: v2026.03.02. Between tags: v2026.03.02-5-gabcdef1. No git: dev.
+    let version = std::process::Command::new("git")
+        .args(["describe", "--tags", "--always"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map_or_else(
+            || "dev".to_string(),
+            |o| String::from_utf8_lossy(&o.stdout).trim().to_string(),
+        );
+    println!("cargo:rustc-env=RESIDUUM_VERSION={version}");
 }

--- a/src/interfaces/cli/mod.rs
+++ b/src/interfaces/cli/mod.rs
@@ -73,7 +73,11 @@ impl CliClient {
 
     /// Print the startup banner to stderr.
     pub fn print_banner(&self) {
-        let banner = format!("residuum v0.1.0 \u{2014} connected to {}", self.url);
+        let banner = format!(
+            "residuum {} \u{2014} connected to {}",
+            env!("RESIDUUM_VERSION"),
+            self.url
+        );
         eprintln!("{}", self.theme.format_banner(&banner));
         let http_url = ws_url_to_http(&self.url);
         eprintln!("  web UI: {http_url}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,7 @@ async fn run() -> Result<(), ResiduumError> {
             run_setup_command(&args)
         }
         Some("stop") => run_stop_command(),
+        Some("update") => run_update_command(&args).await,
         // "serve" or no subcommand → start gateway
         Some("serve") | None => {
             let foreground = args.iter().any(|a| a == "--foreground");
@@ -66,7 +67,7 @@ async fn run() -> Result<(), ResiduumError> {
             }
         }
         Some(other) => Err(ResiduumError::Config(format!(
-            "unknown subcommand '{other}', expected one of: serve, connect, logs, setup, secret, stop"
+            "unknown subcommand '{other}', expected one of: serve, connect, logs, setup, secret, stop, update"
         ))),
     }
 }
@@ -319,6 +320,134 @@ fn run_daemonize(args: &[String]) -> Result<(), ResiduumError> {
 
         std::thread::sleep(poll_interval);
     }
+}
+
+/// Check for and install updates from GitHub Releases.
+///
+/// Fetches the latest release tag, compares it against the build-time
+/// version, and optionally downloads the install script to replace the
+/// current binary.
+///
+/// # Errors
+///
+/// Returns `ResiduumError::Gateway` if the GitHub API request fails or
+/// the install script cannot be executed.
+async fn run_update_command(args: &[String]) -> Result<(), ResiduumError> {
+    let check_only = args.iter().any(|a| a == "--check");
+    let current = env!("RESIDUUM_VERSION");
+
+    eprintln!("residuum: checking for updates...");
+
+    let latest = fetch_latest_version().await?;
+
+    if is_up_to_date(current, &latest) {
+        eprintln!("residuum: already up to date ({current})");
+        return Ok(());
+    }
+
+    eprintln!("residuum: current version: {current}");
+    eprintln!("residuum: latest version:  {latest}");
+
+    if check_only {
+        return Ok(());
+    }
+
+    eprintln!("residuum: downloading and installing {latest}...");
+
+    // Download install script to a temp file and execute it
+    let client = reqwest::Client::new();
+    let script = client
+        .get("https://residuum.bearflinn.com/install")
+        .send()
+        .await
+        .map_err(|e| ResiduumError::Gateway(format!("failed to download install script: {e}")))?
+        .text()
+        .await
+        .map_err(|e| ResiduumError::Gateway(format!("failed to read install script body: {e}")))?;
+
+    let tmp_dir = std::env::temp_dir();
+    let script_path = tmp_dir.join("residuum-install.sh");
+    std::fs::write(&script_path, &script)
+        .map_err(|e| ResiduumError::Gateway(format!("failed to write install script: {e}")))?;
+
+    let status = std::process::Command::new("sh")
+        .arg(&script_path)
+        .status()
+        .map_err(|e| ResiduumError::Gateway(format!("failed to execute install script: {e}")))?;
+
+    // Clean up temp script (best-effort, ignore failure)
+    drop(std::fs::remove_file(&script_path));
+
+    if !status.success() {
+        return Err(ResiduumError::Gateway(format!(
+            "install script exited with {status}"
+        )));
+    }
+
+    eprintln!("residuum: updated to {latest}");
+
+    // Warn if gateway is running
+    if let Ok(pid_path) = residuum::daemon::pid_file_path()
+        && let Ok(pid) = residuum::daemon::read_pid_file(&pid_path)
+        && residuum::daemon::is_process_running(pid)
+    {
+        eprintln!(
+            "residuum: gateway is still running (pid {pid}) — restart it to use the new version"
+        );
+    }
+
+    Ok(())
+}
+
+/// Fetch the latest release tag name from GitHub.
+async fn fetch_latest_version() -> Result<String, ResiduumError> {
+    let client = reqwest::Client::builder()
+        .user_agent("residuum-updater")
+        .build()
+        .map_err(|e| ResiduumError::Gateway(format!("failed to build http client: {e}")))?;
+
+    let resp = client
+        .get("https://api.github.com/repos/grizzly-endeavors/residuum/releases/latest")
+        .header("Accept", "application/vnd.github+json")
+        .send()
+        .await
+        .map_err(|e| ResiduumError::Gateway(format!("failed to fetch latest release: {e}")))?;
+
+    if !resp.status().is_success() {
+        return Err(ResiduumError::Gateway(format!(
+            "github api returned {} — are you online?",
+            resp.status()
+        )));
+    }
+
+    let body: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| ResiduumError::Gateway(format!("failed to parse release response: {e}")))?;
+
+    body.get("tag_name")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .ok_or_else(|| {
+            ResiduumError::Gateway("release response missing tag_name field".to_string())
+        })
+}
+
+/// Compare the current build version against the latest release tag.
+///
+/// Returns `true` if the current version starts with the latest tag,
+/// accounting for `git describe` suffixes like `-5-gabcdef1`.
+fn is_up_to_date(current: &str, latest: &str) -> bool {
+    // Exact match (tagged commit)
+    if current == latest {
+        return true;
+    }
+    // current is "v2026.03.02-5-gabcdef1" and latest is "v2026.03.02" —
+    // the current build is *ahead* of the latest release
+    if current.starts_with(latest) && current.as_bytes().get(latest.len()) == Some(&b'-') {
+        return true;
+    }
+    false
 }
 
 /// Stop a running gateway daemon.
@@ -911,6 +1040,58 @@ mod tests {
         assert!(
             !rollback_config(dir.path()),
             "rollback should fail when no backup exists"
+        );
+    }
+
+    #[test]
+    fn is_up_to_date_exact_match() {
+        assert!(
+            super::is_up_to_date("v2026.03.02", "v2026.03.02"),
+            "exact match should be up to date"
+        );
+    }
+
+    #[test]
+    fn is_up_to_date_ahead_of_release() {
+        assert!(
+            super::is_up_to_date("v2026.03.02-5-gabcdef1", "v2026.03.02"),
+            "build ahead of latest release should be up to date"
+        );
+    }
+
+    #[test]
+    fn is_up_to_date_different_version() {
+        assert!(
+            !super::is_up_to_date("v2026.03.01", "v2026.03.02"),
+            "older version should not be up to date"
+        );
+    }
+
+    #[test]
+    fn is_up_to_date_dev_build() {
+        assert!(
+            !super::is_up_to_date("dev", "v2026.03.02"),
+            "dev build should not be up to date"
+        );
+    }
+
+    #[test]
+    fn is_up_to_date_no_false_prefix_match() {
+        assert!(
+            !super::is_up_to_date("v2026.03.021", "v2026.03.02"),
+            "version with shared prefix but no dash separator should not match"
+        );
+    }
+
+    #[test]
+    fn extract_check_flag() {
+        let args: Vec<String> = vec!["residuum", "update", "--check"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        assert!(
+            args.iter().any(|a| a == "--check"),
+            "--check flag should be detected"
         );
     }
 }


### PR DESCRIPTION
## Summary
- Add `residuum update` command that checks GitHub Releases for new versions and self-updates via the install script
- Embed git version at build time (`build.rs`) and use it in the CLI banner (replaces hardcoded `v0.1.0`)
- Support `--check` flag for version comparison without installing
- Curate MCP catalog: remove filesystem, memory, and sequential-thinking servers that duplicate built-in capabilities (10 → 7 entries)

## Test plan
- [x] `cargo build` — build.rs captures git version
- [x] `cargo test --quiet` — all 1087 tests pass including new version comparison tests
- [ ] `residuum update --check` — prints current and latest versions
- [ ] `residuum update` — downloads and replaces binary via install script
- [ ] `residuum connect` banner shows git tag instead of `v0.1.0`
- [ ] Web UI settings → MCP catalog shows 7 curated entries

Closes #5, closes #25