### PR TITLE
feat: settings panel with provider/MCP/config management

### DIFF
--- a/src/gateway/server/web.rs
+++ b/src/gateway/server/web.rs
@@ -71,6 +71,11 @@ pub(super) fn config_api_router(state: ConfigApiState) -> axum::Router {
         .route("/api/mcp-catalog", get(api_mcp_catalog))
         .route("/api/chat/history", get(api_chat_history))
         .route("/api/providers/models", post(api_provider_models))
+        .route("/api/providers/raw", get(api_providers_raw_get))
+        .route("/api/providers/raw", put(api_providers_raw_put))
+        .route("/api/providers/validate", post(api_providers_validate))
+        .route("/api/mcp/raw", get(api_mcp_raw_get))
+        .route("/api/mcp/raw", put(api_mcp_raw_put))
         .route("/api/secrets", post(api_secrets_set))
         .route("/api/secrets", get(api_secrets_list))
         .route("/api/secrets/{name}", delete(api_secrets_delete))
@@ -171,6 +176,170 @@ async fn api_config_validate(
             error: Some(e),
         }),
     }
+}
+
+// ── Providers raw endpoints ───────────────────────────────────────────
+
+/// `GET /api/providers/raw` — return raw `providers.toml` contents as text.
+async fn api_providers_raw_get(
+    State(state): State<ConfigApiState>,
+) -> Result<Response, (StatusCode, String)> {
+    let providers_path = state.config_dir.join("providers.toml");
+    let contents = tokio::fs::read_to_string(&providers_path)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("failed to read providers.toml: {e}"),
+            )
+        })?;
+    Response::builder()
+        .header(header::CONTENT_TYPE, "text/plain; charset=utf-8")
+        .body(Body::from(contents))
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("response build error: {e}"),
+            )
+        })
+}
+
+/// `PUT /api/providers/raw` — validate and write `providers.toml`, trigger reload.
+async fn api_providers_raw_put(
+    State(state): State<ConfigApiState>,
+    body: String,
+) -> Result<Json<ValidateResponse>, (StatusCode, Json<ValidateResponse>)> {
+    if let Err(e) = Config::validate_providers_toml(&body, &state.config_dir) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ValidateResponse {
+                valid: false,
+                error: Some(e),
+            }),
+        ));
+    }
+
+    let providers_path = state.config_dir.join("providers.toml");
+    tokio::fs::write(&providers_path, &body)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ValidateResponse {
+                    valid: false,
+                    error: Some(format!("failed to write providers.toml: {e}")),
+                }),
+            )
+        })?;
+
+    // Trigger root reload — provider changes affect model resolution
+    if let Some(reload_tx) = &state.reload_tx {
+        reload_tx.send(ReloadSignal::Root).ok();
+    }
+
+    Ok(Json(ValidateResponse {
+        valid: true,
+        error: None,
+    }))
+}
+
+/// `POST /api/providers/validate` — validate providers TOML body without saving.
+async fn api_providers_validate(
+    State(state): State<ConfigApiState>,
+    body: String,
+) -> Json<ValidateResponse> {
+    match Config::validate_providers_toml(&body, &state.config_dir) {
+        Ok(()) => Json(ValidateResponse {
+            valid: true,
+            error: None,
+        }),
+        Err(e) => Json(ValidateResponse {
+            valid: false,
+            error: Some(e),
+        }),
+    }
+}
+
+// ── MCP raw endpoints ────────────────────────────────────────────────
+
+/// `GET /api/mcp/raw` — return raw `mcp.json` contents as JSON.
+///
+/// Returns `{"mcpServers":{}}` if the file doesn't exist yet.
+async fn api_mcp_raw_get(
+    State(state): State<ConfigApiState>,
+) -> Result<Response, (StatusCode, String)> {
+    let mcp_path = state
+        .config_dir
+        .join("workspace")
+        .join("config")
+        .join("mcp.json");
+
+    let contents = match tokio::fs::read_to_string(&mcp_path).await {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => r#"{"mcpServers":{}}"#.to_string(),
+        Err(e) => {
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("failed to read mcp.json: {e}"),
+            ));
+        }
+    };
+
+    Response::builder()
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(contents))
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("response build error: {e}"),
+            )
+        })
+}
+
+/// `PUT /api/mcp/raw` — validate JSON and write `mcp.json`, trigger workspace reload.
+async fn api_mcp_raw_put(
+    State(state): State<ConfigApiState>,
+    body: String,
+) -> Result<Json<ValidateResponse>, (StatusCode, Json<ValidateResponse>)> {
+    // Validate JSON parse
+    serde_json::from_str::<serde_json::Value>(&body).map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ValidateResponse {
+                valid: false,
+                error: Some(format!("invalid JSON: {e}")),
+            }),
+        )
+    })?;
+
+    let mcp_path = state
+        .config_dir
+        .join("workspace")
+        .join("config")
+        .join("mcp.json");
+
+    if let Some(parent) = mcp_path.parent() {
+        tokio::fs::create_dir_all(parent).await.ok();
+    }
+
+    tokio::fs::write(&mcp_path, &body).await.map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ValidateResponse {
+                valid: false,
+                error: Some(format!("failed to write mcp.json: {e}")),
+            }),
+        )
+    })?;
+
+    if let Some(reload_tx) = &state.reload_tx {
+        reload_tx.send(ReloadSignal::Workspace).ok();
+    }
+
+    Ok(Json(ValidateResponse {
+        valid: true,
+        error: None,
+    }))
 }
 
 /// Request body for the complete-setup endpoint.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "residuum-web",
       "version": "0.0.1",
+      "dependencies": {
+        "smol-toml": "^1.6.0"
+      },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^5.0.0",
         "svelte": "^5.0.0",
@@ -1245,6 +1248,18 @@
         "@rollup/rollup-win32-x64-gnu": "4.59.0",
         "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz",
+      "integrity": "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
       }
     },
     "node_modules/source-map-js": {

--- a/web/package.json
+++ b/web/package.json
@@ -13,5 +13,8 @@
     "svelte": "^5.0.0",
     "typescript": "^5.0.0",
     "vite": "^6.0.0"
+  },
+  "dependencies": {
+    "smol-toml": "^1.6.0"
   }
 }

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -5,8 +5,10 @@
   import Header from "./components/Header.svelte";
   import Chat from "./Chat.svelte";
   import Setup from "./Setup.svelte";
+  import Settings from "./Settings.svelte";
 
   let mode = $state<"loading" | "setup" | "running">("loading");
+  let showSettings = $state(false);
 
   onMount(async () => {
     try {
@@ -20,6 +22,10 @@
 
   function handleToggleVerbose() {
     ws.setVerbose(!ws.verbose);
+  }
+
+  function handleToggleSettings() {
+    showSettings = !showSettings;
   }
 </script>
 
@@ -43,7 +49,13 @@
   <Header
     status={ws.status}
     verbose={ws.verbose}
+    {showSettings}
     onToggleVerbose={handleToggleVerbose}
+    onToggleSettings={handleToggleSettings}
   />
-  <Chat />
+  {#if showSettings}
+    <Settings onClose={() => { showSettings = false; }} />
+  {:else}
+    <Chat />
+  {/if}
 {/if}

--- a/web/src/Settings.svelte
+++ b/web/src/Settings.svelte
@@ -1,0 +1,379 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import type { SettingsSection, McpServerEntry, SettingsProviderEntry, SettingsModelAssignments } from "./lib/types";
+  import {
+    fetchConfigRaw,
+    fetchProvidersRaw,
+    fetchMcpRaw,
+    putConfigRaw,
+    putProvidersRaw,
+    putMcpRaw,
+    validateConfig,
+    validateProviders,
+    storeSecret,
+    listSecrets,
+  } from "./lib/api";
+  import {
+    parseConfigToml,
+    parseProvidersToml,
+    parseMcpJson,
+    serializeConfigToml,
+    serializeProvidersToml,
+    serializeMcpJson,
+    defaultConfigFields,
+    defaultModels,
+    type ConfigFields,
+  } from "./lib/settings-toml";
+  import Runtime from "./components/settings/Runtime.svelte";
+  import Providers from "./components/settings/Providers.svelte";
+  import Memory from "./components/settings/Memory.svelte";
+  import Integrations from "./components/settings/Integrations.svelte";
+  import MCP from "./components/settings/MCP.svelte";
+
+  let { onClose }: { onClose: () => void } = $props();
+
+  // ── State ──────────────────────────────────────────────────────────
+
+  let activeSection = $state<SettingsSection>("runtime");
+  let advancedMode = $state(false);
+  let loading = $state(true);
+  let saving = $state(false);
+  let validationMsg = $state("");
+  let validationKind = $state<"error" | "success" | "">("");
+
+  // Raw text (source of truth from last save/load)
+  let rawConfig = $state("");
+  let rawProviders = $state("");
+  let rawMcp = $state("");
+
+  // Advanced mode editing buffers
+  let editConfig = $state("");
+  let editProviders = $state("");
+  let editMcp = $state("");
+  let advancedTab = $state<"config" | "providers" | "mcp">("config");
+
+  // Form state
+  let configFields = $state<ConfigFields>(defaultConfigFields());
+  let providerEntries = $state<SettingsProviderEntry[]>([]);
+  let modelAssignments = $state<SettingsModelAssignments>(defaultModels());
+  let mcpServers = $state<McpServerEntry[]>([]);
+
+  // Secrets tracking
+  let existingSecrets = $state<string[]>([]);
+
+  // ── Sidebar ────────────────────────────────────────────────────────
+
+  const sections: { id: SettingsSection; label: string }[] = [
+    { id: "runtime", label: "Runtime" },
+    { id: "providers", label: "Providers" },
+    { id: "memory", label: "Memory" },
+    { id: "integrations", label: "Integrations" },
+    { id: "mcp", label: "MCP" },
+  ];
+
+  // ── Load ───────────────────────────────────────────────────────────
+
+  onMount(async () => {
+    try {
+      const [cfgRaw, provRaw, mcpRaw, secrets] = await Promise.all([
+        fetchConfigRaw(),
+        fetchProvidersRaw(),
+        fetchMcpRaw(),
+        listSecrets(),
+      ]);
+      rawConfig = cfgRaw;
+      rawProviders = provRaw;
+      rawMcp = mcpRaw;
+      existingSecrets = secrets;
+
+      parseAllToForm();
+    } catch (err) {
+      validationMsg = `Failed to load settings: ${err}`;
+      validationKind = "error";
+    } finally {
+      loading = false;
+    }
+  });
+
+  function parseAllToForm() {
+    configFields = parseConfigToml(rawConfig);
+    const prov = parseProvidersToml(rawProviders);
+    providerEntries = prov.providers;
+    modelAssignments = prov.models;
+    mcpServers = parseMcpJson(rawMcp);
+  }
+
+  // ── Mode toggle ────────────────────────────────────────────────────
+
+  function toggleMode() {
+    validationMsg = "";
+    validationKind = "";
+    if (advancedMode) {
+      // Switching to form mode — reload from saved raw state
+      parseAllToForm();
+      advancedMode = false;
+    } else {
+      // Switching to advanced — load raw text into editors
+      editConfig = rawConfig;
+      editProviders = rawProviders;
+      editMcp = rawMcp;
+      advancedMode = true;
+    }
+  }
+
+  // ── Reload ─────────────────────────────────────────────────────────
+
+  async function handleReload() {
+    loading = true;
+    validationMsg = "";
+    validationKind = "";
+    try {
+      const [cfgRaw, provRaw, mcpRaw] = await Promise.all([
+        fetchConfigRaw(),
+        fetchProvidersRaw(),
+        fetchMcpRaw(),
+      ]);
+      rawConfig = cfgRaw;
+      rawProviders = provRaw;
+      rawMcp = mcpRaw;
+
+      if (advancedMode) {
+        editConfig = rawConfig;
+        editProviders = rawProviders;
+        editMcp = rawMcp;
+      } else {
+        parseAllToForm();
+      }
+      validationMsg = "Reloaded from disk.";
+      validationKind = "success";
+    } catch (err) {
+      validationMsg = `Reload failed: ${err}`;
+      validationKind = "error";
+    } finally {
+      loading = false;
+    }
+  }
+
+  // ── Validate ───────────────────────────────────────────────────────
+
+  async function handleValidate() {
+    validationMsg = "";
+    validationKind = "";
+    saving = true;
+
+    try {
+      let cfgToml: string;
+      let provToml: string;
+
+      if (advancedMode) {
+        cfgToml = editConfig;
+        provToml = editProviders;
+      } else {
+        cfgToml = serializeConfigToml(configFields);
+        provToml = serializeProvidersToml(providerEntries, modelAssignments);
+      }
+
+      // Validate providers first (config validation reads it from disk)
+      const provResult = await validateProviders(provToml);
+      if (!provResult.valid) {
+        validationMsg = `providers.toml: ${provResult.error}`;
+        validationKind = "error";
+        return;
+      }
+
+      const cfgResult = await validateConfig(cfgToml);
+      if (!cfgResult.valid) {
+        validationMsg = `config.toml: ${cfgResult.error}`;
+        validationKind = "error";
+        return;
+      }
+
+      validationMsg = "Configuration is valid.";
+      validationKind = "success";
+    } catch (err) {
+      validationMsg = `Validation error: ${err}`;
+      validationKind = "error";
+    } finally {
+      saving = false;
+    }
+  }
+
+  // ── Save ───────────────────────────────────────────────────────────
+
+  async function handleSave() {
+    validationMsg = "";
+    validationKind = "";
+    saving = true;
+
+    try {
+      let cfgToml: string;
+      let provToml: string;
+      let mcpJson: string;
+
+      if (advancedMode) {
+        cfgToml = editConfig;
+        provToml = editProviders;
+        mcpJson = editMcp;
+      } else {
+        // Store new secrets before serializing
+        await storeNewSecrets();
+        cfgToml = serializeConfigToml(configFields);
+        provToml = serializeProvidersToml(providerEntries, modelAssignments);
+        mcpJson = serializeMcpJson(mcpServers);
+      }
+
+      // Save providers.toml first (config validation reads it from disk)
+      const provResult = await putProvidersRaw(provToml);
+      if (!provResult.valid) {
+        validationMsg = `providers.toml: ${provResult.error}`;
+        validationKind = "error";
+        return;
+      }
+
+      const cfgResult = await putConfigRaw(cfgToml);
+      if (!cfgResult.valid) {
+        validationMsg = `config.toml: ${cfgResult.error}`;
+        validationKind = "error";
+        return;
+      }
+
+      const mcpResult = await putMcpRaw(mcpJson);
+      if (!mcpResult.valid) {
+        validationMsg = `mcp.json: ${mcpResult.error}`;
+        validationKind = "error";
+        return;
+      }
+
+      // Update raw state to match what was saved
+      rawConfig = cfgToml;
+      rawProviders = provToml;
+      rawMcp = mcpJson;
+
+      validationMsg = "Settings saved and applied.";
+      validationKind = "success";
+    } catch (err) {
+      validationMsg = `Save failed: ${err}`;
+      validationKind = "error";
+    } finally {
+      saving = false;
+    }
+  }
+
+  // ── Secret management ──────────────────────────────────────────────
+
+  async function storeNewSecrets() {
+    // Collect secrets that need storing (non-empty, non-secret: values)
+    const secretOps: { field: "discord_token" | "telegram_token" | "webhook_secret"; name: string }[] = [];
+
+    const secretFields = [
+      { field: "discord_token" as const, name: "discord" },
+      { field: "telegram_token" as const, name: "telegram" },
+      { field: "webhook_secret" as const, name: "webhook_secret" },
+    ];
+
+    for (const { field, name } of secretFields) {
+      const val = configFields[field];
+      if (val && !val.startsWith("secret:")) {
+        secretOps.push({ field, name });
+      }
+    }
+
+    // Store provider API keys
+    const provKeyOps: { idx: number; name: string }[] = [];
+    for (let i = 0; i < providerEntries.length; i++) {
+      const p = providerEntries[i];
+      if (p.apiKey && !p.apiKey.startsWith("secret:") && p.type !== "ollama") {
+        provKeyOps.push({ idx: i, name: p.name });
+      }
+    }
+
+    // Execute all secret stores
+    for (const { field, name } of secretOps) {
+      const result = await storeSecret(name, configFields[field]);
+      configFields[field] = result.reference;
+    }
+
+    for (const { idx, name } of provKeyOps) {
+      const result = await storeSecret(name, providerEntries[idx].apiKey);
+      providerEntries[idx].apiKey = result.reference;
+    }
+  }
+</script>
+
+<div class="settings-view">
+  <div class="settings-header">
+    <span class="settings-title">Settings</span>
+    <div class="settings-header-actions">
+      <button
+        class="btn btn-sm"
+        class:btn-primary={advancedMode}
+        class:btn-secondary={!advancedMode}
+        onclick={toggleMode}
+      >
+        {advancedMode ? "Form Mode" : "Advanced"}
+      </button>
+      <button class="icon-btn" title="Close settings" onclick={onClose}>&#10005;</button>
+    </div>
+  </div>
+
+  <div class="settings-body">
+    {#if !advancedMode}
+      <div class="settings-sidebar">
+        {#each sections as sec}
+          <button
+            class="settings-sidebar-btn"
+            class:active={activeSection === sec.id}
+            onclick={() => { activeSection = sec.id; }}
+          >
+            {sec.label}
+          </button>
+        {/each}
+      </div>
+    {/if}
+
+    <div class="settings-content">
+      {#if loading}
+        <p style="color:var(--text-dim); padding:20px;">Loading settings...</p>
+      {:else if advancedMode}
+        <!-- Advanced tabbed editor -->
+        <div class="advanced-tabs">
+          <button class="advanced-tab" class:active={advancedTab === "config"} onclick={() => { advancedTab = "config"; }}>config.toml</button>
+          <button class="advanced-tab" class:active={advancedTab === "providers"} onclick={() => { advancedTab = "providers"; }}>providers.toml</button>
+          <button class="advanced-tab" class:active={advancedTab === "mcp"} onclick={() => { advancedTab = "mcp"; }}>mcp.json</button>
+        </div>
+        {#if advancedTab === "config"}
+          <textarea class="toml-editor" bind:value={editConfig}></textarea>
+        {:else if advancedTab === "providers"}
+          <textarea class="toml-editor" bind:value={editProviders}></textarea>
+        {:else}
+          <textarea class="toml-editor" bind:value={editMcp}></textarea>
+        {/if}
+      {:else if activeSection === "runtime"}
+        <Runtime bind:fields={configFields} />
+      {:else if activeSection === "providers"}
+        <Providers bind:providers={providerEntries} bind:models={modelAssignments} />
+      {:else if activeSection === "memory"}
+        <Memory bind:fields={configFields} />
+      {:else if activeSection === "integrations"}
+        <Integrations bind:fields={configFields} />
+      {:else if activeSection === "mcp"}
+        <MCP bind:servers={mcpServers} />
+      {/if}
+    </div>
+  </div>
+
+  <div class="settings-footer">
+    <div class="settings-footer-left">
+      <button class="btn btn-secondary" onclick={handleReload} disabled={saving}>Reload</button>
+      <button class="btn btn-secondary" onclick={handleValidate} disabled={saving}>Validate</button>
+    </div>
+    <div class="settings-footer-right">
+      {#if validationMsg}
+        <span class="validation-msg {validationKind}">{validationMsg}</span>
+      {/if}
+      <button class="btn btn-primary" onclick={handleSave} disabled={saving}>
+        {saving ? "Saving..." : "Save"}
+      </button>
+    </div>
+  </div>
+</div>

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -1181,6 +1181,326 @@ body::before {
     margin-top: 8px;
 }
 
+/* ── Settings view ────────────────────────────────────────────────────── */
+
+.settings-view {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    overflow: hidden;
+}
+
+.settings-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 20px;
+    border-bottom: 1px solid var(--border-subtle);
+    background: var(--bg-surface);
+    flex-shrink: 0;
+}
+
+.settings-title {
+    font-family: var(--font-display);
+    font-size: 16px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+}
+
+.settings-header-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.settings-body {
+    display: flex;
+    flex: 1;
+    overflow: hidden;
+}
+
+.settings-sidebar {
+    width: 160px;
+    flex-shrink: 0;
+    border-right: 1px solid var(--border-subtle);
+    background: var(--bg-surface);
+    padding: 12px 0;
+    overflow-y: auto;
+}
+
+.settings-sidebar-btn {
+    display: block;
+    width: 100%;
+    padding: 8px 20px;
+    font-family: var(--font-body);
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text-muted);
+    background: transparent;
+    border: none;
+    text-align: left;
+    cursor: pointer;
+    transition: all 0.15s;
+    border-left: 3px solid transparent;
+}
+
+.settings-sidebar-btn:hover {
+    color: var(--text);
+    background: var(--bg-raised);
+}
+
+.settings-sidebar-btn.active {
+    color: var(--ember);
+    border-left-color: var(--ember);
+    background: var(--ember-glow);
+}
+
+.settings-content {
+    flex: 1;
+    overflow-y: auto;
+    padding: 20px 24px;
+}
+
+.settings-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 20px;
+    border-top: 1px solid var(--border-subtle);
+    background: var(--bg-surface);
+    flex-shrink: 0;
+    gap: 12px;
+}
+
+.settings-footer-left {
+    display: flex;
+    gap: 8px;
+}
+
+.settings-footer-right {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.settings-footer .validation-msg {
+    margin-top: 0;
+    white-space: nowrap;
+    max-width: 400px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* ── Settings sections & groups ──────────────────────────────────────── */
+
+.settings-section {
+    max-width: 640px;
+}
+
+.settings-group {
+    margin-bottom: 24px;
+}
+
+.settings-group-label {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--ember);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 12px;
+    padding-bottom: 6px;
+    border-bottom: 1px solid var(--border-subtle);
+}
+
+/* ── Advanced mode tabs ──────────────────────────────────────────────── */
+
+.advanced-tabs {
+    display: flex;
+    gap: 0;
+    margin-bottom: 12px;
+    border-bottom: 1px solid var(--border);
+}
+
+.advanced-tab {
+    padding: 8px 16px;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text-muted);
+    background: transparent;
+    border: none;
+    border-bottom: 2px solid transparent;
+    cursor: pointer;
+    transition: all 0.15s;
+}
+
+.advanced-tab:hover {
+    color: var(--text);
+}
+
+.advanced-tab.active {
+    color: var(--ember);
+    border-bottom-color: var(--ember);
+}
+
+/* ── Provider entry ──────────────────────────────────────────────────── */
+
+.provider-entry {
+    padding: 14px;
+    background: var(--bg-deep);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-sm);
+    margin-bottom: 10px;
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+}
+
+.provider-entry-fields {
+    flex: 1;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+}
+
+.provider-entry-fields .settings-field {
+    margin-bottom: 0;
+}
+
+/* ── Secret stored badge ─────────────────────────────────────────────── */
+
+.secret-stored {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.secret-badge {
+    font-size: 12px;
+    color: var(--success);
+    padding: 4px 10px;
+    background: rgba(46, 204, 113, 0.08);
+    border: 1px solid rgba(46, 204, 113, 0.2);
+    border-radius: var(--radius-sm);
+}
+
+/* ── MCP server entry ────────────────────────────────────────────────── */
+
+.mcp-server-entry {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 14px;
+    background: var(--bg-deep);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-sm);
+    margin-bottom: 6px;
+}
+
+.mcp-server-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.mcp-server-name {
+    font-weight: 600;
+    font-size: 13px;
+}
+
+.mcp-server-cmd {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--text-dim);
+}
+
+.mcp-add-form {
+    padding: 14px;
+    background: var(--bg-deep);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-sm);
+    margin-top: 8px;
+}
+
+/* ── Toggle switch ───────────────────────────────────────────────────── */
+
+.toggle-switch {
+    position: relative;
+    display: inline-block;
+    width: 32px;
+    height: 18px;
+    flex-shrink: 0;
+}
+
+.toggle-switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+    position: absolute;
+}
+
+.toggle-slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: var(--border);
+    border-radius: 9px;
+    transition: background 0.2s;
+}
+
+.toggle-slider::before {
+    content: '';
+    position: absolute;
+    width: 14px;
+    height: 14px;
+    left: 2px;
+    bottom: 2px;
+    background: var(--text-muted);
+    border-radius: 50%;
+    transition: transform 0.2s, background 0.2s;
+}
+
+.toggle-switch input:checked + .toggle-slider {
+    background: var(--ember-dim);
+}
+
+.toggle-switch input:checked + .toggle-slider::before {
+    transform: translateX(14px);
+    background: var(--ember-bright);
+}
+
+/* ── Skills dir entries ──────────────────────────────────────────────── */
+
+.skill-dir-entry {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 6px 10px;
+    background: var(--bg-deep);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-sm);
+    margin-bottom: 4px;
+}
+
+.skill-dir-path {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--text);
+}
+
+.skill-dir-add {
+    display: flex;
+    gap: 8px;
+    margin-top: 8px;
+}
+
+.skill-dir-add input {
+    flex: 1;
+}
+
 /* ── Responsive ────────────────────────────────────────────────────────── */
 
 @media (max-width: 600px) {
@@ -1190,4 +1510,8 @@ body::before {
     .msg-user { max-width: 90%; }
     .setup-card { padding: 20px; }
     .role-row-fields { grid-template-columns: 1fr; }
+    .settings-sidebar { width: 120px; }
+    .settings-content { padding: 16px; }
+    .provider-entry-fields { grid-template-columns: 1fr; }
+    .settings-footer { flex-direction: column; gap: 8px; }
 }

--- a/web/src/components/Header.svelte
+++ b/web/src/components/Header.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
   import type { ConnectionStatus } from "../lib/types";
 
-  let { status, verbose, onToggleVerbose }: {
+  let { status, verbose, showSettings, onToggleVerbose, onToggleSettings }: {
     status: ConnectionStatus;
     verbose: boolean;
+    showSettings: boolean;
     onToggleVerbose: () => void;
+    onToggleSettings: () => void;
   } = $props();
 </script>
 
@@ -22,6 +24,14 @@
       onclick={onToggleVerbose}
     >
       &#128295;
+    </button>
+    <button
+      class="icon-btn"
+      class:active={showSettings}
+      title="Settings"
+      onclick={onToggleSettings}
+    >
+      &#9881;
     </button>
   </div>
 </div>

--- a/web/src/components/settings/Integrations.svelte
+++ b/web/src/components/settings/Integrations.svelte
@@ -1,0 +1,113 @@
+<script lang="ts">
+  import type { ConfigFields } from "../../lib/settings-toml";
+
+  let { fields = $bindable() }: { fields: ConfigFields } = $props();
+
+  let newSkillDir = $state("");
+
+  function addSkillDir() {
+    const dir = newSkillDir.trim();
+    if (dir && !fields.skills_dirs.includes(dir)) {
+      fields.skills_dirs = [...fields.skills_dirs, dir];
+      newSkillDir = "";
+    }
+  }
+
+  function removeSkillDir(idx: number) {
+    fields.skills_dirs = fields.skills_dirs.filter((_, i) => i !== idx);
+  }
+</script>
+
+<div class="settings-section">
+  <div class="settings-group">
+    <div class="settings-group-label">Discord</div>
+    <div class="integration-card">
+      <div class="integration-desc">
+        Connect a Discord bot so your agent can communicate via DMs.
+        Create a bot at <a href="https://discord.com/developers/applications" target="_blank" rel="noopener">discord.com/developers</a>.
+      </div>
+      <div class="settings-field">
+        <label>Bot Token</label>
+        {#if fields.discord_token.startsWith("secret:")}
+          <div class="secret-stored">
+            <span class="secret-badge">Stored securely</span>
+            <button class="btn btn-sm btn-secondary" onclick={() => { fields.discord_token = ""; }}>Change</button>
+          </div>
+        {:else}
+          <input type="password" bind:value={fields.discord_token} placeholder="Discord bot token" />
+        {/if}
+      </div>
+    </div>
+  </div>
+
+  <div class="settings-group">
+    <div class="settings-group-label">Telegram</div>
+    <div class="integration-card">
+      <div class="integration-desc">
+        Connect a Telegram bot for DM-based interaction.
+        Create a bot via <a href="https://t.me/BotFather" target="_blank" rel="noopener">@BotFather</a>.
+      </div>
+      <div class="settings-field">
+        <label>Bot Token</label>
+        {#if fields.telegram_token.startsWith("secret:")}
+          <div class="secret-stored">
+            <span class="secret-badge">Stored securely</span>
+            <button class="btn btn-sm btn-secondary" onclick={() => { fields.telegram_token = ""; }}>Change</button>
+          </div>
+        {:else}
+          <input type="password" bind:value={fields.telegram_token} placeholder="Telegram bot token" />
+        {/if}
+      </div>
+    </div>
+  </div>
+
+  <div class="settings-group">
+    <div class="settings-group-label">Webhook</div>
+    <div class="integration-card">
+      <div class="integration-desc">
+        Enable an HTTP webhook endpoint for external integrations.
+      </div>
+      <div class="settings-field">
+        <label>
+          <span class="toggle-switch">
+            <input type="checkbox" bind:checked={fields.webhook_enabled} />
+            <span class="toggle-slider"></span>
+          </span>
+          Webhook Enabled
+        </label>
+      </div>
+      {#if fields.webhook_enabled}
+        <div class="settings-field">
+          <label>Secret</label>
+          {#if fields.webhook_secret.startsWith("secret:")}
+            <div class="secret-stored">
+              <span class="secret-badge">Stored securely</span>
+              <button class="btn btn-sm btn-secondary" onclick={() => { fields.webhook_secret = ""; }}>Change</button>
+            </div>
+          {:else}
+            <input type="password" bind:value={fields.webhook_secret} placeholder="Bearer token for authentication (optional)" />
+          {/if}
+        </div>
+      {/if}
+    </div>
+  </div>
+
+  <div class="settings-group">
+    <div class="settings-group-label">Skills</div>
+    <div class="integration-card">
+      <div class="integration-desc">
+        Directories to scan for custom skills.
+      </div>
+      {#each fields.skills_dirs as dir, i}
+        <div class="skill-dir-entry">
+          <span class="skill-dir-path">{dir}</span>
+          <button class="btn btn-sm btn-danger" onclick={() => removeSkillDir(i)}>Remove</button>
+        </div>
+      {/each}
+      <div class="skill-dir-add">
+        <input type="text" bind:value={newSkillDir} placeholder="Path to skills directory" onkeydown={(e) => { if (e.key === "Enter") addSkillDir(); }} />
+        <button class="btn btn-sm btn-secondary" onclick={addSkillDir}>Add</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/web/src/components/settings/MCP.svelte
+++ b/web/src/components/settings/MCP.svelte
@@ -1,0 +1,216 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import type { McpServerEntry, McpCatalogEntry } from "../../lib/types";
+  import { fetchMcpCatalog } from "../../lib/api";
+
+  let { servers = $bindable() }: { servers: McpServerEntry[] } = $props();
+
+  let catalog = $state<McpCatalogEntry[]>([]);
+  let pendingIdx = $state<number | null>(null);
+  let pendingInputs = $state<Record<string, string>>({});
+  let inputErrors = $state<Record<string, boolean>>({});
+
+  // Manual add form
+  let showAddForm = $state(false);
+  let newServer = $state<McpServerEntry>({ name: "", command: "", args: [], env: {} });
+  let newArgsStr = $state("");
+  let newEnvStr = $state("");
+
+  onMount(async () => {
+    catalog = await fetchMcpCatalog();
+  });
+
+  function removeServer(idx: number) {
+    servers.splice(idx, 1);
+    servers = servers;
+  }
+
+  // ── Catalog handling ─────────────────────────────────────────────────
+
+  function isAdded(name: string): boolean {
+    return servers.some((s) => s.name === name);
+  }
+
+  function handleCatalogAdd(idx: number) {
+    const srv = catalog[idx];
+    if (!srv) return;
+
+    if (isAdded(srv.name)) {
+      const existsIdx = servers.findIndex((s) => s.name === srv.name);
+      if (existsIdx >= 0) servers.splice(existsIdx, 1);
+      servers = servers;
+      pendingIdx = null;
+      return;
+    }
+
+    if (srv.requires_input && srv.requires_input.length > 0) {
+      pendingIdx = idx;
+      pendingInputs = {};
+      inputErrors = {};
+    } else {
+      servers.push({
+        name: srv.name,
+        command: srv.command,
+        args: [...(srv.args || [])],
+        env: { ...(srv.env || {}) },
+      });
+      servers = servers;
+    }
+  }
+
+  function handleConfirm(idx: number) {
+    const srv = catalog[idx];
+    if (!srv) return;
+
+    let hasError = false;
+    for (const req of srv.requires_input) {
+      const val = (pendingInputs[req.field] || "").trim();
+      if (!val) {
+        inputErrors[req.field] = true;
+        hasError = true;
+      }
+    }
+    if (hasError) return;
+
+    const env = { ...(srv.env || {}) };
+    for (const req of srv.requires_input) {
+      const key = req.field.startsWith("env.") ? req.field.slice(4) : req.field;
+      env[key] = pendingInputs[req.field].trim();
+    }
+
+    servers.push({
+      name: srv.name,
+      command: srv.command,
+      args: [...(srv.args || [])],
+      env: env as Record<string, string>,
+    });
+    servers = servers;
+    pendingIdx = null;
+  }
+
+  function handleCancel() {
+    pendingIdx = null;
+  }
+
+  // ── Manual add ─────────────────────────────────────────────────────
+
+  function handleManualAdd() {
+    if (!newServer.name.trim() || !newServer.command.trim()) return;
+    const args = newArgsStr.trim() ? newArgsStr.trim().split(/\s+/) : [];
+    const env: Record<string, string> = {};
+    if (newEnvStr.trim()) {
+      for (const line of newEnvStr.trim().split("\n")) {
+        const eq = line.indexOf("=");
+        if (eq > 0) {
+          env[line.slice(0, eq).trim()] = line.slice(eq + 1).trim();
+        }
+      }
+    }
+    servers.push({
+      name: newServer.name.trim(),
+      command: newServer.command.trim(),
+      args,
+      env,
+    });
+    servers = servers;
+    newServer = { name: "", command: "", args: [], env: {} };
+    newArgsStr = "";
+    newEnvStr = "";
+    showAddForm = false;
+  }
+</script>
+
+<div class="settings-section">
+  <div class="settings-group">
+    <div class="settings-group-label">Configured Servers</div>
+
+    {#if servers.length === 0}
+      <p style="color:var(--text-dim); font-size:13px;">No MCP servers configured.</p>
+    {/if}
+
+    {#each servers as srv, i}
+      <div class="mcp-server-entry">
+        <div class="mcp-server-info">
+          <span class="mcp-server-name">{srv.name}</span>
+          <span class="mcp-server-cmd">{srv.command} {srv.args.join(" ")}</span>
+        </div>
+        <button class="btn btn-sm btn-danger" onclick={() => removeServer(i)}>Remove</button>
+      </div>
+    {/each}
+
+    {#if showAddForm}
+      <div class="mcp-add-form">
+        <div class="settings-field">
+          <label>Name</label>
+          <input type="text" bind:value={newServer.name} placeholder="Server name" />
+        </div>
+        <div class="settings-field">
+          <label>Command</label>
+          <input type="text" bind:value={newServer.command} placeholder="e.g. npx, uvx" />
+        </div>
+        <div class="settings-field">
+          <label>Arguments (space-separated)</label>
+          <input type="text" bind:value={newArgsStr} placeholder="e.g. -y @org/server" />
+        </div>
+        <div class="settings-field">
+          <label>Environment (KEY=value, one per line)</label>
+          <textarea class="toml-editor" style="min-height:60px;" bind:value={newEnvStr} placeholder="API_KEY=abc123"></textarea>
+        </div>
+        <div class="mcp-inline-actions">
+          <button class="btn btn-primary btn-sm" onclick={handleManualAdd}>Add</button>
+          <button class="btn btn-secondary btn-sm" onclick={() => { showAddForm = false; }}>Cancel</button>
+        </div>
+      </div>
+    {:else}
+      <button class="btn btn-secondary btn-sm" style="margin-top:8px;" onclick={() => { showAddForm = true; }}>+ Add Server</button>
+    {/if}
+  </div>
+
+  <!-- Catalog Browser -->
+  <div class="settings-group">
+    <div class="settings-group-label">Catalog</div>
+    <p class="roles-section-hint">Browse available MCP servers. Click to add or remove.</p>
+
+    {#if catalog.length === 0}
+      <p style="color:var(--text-dim); font-size:13px;">Loading catalog...</p>
+    {:else}
+      {#each catalog as srv, i}
+        {@const added = isAdded(srv.name)}
+        {@const isPending = pendingIdx === i}
+        <div class="mcp-item" class:added class:pending={isPending}>
+          <div class="mcp-info">
+            <div class="mcp-name">{srv.name}</div>
+            <div class="mcp-desc">{srv.description}</div>
+          </div>
+
+          {#if !isPending}
+            <button class="mcp-add-btn" onclick={() => handleCatalogAdd(i)}>
+              {added ? "Added" : "Add"}
+            </button>
+          {/if}
+
+          {#if isPending && srv.requires_input.length > 0}
+            <div class="mcp-inline-inputs">
+              {#each srv.requires_input as req}
+                <div class="settings-field mcp-input-field">
+                  <label>{req.label}</label>
+                  <input
+                    type="text"
+                    class:input-error={inputErrors[req.field]}
+                    bind:value={pendingInputs[req.field]}
+                    placeholder={req.label}
+                    oninput={() => { inputErrors[req.field] = false; }}
+                  />
+                </div>
+              {/each}
+              <div class="mcp-inline-actions">
+                <button class="btn btn-primary btn-sm" onclick={() => handleConfirm(i)}>Add</button>
+                <button class="btn btn-secondary btn-sm" onclick={handleCancel}>Cancel</button>
+              </div>
+            </div>
+          {/if}
+        </div>
+      {/each}
+    {/if}
+  </div>
+</div>

--- a/web/src/components/settings/Memory.svelte
+++ b/web/src/components/settings/Memory.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+  import type { ConfigFields } from "../../lib/settings-toml";
+
+  let { fields = $bindable() }: { fields: ConfigFields } = $props();
+</script>
+
+<div class="settings-section">
+  <div class="settings-group">
+    <div class="settings-group-label">Observation Thresholds</div>
+    <div class="settings-field">
+      <label>Observer Threshold (tokens)</label>
+      <input type="number" bind:value={fields.observer_threshold_tokens} placeholder="Default: 2000" />
+      <span class="field-hint">Token count before the observer fires.</span>
+    </div>
+    <div class="settings-field">
+      <label>Reflector Threshold (tokens)</label>
+      <input type="number" bind:value={fields.reflector_threshold_tokens} placeholder="Default: 8000" />
+      <span class="field-hint">Token count before the reflector compresses memories.</span>
+    </div>
+    <div class="settings-field">
+      <label>Observer Cooldown (seconds)</label>
+      <input type="number" bind:value={fields.observer_cooldown_secs} placeholder="Default: 120" />
+      <span class="field-hint">Cooldown after soft threshold is crossed.</span>
+    </div>
+    <div class="settings-field">
+      <label>Observer Force Threshold (tokens)</label>
+      <input type="number" bind:value={fields.observer_force_threshold_tokens} placeholder="Default: 6000" />
+      <span class="field-hint">Forces immediate observation, bypassing cooldown.</span>
+    </div>
+  </div>
+
+  <div class="settings-group">
+    <div class="settings-group-label">Search Tuning</div>
+    <div class="settings-field">
+      <label>Vector Weight</label>
+      <input type="number" step="0.05" bind:value={fields.search_vector_weight} placeholder="Default: 0.6" />
+      <span class="field-hint">Weight for vector similarity in hybrid search (0.0-1.0).</span>
+    </div>
+    <div class="settings-field">
+      <label>Text Weight</label>
+      <input type="number" step="0.05" bind:value={fields.search_text_weight} placeholder="Default: 0.4" />
+      <span class="field-hint">Weight for BM25 text scores in hybrid search (0.0-1.0).</span>
+    </div>
+    <div class="settings-field">
+      <label>Min Score</label>
+      <input type="number" step="0.01" bind:value={fields.search_min_score} placeholder="Default: 0.3" />
+      <span class="field-hint">Minimum hybrid score threshold for results.</span>
+    </div>
+    <div class="settings-field">
+      <label>Candidate Multiplier</label>
+      <input type="number" bind:value={fields.search_candidate_multiplier} placeholder="Default: 3" />
+      <span class="field-hint">Multiplier on limit for candidate retrieval before merge.</span>
+    </div>
+    <div class="settings-field">
+      <label>
+        <span class="toggle-switch">
+          <input type="checkbox" bind:checked={fields.search_temporal_decay} />
+          <span class="toggle-slider"></span>
+        </span>
+        Temporal Decay
+      </label>
+      <span class="field-hint">Reduce relevance of older memories over time.</span>
+    </div>
+    {#if fields.search_temporal_decay}
+      <div class="settings-field">
+        <label>Decay Half-Life (days)</label>
+        <input type="number" step="1" bind:value={fields.search_temporal_decay_half_life_days} placeholder="Default: 30" />
+        <span class="field-hint">Number of days for memory relevance to halve.</span>
+      </div>
+    {/if}
+  </div>
+</div>

--- a/web/src/components/settings/Providers.svelte
+++ b/web/src/components/settings/Providers.svelte
@@ -1,0 +1,457 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import type { SettingsProviderEntry, SettingsModelAssignments } from "../../lib/types";
+  import {
+    fetchModels,
+    DEFAULT_MODELS,
+    DEFAULT_EMBEDDING_MODELS,
+    EMBEDDING_PROVIDERS,
+    EMBEDDING_MODEL_LISTS,
+    debounce,
+    invalidateProvider,
+    type ModelEntry,
+  } from "../../lib/models";
+
+  let {
+    providers = $bindable(),
+    models = $bindable(),
+  }: {
+    providers: SettingsProviderEntry[];
+    models: SettingsModelAssignments;
+  } = $props();
+
+  const providerTypes: Record<string, string> = {
+    anthropic: "Anthropic",
+    openai: "OpenAI",
+    gemini: "Google Gemini",
+    ollama: "Ollama",
+  };
+
+  const roleTooltips: Record<string, string> = {
+    main: "The primary model used for conversations and task execution.",
+    observer: "Watches conversations and extracts facts, preferences, and patterns for long-term memory.",
+    reflector: "Periodically reviews stored memories, consolidates duplicates, and resolves contradictions.",
+    pulse: "Drives proactive behavior — daily briefings, check-ins, and ambient monitoring tasks.",
+    embedding: "Generates vector embeddings for semantic memory search. Only some providers support this.",
+    "bg-small": "Used for lightweight background tasks like formatting, simple lookups, and notifications.",
+    "bg-medium": "Used for moderate background tasks like summarization and analysis.",
+    "bg-large": "Used for complex background tasks that need strong reasoning ability.",
+  };
+
+  const allRoles = ["main", "observer", "reflector", "pulse"];
+  const bgTiers = ["bg-small", "bg-medium", "bg-large"];
+
+  // Model lists and loading state per role
+  let modelLists = $state<Record<string, ModelEntry[]>>({});
+  let modelLoading = $state<Record<string, boolean>>({});
+  let otherActive = $state<Record<string, boolean>>({});
+  let otherValues = $state<Record<string, string>>({});
+
+  // Map role key to models field key
+  function modelsKey(role: string): keyof SettingsModelAssignments {
+    if (role === "bg-small") return "bgSmall";
+    if (role === "bg-medium") return "bgMedium";
+    if (role === "bg-large") return "bgLarge";
+    return role as keyof SettingsModelAssignments;
+  }
+
+  // Extract provider from "provider/model" string
+  function getProvider(role: string): string {
+    const val = models[modelsKey(role)];
+    if (!val) return providers[0]?.name || "";
+    const slash = val.indexOf("/");
+    return slash >= 0 ? val.slice(0, slash) : providers[0]?.name || "";
+  }
+
+  // Extract model from "provider/model" string
+  function getModel(role: string): string {
+    const val = models[modelsKey(role)];
+    if (!val) return "";
+    const slash = val.indexOf("/");
+    return slash >= 0 ? val.slice(slash + 1) : val;
+  }
+
+  function setProvider(role: string, prov: string) {
+    const key = modelsKey(role);
+    models[key] = prov + "/";
+    otherActive[role] = false;
+    otherValues[role] = "";
+    loadModels(role);
+  }
+
+  function setModel(role: string, value: string) {
+    if (value === "__other__") {
+      otherActive[role] = true;
+      return;
+    }
+    otherActive[role] = false;
+    const prov = getProvider(role);
+    models[modelsKey(role)] = prov + "/" + value;
+  }
+
+  function setOtherModel(role: string, value: string) {
+    otherValues[role] = value;
+    const prov = getProvider(role);
+    models[modelsKey(role)] = prov + "/" + value;
+  }
+
+  // Find provider entry for a role's current provider name
+  function providerEntry(name: string): SettingsProviderEntry | undefined {
+    return providers.find((p) => p.name === name);
+  }
+
+  async function loadModels(role: string) {
+    const provName = getProvider(role);
+    const entry = providerEntry(provName);
+    if (!entry) return;
+
+    // Embedding uses hardcoded lists
+    if (role === "embedding") {
+      const list = EMBEDDING_MODEL_LISTS[entry.type] || [];
+      modelLists[role] = list;
+      const current = getModel(role);
+      if (!current && list.length > 0) {
+        const def = DEFAULT_EMBEDDING_MODELS[entry.type] || "";
+        const found = list.some((m) => m.id === def);
+        setModel(role, found ? def : list[0].id);
+      }
+      return;
+    }
+
+    const apiKey = entry.type !== "ollama" ? entry.apiKey : undefined;
+    const url = entry.url || undefined;
+
+    modelLoading[role] = true;
+    const result = await fetchModels(entry.type, apiKey, url);
+    modelLists[role] = result.models;
+    modelLoading[role] = false;
+
+    const current = getModel(role);
+    if (!current && result.models.length > 0) {
+      const def = DEFAULT_MODELS[entry.type] || "";
+      const found = result.models.some((m) => m.id === def);
+      setModel(role, found ? def : result.models[0].id);
+    }
+  }
+
+  const debouncedLoadModels = debounce((role: string) => {
+    loadModels(role);
+  }, 500);
+
+  function addProvider() {
+    providers.push({ name: "", type: "anthropic", apiKey: "", url: "" });
+    providers = providers;
+  }
+
+  function removeProvider(idx: number) {
+    providers.splice(idx, 1);
+    providers = providers;
+  }
+
+  function providerNameOptions(): string[] {
+    return providers.map((p) => p.name).filter(Boolean);
+  }
+
+  function roleLabel(role: string): string {
+    const labels: Record<string, string> = {
+      main: "Main Agent",
+      observer: "Observer",
+      reflector: "Reflector",
+      pulse: "Pulse",
+      embedding: "Embedding",
+      "bg-small": "Small",
+      "bg-medium": "Medium",
+      "bg-large": "Large",
+    };
+    return labels[role] || role;
+  }
+
+  onMount(() => {
+    if (providers.length === 0) return;
+    for (const role of [...allRoles, "embedding", ...bgTiers]) {
+      loadModels(role);
+    }
+  });
+</script>
+
+<div class="settings-section">
+  <div class="settings-group">
+    <div class="settings-group-label">Provider Connections</div>
+
+    {#each providers as prov, i}
+      <div class="provider-entry">
+        <div class="provider-entry-fields">
+          <div class="settings-field">
+            <label>Name</label>
+            <input type="text" bind:value={prov.name} placeholder="e.g. anthropic" />
+          </div>
+          <div class="settings-field">
+            <label>Type</label>
+            <select bind:value={prov.type}>
+              {#each Object.entries(providerTypes) as [val, label]}
+                <option value={val}>{label}</option>
+              {/each}
+            </select>
+          </div>
+          {#if prov.type !== "ollama"}
+            <div class="settings-field">
+              <label>API Key</label>
+              {#if prov.apiKey.startsWith("secret:")}
+                <div class="secret-stored">
+                  <span class="secret-badge">Stored securely</span>
+                  <button class="btn btn-sm btn-secondary" onclick={() => { prov.apiKey = ""; }}>Change</button>
+                </div>
+              {:else}
+                <input
+                  type="password"
+                  bind:value={prov.apiKey}
+                  placeholder="API key"
+                  onblur={() => {
+                    invalidateProvider(prov.type);
+                    for (const role of [...allRoles, "embedding", ...bgTiers]) {
+                      if (getProvider(role) === prov.name) debouncedLoadModels(role);
+                    }
+                  }}
+                />
+              {/if}
+            </div>
+          {/if}
+          <div class="settings-field">
+            <label>Base URL (optional)</label>
+            <input type="text" bind:value={prov.url} placeholder="Override base URL" />
+          </div>
+        </div>
+        <button class="btn btn-sm btn-danger" onclick={() => removeProvider(i)}>Remove</button>
+      </div>
+    {/each}
+
+    <button class="btn btn-secondary btn-sm" onclick={addProvider}>+ Add Provider</button>
+  </div>
+
+  <!-- Model Role Assignments -->
+  <div class="settings-group">
+    <div class="settings-group-label">Model Role Assignments</div>
+
+    <div class="roles-section">
+      <div class="roles-section-label">Agent</div>
+      {#each ["main"] as role}
+        <div class="role-row">
+          <div class="role-row-label">
+            {roleLabel(role)}
+            <span class="role-tooltip">
+              <span class="role-tooltip-icon">?</span>
+              <span class="role-tooltip-text">{roleTooltips[role]}</span>
+            </span>
+          </div>
+          <div class="role-row-fields">
+            <div class="settings-field">
+              <label>Provider</label>
+              <select
+                value={getProvider(role)}
+                onchange={(e) => setProvider(role, (e.target as HTMLSelectElement).value)}
+              >
+                {#each providerNameOptions() as pk}
+                  <option value={pk}>{pk}</option>
+                {/each}
+              </select>
+            </div>
+            <div class="settings-field">
+              <label>Model</label>
+              <div class="model-select-wrap">
+                <select
+                  value={otherActive[role] ? "__other__" : getModel(role)}
+                  onchange={(e) => setModel(role, (e.target as HTMLSelectElement).value)}
+                  disabled={modelLoading[role]}
+                >
+                  {#if modelLoading[role]}
+                    <option value="">Loading...</option>
+                  {:else}
+                    {#each modelLists[role] || [] as m}
+                      <option value={m.id}>{m.name || m.id}</option>
+                    {/each}
+                    <option value="__other__">Other...</option>
+                  {/if}
+                </select>
+                {#if otherActive[role]}
+                  <input
+                    class="model-other-input"
+                    type="text"
+                    placeholder="Enter model ID..."
+                    value={otherValues[role] || ""}
+                    oninput={(e) => setOtherModel(role, (e.target as HTMLInputElement).value)}
+                  />
+                {/if}
+              </div>
+            </div>
+          </div>
+        </div>
+      {/each}
+    </div>
+
+    <div class="roles-section">
+      <div class="roles-section-label">Subsystems</div>
+      {#each ["observer", "reflector", "pulse"] as role}
+        <div class="role-row">
+          <div class="role-row-label">
+            {roleLabel(role)}
+            <span class="role-tooltip">
+              <span class="role-tooltip-icon">?</span>
+              <span class="role-tooltip-text">{roleTooltips[role]}</span>
+            </span>
+          </div>
+          <div class="role-row-fields">
+            <div class="settings-field">
+              <label>Provider</label>
+              <select
+                value={getProvider(role)}
+                onchange={(e) => setProvider(role, (e.target as HTMLSelectElement).value)}
+              >
+                {#each providerNameOptions() as pk}
+                  <option value={pk}>{pk}</option>
+                {/each}
+              </select>
+            </div>
+            <div class="settings-field">
+              <label>Model</label>
+              <div class="model-select-wrap">
+                <select
+                  value={otherActive[role] ? "__other__" : getModel(role)}
+                  onchange={(e) => setModel(role, (e.target as HTMLSelectElement).value)}
+                  disabled={modelLoading[role]}
+                >
+                  {#if modelLoading[role]}
+                    <option value="">Loading...</option>
+                  {:else}
+                    {#each modelLists[role] || [] as m}
+                      <option value={m.id}>{m.name || m.id}</option>
+                    {/each}
+                    <option value="__other__">Other...</option>
+                  {/if}
+                </select>
+                {#if otherActive[role]}
+                  <input
+                    class="model-other-input"
+                    type="text"
+                    placeholder="Enter model ID..."
+                    value={otherValues[role] || ""}
+                    oninput={(e) => setOtherModel(role, (e.target as HTMLInputElement).value)}
+                  />
+                {/if}
+              </div>
+            </div>
+          </div>
+        </div>
+      {/each}
+    </div>
+
+    <div class="roles-section">
+      <div class="roles-section-label">Embedding</div>
+      <div class="role-row">
+        <div class="role-row-label">
+          Embedding
+          <span class="role-tooltip">
+            <span class="role-tooltip-icon">?</span>
+            <span class="role-tooltip-text">{roleTooltips.embedding}</span>
+          </span>
+        </div>
+        <div class="role-row-fields">
+          <div class="settings-field">
+            <label>Provider</label>
+            <select
+              value={getProvider("embedding")}
+              onchange={(e) => setProvider("embedding", (e.target as HTMLSelectElement).value)}
+            >
+              {#each providerNameOptions().filter((n) => { const entry = providerEntry(n); return entry && EMBEDDING_PROVIDERS.includes(entry.type); }) as pk}
+                <option value={pk}>{pk}</option>
+              {/each}
+            </select>
+          </div>
+          <div class="settings-field">
+            <label>Model</label>
+            <div class="model-select-wrap">
+              <select
+                value={otherActive["embedding"] ? "__other__" : getModel("embedding")}
+                onchange={(e) => setModel("embedding", (e.target as HTMLSelectElement).value)}
+                disabled={modelLoading["embedding"]}
+              >
+                {#if modelLoading["embedding"]}
+                  <option value="">Loading...</option>
+                {:else}
+                  {#each modelLists["embedding"] || [] as m}
+                    <option value={m.id}>{m.name || m.id}</option>
+                  {/each}
+                  <option value="__other__">Other...</option>
+                {/if}
+              </select>
+              {#if otherActive["embedding"]}
+                <input
+                  class="model-other-input"
+                  type="text"
+                  placeholder="Enter model ID..."
+                  value={otherValues["embedding"] || ""}
+                  oninput={(e) => setOtherModel("embedding", (e.target as HTMLInputElement).value)}
+                />
+              {/if}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="roles-section">
+      <div class="roles-section-label">Background Tasks</div>
+      {#each bgTiers as role}
+        <div class="role-row">
+          <div class="role-row-label">
+            {roleLabel(role)}
+            <span class="role-tooltip">
+              <span class="role-tooltip-icon">?</span>
+              <span class="role-tooltip-text">{roleTooltips[role]}</span>
+            </span>
+          </div>
+          <div class="role-row-fields">
+            <div class="settings-field">
+              <label>Provider</label>
+              <select
+                value={getProvider(role)}
+                onchange={(e) => setProvider(role, (e.target as HTMLSelectElement).value)}
+              >
+                {#each providerNameOptions() as pk}
+                  <option value={pk}>{pk}</option>
+                {/each}
+              </select>
+            </div>
+            <div class="settings-field">
+              <label>Model</label>
+              <div class="model-select-wrap">
+                <select
+                  value={otherActive[role] ? "__other__" : getModel(role)}
+                  onchange={(e) => setModel(role, (e.target as HTMLSelectElement).value)}
+                  disabled={modelLoading[role]}
+                >
+                  {#if modelLoading[role]}
+                    <option value="">Loading...</option>
+                  {:else}
+                    {#each modelLists[role] || [] as m}
+                      <option value={m.id}>{m.name || m.id}</option>
+                    {/each}
+                    <option value="__other__">Other...</option>
+                  {/if}
+                </select>
+                {#if otherActive[role]}
+                  <input
+                    class="model-other-input"
+                    type="text"
+                    placeholder="Enter model ID..."
+                    value={otherValues[role] || ""}
+                    oninput={(e) => setOtherModel(role, (e.target as HTMLInputElement).value)}
+                  />
+                {/if}
+              </div>
+            </div>
+          </div>
+        </div>
+      {/each}
+    </div>
+  </div>
+</div>

--- a/web/src/components/settings/Runtime.svelte
+++ b/web/src/components/settings/Runtime.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+  import type { ConfigFields } from "../../lib/settings-toml";
+
+  let { fields = $bindable() }: { fields: ConfigFields } = $props();
+</script>
+
+<div class="settings-section">
+  <div class="settings-group">
+    <div class="settings-group-label">General</div>
+    <div class="settings-field">
+      <label>Name</label>
+      <input type="text" bind:value={fields.name} placeholder="What the agent calls you" />
+    </div>
+    <div class="settings-field">
+      <label>Timezone</label>
+      <input type="text" bind:value={fields.timezone} placeholder="e.g. America/New_York" />
+    </div>
+    <div class="settings-field">
+      <label>Workspace Directory</label>
+      <input type="text" bind:value={fields.workspace_dir} placeholder="Default: ~/.residuum/workspace" />
+    </div>
+    <div class="settings-field">
+      <label>Timeout (seconds)</label>
+      <input type="number" bind:value={fields.timeout_secs} placeholder="Default: 120" />
+    </div>
+    <div class="settings-field">
+      <label>Max Tokens</label>
+      <input type="number" bind:value={fields.max_tokens} placeholder="Default: 8192" />
+    </div>
+  </div>
+
+  <div class="settings-group">
+    <div class="settings-group-label">Gateway</div>
+    <div class="settings-field">
+      <label>Bind Address</label>
+      <input type="text" bind:value={fields.gateway_bind} placeholder="Default: 127.0.0.1" />
+    </div>
+    <div class="settings-field">
+      <label>Port</label>
+      <input type="number" bind:value={fields.gateway_port} placeholder="Default: 7700" />
+    </div>
+  </div>
+
+  <div class="settings-group">
+    <div class="settings-group-label">Pulse & Background</div>
+    <div class="settings-field">
+      <label>
+        <span class="toggle-switch">
+          <input type="checkbox" bind:checked={fields.pulse_enabled} />
+          <span class="toggle-slider"></span>
+        </span>
+        Pulse Enabled
+      </label>
+    </div>
+    <div class="settings-field">
+      <label>Max Concurrent Background Tasks</label>
+      <input type="number" bind:value={fields.bg_max_concurrent} placeholder="Default: 3" />
+    </div>
+    <div class="settings-field">
+      <label>Transcript Retention (days)</label>
+      <input type="number" bind:value={fields.bg_transcript_retention_days} placeholder="Default: 7" />
+    </div>
+  </div>
+
+  <div class="settings-group">
+    <div class="settings-group-label">Retry</div>
+    <div class="settings-field">
+      <label>Max Retries</label>
+      <input type="number" bind:value={fields.retry_max_retries} placeholder="Default: 3" />
+    </div>
+    <div class="settings-field">
+      <label>Initial Delay (ms)</label>
+      <input type="number" bind:value={fields.retry_initial_delay_ms} placeholder="Default: 1000" />
+    </div>
+    <div class="settings-field">
+      <label>Max Delay (ms)</label>
+      <input type="number" bind:value={fields.retry_max_delay_ms} placeholder="Default: 30000" />
+    </div>
+    <div class="settings-field">
+      <label>Backoff Multiplier</label>
+      <input type="number" step="0.1" bind:value={fields.retry_backoff_multiplier} placeholder="Default: 2.0" />
+    </div>
+  </div>
+
+  <div class="settings-group">
+    <div class="settings-group-label">Agent Abilities</div>
+    <div class="settings-field">
+      <label>
+        <span class="toggle-switch">
+          <input type="checkbox" bind:checked={fields.agent_modify_mcp} />
+          <span class="toggle-slider"></span>
+        </span>
+        Allow MCP Modifications
+      </label>
+    </div>
+    <div class="settings-field">
+      <label>
+        <span class="toggle-switch">
+          <input type="checkbox" bind:checked={fields.agent_modify_channels} />
+          <span class="toggle-slider"></span>
+        </span>
+        Allow Channel Modifications
+      </label>
+    </div>
+  </div>
+</div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -8,6 +8,7 @@ import type {
   McpCatalogEntry,
   SecretResponse,
   ValidateResponse,
+  SecretsListResponse,
 } from "./types";
 
 export async function fetchStatus(): Promise<StatusResponse> {
@@ -91,4 +92,86 @@ export async function completeSetup(
     body: JSON.stringify(payload),
   });
   return resp.json();
+}
+
+// ── Settings API wrappers ────────────────────────────────────────────
+
+export async function fetchConfigRaw(): Promise<string> {
+  const resp = await fetch("/api/config/raw");
+  if (!resp.ok) throw new Error(`failed to read config: ${resp.status}`);
+  return resp.text();
+}
+
+export async function putConfigRaw(toml: string): Promise<ValidateResponse> {
+  const resp = await fetch("/api/config/raw", {
+    method: "PUT",
+    headers: { "Content-Type": "text/plain" },
+    body: toml,
+  });
+  return resp.json();
+}
+
+export async function validateConfig(toml: string): Promise<ValidateResponse> {
+  const resp = await fetch("/api/config/validate", {
+    method: "POST",
+    headers: { "Content-Type": "text/plain" },
+    body: toml,
+  });
+  return resp.json();
+}
+
+export async function fetchProvidersRaw(): Promise<string> {
+  const resp = await fetch("/api/providers/raw");
+  if (!resp.ok) throw new Error(`failed to read providers: ${resp.status}`);
+  return resp.text();
+}
+
+export async function putProvidersRaw(toml: string): Promise<ValidateResponse> {
+  const resp = await fetch("/api/providers/raw", {
+    method: "PUT",
+    headers: { "Content-Type": "text/plain" },
+    body: toml,
+  });
+  return resp.json();
+}
+
+export async function validateProviders(toml: string): Promise<ValidateResponse> {
+  const resp = await fetch("/api/providers/validate", {
+    method: "POST",
+    headers: { "Content-Type": "text/plain" },
+    body: toml,
+  });
+  return resp.json();
+}
+
+export async function fetchMcpRaw(): Promise<string> {
+  const resp = await fetch("/api/mcp/raw");
+  if (!resp.ok) throw new Error(`failed to read mcp.json: ${resp.status}`);
+  return resp.text();
+}
+
+export async function putMcpRaw(json: string): Promise<ValidateResponse> {
+  const resp = await fetch("/api/mcp/raw", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: json,
+  });
+  return resp.json();
+}
+
+export async function listSecrets(): Promise<string[]> {
+  const resp = await fetch("/api/secrets");
+  if (!resp.ok) return [];
+  const data: SecretsListResponse = await resp.json();
+  return data.names;
+}
+
+export async function deleteSecret(name: string): Promise<void> {
+  const resp = await fetch(`/api/secrets/${encodeURIComponent(name)}`, {
+    method: "DELETE",
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`failed to delete secret "${name}": ${text}`);
+  }
 }

--- a/web/src/lib/settings-toml.ts
+++ b/web/src/lib/settings-toml.ts
@@ -1,0 +1,453 @@
+// ── Settings TOML/JSON Parse & Serialize ─────────────────────────────
+//
+// Bidirectional conversion between raw config text and structured form state.
+// Uses smol-toml for parsing and line-building for serialization (matching toml.ts).
+
+import { parse as parseToml } from "smol-toml";
+import type {
+  McpServerEntry,
+  SettingsProviderEntry,
+  SettingsModelAssignments,
+} from "./types";
+
+// ── Config form fields (config.toml) ─────────────────────────────────
+
+export interface ConfigFields {
+  name: string;
+  timezone: string;
+  workspace_dir: string;
+  timeout_secs: string;
+  max_tokens: string;
+  // gateway
+  gateway_bind: string;
+  gateway_port: string;
+  // pulse
+  pulse_enabled: boolean;
+  // background
+  bg_max_concurrent: string;
+  bg_transcript_retention_days: string;
+  // retry
+  retry_max_retries: string;
+  retry_initial_delay_ms: string;
+  retry_max_delay_ms: string;
+  retry_backoff_multiplier: string;
+  // agent
+  agent_modify_mcp: boolean;
+  agent_modify_channels: boolean;
+  // memory observation
+  observer_threshold_tokens: string;
+  reflector_threshold_tokens: string;
+  observer_cooldown_secs: string;
+  observer_force_threshold_tokens: string;
+  // memory search
+  search_vector_weight: string;
+  search_text_weight: string;
+  search_min_score: string;
+  search_candidate_multiplier: string;
+  search_temporal_decay: boolean;
+  search_temporal_decay_half_life_days: string;
+  // integrations
+  discord_token: string;
+  telegram_token: string;
+  webhook_enabled: boolean;
+  webhook_secret: string;
+  // skills
+  skills_dirs: string[];
+}
+
+export function defaultConfigFields(): ConfigFields {
+  return {
+    name: "",
+    timezone: "",
+    workspace_dir: "",
+    timeout_secs: "",
+    max_tokens: "",
+    gateway_bind: "",
+    gateway_port: "",
+    pulse_enabled: true,
+    bg_max_concurrent: "",
+    bg_transcript_retention_days: "",
+    retry_max_retries: "",
+    retry_initial_delay_ms: "",
+    retry_max_delay_ms: "",
+    retry_backoff_multiplier: "",
+    agent_modify_mcp: true,
+    agent_modify_channels: true,
+    observer_threshold_tokens: "",
+    reflector_threshold_tokens: "",
+    observer_cooldown_secs: "",
+    observer_force_threshold_tokens: "",
+    search_vector_weight: "",
+    search_text_weight: "",
+    search_min_score: "",
+    search_candidate_multiplier: "",
+    search_temporal_decay: false,
+    search_temporal_decay_half_life_days: "",
+    discord_token: "",
+    telegram_token: "",
+    webhook_enabled: false,
+    webhook_secret: "",
+    skills_dirs: [],
+  };
+}
+
+// Helper to safely read nested TOML values
+function str(v: unknown): string {
+  return v == null ? "" : String(v);
+}
+
+function bool(v: unknown, fallback: boolean): boolean {
+  return typeof v === "boolean" ? v : fallback;
+}
+
+export function parseConfigToml(raw: string): ConfigFields {
+  const fields = defaultConfigFields();
+  if (!raw.trim()) return fields;
+
+  let doc: Record<string, unknown>;
+  try {
+    doc = parseToml(raw) as Record<string, unknown>;
+  } catch {
+    return fields;
+  }
+
+  fields.name = str(doc.name);
+  fields.timezone = str(doc.timezone);
+  fields.workspace_dir = str(doc.workspace_dir);
+  fields.timeout_secs = str(doc.timeout_secs);
+  fields.max_tokens = str(doc.max_tokens);
+
+  const gw = doc.gateway as Record<string, unknown> | undefined;
+  if (gw) {
+    fields.gateway_bind = str(gw.bind);
+    fields.gateway_port = str(gw.port);
+  }
+
+  const pulse = doc.pulse as Record<string, unknown> | undefined;
+  if (pulse) {
+    fields.pulse_enabled = bool(pulse.enabled, true);
+  }
+
+  const bg = doc.background as Record<string, unknown> | undefined;
+  if (bg) {
+    fields.bg_max_concurrent = str(bg.max_concurrent);
+    fields.bg_transcript_retention_days = str(bg.transcript_retention_days);
+  }
+
+  const retry = doc.retry as Record<string, unknown> | undefined;
+  if (retry) {
+    fields.retry_max_retries = str(retry.max_retries);
+    fields.retry_initial_delay_ms = str(retry.initial_delay_ms);
+    fields.retry_max_delay_ms = str(retry.max_delay_ms);
+    fields.retry_backoff_multiplier = str(retry.backoff_multiplier);
+  }
+
+  const agent = doc.agent as Record<string, unknown> | undefined;
+  if (agent) {
+    fields.agent_modify_mcp = bool(agent.modify_mcp, true);
+    fields.agent_modify_channels = bool(agent.modify_channels, true);
+  }
+
+  const mem = doc.memory as Record<string, unknown> | undefined;
+  if (mem) {
+    fields.observer_threshold_tokens = str(mem.observer_threshold_tokens);
+    fields.reflector_threshold_tokens = str(mem.reflector_threshold_tokens);
+    fields.observer_cooldown_secs = str(mem.observer_cooldown_secs);
+    fields.observer_force_threshold_tokens = str(mem.observer_force_threshold_tokens);
+    const search = mem.search as Record<string, unknown> | undefined;
+    if (search) {
+      fields.search_vector_weight = str(search.vector_weight);
+      fields.search_text_weight = str(search.text_weight);
+      fields.search_min_score = str(search.min_score);
+      fields.search_candidate_multiplier = str(search.candidate_multiplier);
+      fields.search_temporal_decay = bool(search.temporal_decay, false);
+      fields.search_temporal_decay_half_life_days = str(search.temporal_decay_half_life_days);
+    }
+  }
+
+  const discord = doc.discord as Record<string, unknown> | undefined;
+  if (discord) {
+    fields.discord_token = str(discord.token);
+  }
+
+  const telegram = doc.telegram as Record<string, unknown> | undefined;
+  if (telegram) {
+    fields.telegram_token = str(telegram.token);
+  }
+
+  const webhook = doc.webhook as Record<string, unknown> | undefined;
+  if (webhook) {
+    fields.webhook_enabled = bool(webhook.enabled, false);
+    fields.webhook_secret = str(webhook.secret);
+  }
+
+  const skills = doc.skills as Record<string, unknown> | undefined;
+  if (skills && Array.isArray(skills.dirs)) {
+    fields.skills_dirs = (skills.dirs as unknown[]).map(String);
+  }
+
+  return fields;
+}
+
+// ── Providers (providers.toml) ───────────────────────────────────────
+
+export interface ProvidersFormState {
+  providers: SettingsProviderEntry[];
+  models: SettingsModelAssignments;
+}
+
+export function defaultModels(): SettingsModelAssignments {
+  return {
+    main: "",
+    default: "",
+    observer: "",
+    reflector: "",
+    pulse: "",
+    embedding: "",
+    bgSmall: "",
+    bgMedium: "",
+    bgLarge: "",
+  };
+}
+
+export function parseProvidersToml(raw: string): ProvidersFormState {
+  const result: ProvidersFormState = { providers: [], models: defaultModels() };
+  if (!raw.trim()) return result;
+
+  let doc: Record<string, unknown>;
+  try {
+    doc = parseToml(raw) as Record<string, unknown>;
+  } catch {
+    return result;
+  }
+
+  const provs = doc.providers as Record<string, Record<string, unknown>> | undefined;
+  if (provs) {
+    for (const [name, entry] of Object.entries(provs)) {
+      result.providers.push({
+        name,
+        type: str(entry.type),
+        apiKey: str(entry.api_key),
+        url: str(entry.url),
+      });
+    }
+  }
+
+  const models = doc.models as Record<string, unknown> | undefined;
+  if (models) {
+    result.models.main = modelStr(models.main);
+    result.models.default = modelStr(models.default);
+    result.models.observer = modelStr(models.observer);
+    result.models.reflector = modelStr(models.reflector);
+    result.models.pulse = modelStr(models.pulse);
+    result.models.embedding = str(models.embedding);
+  }
+
+  const bg = doc.background as Record<string, unknown> | undefined;
+  if (bg) {
+    const bgModels = bg.models as Record<string, unknown> | undefined;
+    if (bgModels) {
+      result.models.bgSmall = modelStr(bgModels.small);
+      result.models.bgMedium = modelStr(bgModels.medium);
+      result.models.bgLarge = modelStr(bgModels.large);
+    }
+  }
+
+  return result;
+}
+
+/** Model values can be a string or array (failover). Show first entry for form. */
+function modelStr(v: unknown): string {
+  if (Array.isArray(v)) return v.length > 0 ? String(v[0]) : "";
+  return v == null ? "" : String(v);
+}
+
+// ── MCP (mcp.json) ──────────────────────────────────────────────────
+
+export function parseMcpJson(raw: string): McpServerEntry[] {
+  if (!raw.trim()) return [];
+  try {
+    const doc = JSON.parse(raw) as Record<string, unknown>;
+    const servers = (doc.mcpServers || {}) as Record<string, Record<string, unknown>>;
+    return Object.entries(servers).map(([name, srv]) => ({
+      name,
+      command: str(srv.command),
+      args: Array.isArray(srv.args) ? (srv.args as string[]) : [],
+      env: (srv.env || {}) as Record<string, string>,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+// ── Serializers ──────────────────────────────────────────────────────
+
+/** Serialize config fields back to config.toml. */
+export function serializeConfigToml(f: ConfigFields): string {
+  const lines: string[] = [];
+
+  if (f.name) lines.push(`name = "${f.name}"`);
+  if (f.timezone) lines.push(`timezone = "${f.timezone}"`);
+  if (f.workspace_dir) lines.push(`workspace_dir = "${f.workspace_dir}"`);
+  if (f.timeout_secs) lines.push(`timeout_secs = ${f.timeout_secs}`);
+  if (f.max_tokens) lines.push(`max_tokens = ${f.max_tokens}`);
+
+  // gateway
+  if (f.gateway_bind || f.gateway_port) {
+    lines.push("");
+    lines.push("[gateway]");
+    if (f.gateway_bind) lines.push(`bind = "${f.gateway_bind}"`);
+    if (f.gateway_port) lines.push(`port = ${f.gateway_port}`);
+  }
+
+  // pulse
+  if (!f.pulse_enabled) {
+    lines.push("");
+    lines.push("[pulse]");
+    lines.push("enabled = false");
+  }
+
+  // memory
+  const memLines: string[] = [];
+  if (f.observer_threshold_tokens) memLines.push(`observer_threshold_tokens = ${f.observer_threshold_tokens}`);
+  if (f.reflector_threshold_tokens) memLines.push(`reflector_threshold_tokens = ${f.reflector_threshold_tokens}`);
+  if (f.observer_cooldown_secs) memLines.push(`observer_cooldown_secs = ${f.observer_cooldown_secs}`);
+  if (f.observer_force_threshold_tokens) memLines.push(`observer_force_threshold_tokens = ${f.observer_force_threshold_tokens}`);
+
+  const searchLines: string[] = [];
+  if (f.search_vector_weight) searchLines.push(`vector_weight = ${f.search_vector_weight}`);
+  if (f.search_text_weight) searchLines.push(`text_weight = ${f.search_text_weight}`);
+  if (f.search_min_score) searchLines.push(`min_score = ${f.search_min_score}`);
+  if (f.search_candidate_multiplier) searchLines.push(`candidate_multiplier = ${f.search_candidate_multiplier}`);
+  if (f.search_temporal_decay) searchLines.push(`temporal_decay = true`);
+  if (f.search_temporal_decay_half_life_days) searchLines.push(`temporal_decay_half_life_days = ${f.search_temporal_decay_half_life_days}`);
+
+  if (memLines.length > 0 || searchLines.length > 0) {
+    lines.push("");
+    lines.push("[memory]");
+    lines.push(...memLines);
+    if (searchLines.length > 0) {
+      lines.push("");
+      lines.push("[memory.search]");
+      lines.push(...searchLines);
+    }
+  }
+
+  // discord
+  if (f.discord_token) {
+    lines.push("");
+    lines.push("[discord]");
+    lines.push(`token = "${f.discord_token}"`);
+  }
+
+  // telegram
+  if (f.telegram_token) {
+    lines.push("");
+    lines.push("[telegram]");
+    lines.push(`token = "${f.telegram_token}"`);
+  }
+
+  // webhook
+  if (f.webhook_enabled || f.webhook_secret) {
+    lines.push("");
+    lines.push("[webhook]");
+    if (f.webhook_enabled) lines.push("enabled = true");
+    if (f.webhook_secret) lines.push(`secret = "${f.webhook_secret}"`);
+  }
+
+  // skills
+  if (f.skills_dirs.length > 0) {
+    lines.push("");
+    lines.push("[skills]");
+    const dirsStr = f.skills_dirs.map((d) => `"${d}"`).join(", ");
+    lines.push(`dirs = [${dirsStr}]`);
+  }
+
+  // retry
+  if (f.retry_max_retries || f.retry_initial_delay_ms || f.retry_max_delay_ms || f.retry_backoff_multiplier) {
+    lines.push("");
+    lines.push("[retry]");
+    if (f.retry_max_retries) lines.push(`max_retries = ${f.retry_max_retries}`);
+    if (f.retry_initial_delay_ms) lines.push(`initial_delay_ms = ${f.retry_initial_delay_ms}`);
+    if (f.retry_max_delay_ms) lines.push(`max_delay_ms = ${f.retry_max_delay_ms}`);
+    if (f.retry_backoff_multiplier) lines.push(`backoff_multiplier = ${f.retry_backoff_multiplier}`);
+  }
+
+  // background
+  if (f.bg_max_concurrent || f.bg_transcript_retention_days) {
+    lines.push("");
+    lines.push("[background]");
+    if (f.bg_max_concurrent) lines.push(`max_concurrent = ${f.bg_max_concurrent}`);
+    if (f.bg_transcript_retention_days) lines.push(`transcript_retention_days = ${f.bg_transcript_retention_days}`);
+  }
+
+  // agent
+  if (!f.agent_modify_mcp || !f.agent_modify_channels) {
+    lines.push("");
+    lines.push("[agent]");
+    if (!f.agent_modify_mcp) lines.push("modify_mcp = false");
+    if (!f.agent_modify_channels) lines.push("modify_channels = false");
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}
+
+/** Serialize providers form state back to providers.toml. */
+export function serializeProvidersToml(
+  providers: SettingsProviderEntry[],
+  models: SettingsModelAssignments,
+): string {
+  const lines: string[] = [];
+
+  for (const p of providers) {
+    lines.push(`[providers.${p.name}]`);
+    lines.push(`type = "${p.type}"`);
+    if (p.apiKey && p.type !== "ollama") lines.push(`api_key = "${p.apiKey}"`);
+    if (p.url) lines.push(`url = "${p.url}"`);
+    lines.push("");
+  }
+
+  // Models
+  const modelLines: string[] = [];
+  if (models.main) modelLines.push(`main = "${models.main}"`);
+  if (models.default) modelLines.push(`default = "${models.default}"`);
+  if (models.observer) modelLines.push(`observer = "${models.observer}"`);
+  if (models.reflector) modelLines.push(`reflector = "${models.reflector}"`);
+  if (models.pulse) modelLines.push(`pulse = "${models.pulse}"`);
+  if (models.embedding) modelLines.push(`embedding = "${models.embedding}"`);
+
+  if (modelLines.length > 0) {
+    lines.push("[models]");
+    lines.push(...modelLines);
+    lines.push("");
+  }
+
+  // Background models
+  const bgLines: string[] = [];
+  if (models.bgSmall) bgLines.push(`small = "${models.bgSmall}"`);
+  if (models.bgMedium) bgLines.push(`medium = "${models.bgMedium}"`);
+  if (models.bgLarge) bgLines.push(`large = "${models.bgLarge}"`);
+
+  if (bgLines.length > 0) {
+    lines.push("[background.models]");
+    lines.push(...bgLines);
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+/** Serialize MCP servers back to mcp.json. */
+export function serializeMcpJson(servers: McpServerEntry[]): string {
+  const obj: Record<string, { command: string; args?: string[]; env?: Record<string, string> }> = {};
+  for (const srv of servers) {
+    const entry: { command: string; args?: string[]; env?: Record<string, string> } = {
+      command: srv.command,
+    };
+    if (srv.args && srv.args.length > 0) entry.args = srv.args;
+    if (srv.env && Object.keys(srv.env).length > 0) entry.env = srv.env;
+    obj[srv.name] = entry;
+  }
+  return JSON.stringify({ mcpServers: obj }, null, 2) + "\n";
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -143,6 +143,37 @@ export interface ValidateResponse {
   error?: string;
 }
 
+// ── Settings types ───────────────────────────────────────────────────
+
+export type SettingsSection = "runtime" | "providers" | "memory" | "integrations" | "mcp";
+
+export interface SettingsProviderEntry {
+  name: string;
+  type: string;
+  apiKey: string;
+  url: string;
+}
+
+export interface SettingsModelAssignments {
+  main: string;
+  default: string;
+  observer: string;
+  reflector: string;
+  pulse: string;
+  embedding: string;
+  bgSmall: string;
+  bgMedium: string;
+  bgLarge: string;
+}
+
+export interface SecretsListResponse {
+  names: string[];
+}
+
+export interface DeleteSecretResponse {
+  deleted: boolean;
+}
+
 // ── Feed items (UI rendering) ────────────────────────────────────────
 
 export type ConnectionStatus =


### PR DESCRIPTION
## Summary

- Add 5 new backend API endpoints for `providers.toml` and `mcp.json` (GET/PUT raw, POST validate)
- Add settings panel with sidebar navigation across 5 sections: Runtime, Providers, Memory, Integrations, MCP
- Add form mode with structured editing and advanced mode with tabbed raw TOML/JSON editors
- Add `smol-toml` for client-side TOML parsing with bidirectional form ↔ text conversion
- Provider section includes model role assignments with live API-fetched dropdowns and role tooltips (fixes #19)
- Integrations section reads from correct top-level `discord`/`telegram`/`webhook` config paths
- Secret fields show "Stored securely" badge for existing `secret:*` references with Change button
- MCP section includes both configured server management and catalog browser
- Mode switch reloads from last saved state (no stale edit bugs)
- Save flow: store secrets → serialize → validate → write providers.toml → config.toml → mcp.json

## Test plan

- [x] `cargo test --quiet` — 1090 tests pass
- [x] `cargo clippy` — no warnings
- [x] `npm run build` — frontend builds cleanly
- [x] Manual verification via Playwright: all 5 sections render, form fields load current values, advanced mode shows raw config, close button returns to chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)