### PR TITLE
feat: add web linting with ESLint and Prettier

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -12,23 +12,34 @@ NC='\033[0m' # No Color
 
 echo -e "${YELLOW}Running pre-commit checks...${NC}"
 
-# Check if there are staged Rust files
+# Detect staged file categories
 STAGED_RS_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.rs$' || true)
 STAGED_TOML_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.toml$' || true)
+STAGED_WEB_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^web/src/.*\.(ts|svelte|js|css)$' || true)
 
-# Always run these checks if any Rust or TOML files are staged
-if [ -n "$STAGED_RS_FILES" ] || [ -n "$STAGED_TOML_FILES" ]; then
+HAS_RUST=false
+HAS_WEB=false
+[ -n "$STAGED_RS_FILES" ] || [ -n "$STAGED_TOML_FILES" ] && HAS_RUST=true
+[ -n "$STAGED_WEB_FILES" ] && HAS_WEB=true
 
-    # 1. Auto-format code
-    echo -e "\n${YELLOW}[1/3] Auto-formatting code...${NC}"
+# Calculate total steps for progress display
+RUST_STEPS=0
+WEB_STEPS=0
+$HAS_RUST && RUST_STEPS=3
+$HAS_WEB && WEB_STEPS=3
+TOTAL_STEPS=$((RUST_STEPS + WEB_STEPS))
+STEP=0
+
+# --- Rust checks ---
+if $HAS_RUST; then
+    STEP=$((STEP + 1))
+    echo -e "\n${YELLOW}[$STEP/$TOTAL_STEPS] Auto-formatting Rust code...${NC}"
     cargo fmt > /dev/null 2>&1
-
-    # Auto-stage any formatting changes
     git add -u > /dev/null 2>&1
     echo -e "${GREEN}✓ Formatting applied${NC}"
 
-    # 2. Run clippy (warnings are errors)
-    echo -e "\n${YELLOW}[2/3] Running clippy...${NC}"
+    STEP=$((STEP + 1))
+    echo -e "\n${YELLOW}[$STEP/$TOTAL_STEPS] Running clippy...${NC}"
     if ! OUTPUT=$(cargo clippy --all-targets -- -D warnings 2>&1); then
         echo "$OUTPUT"
         echo -e "${RED}ERROR: Clippy found issues.${NC}"
@@ -36,17 +47,45 @@ if [ -n "$STAGED_RS_FILES" ] || [ -n "$STAGED_TOML_FILES" ]; then
     fi
     echo -e "${GREEN}✓ Clippy OK${NC}"
 
-    # 3. Run tests
-    echo -e "\n${YELLOW}[3/3] Running tests...${NC}"
+    STEP=$((STEP + 1))
+    echo -e "\n${YELLOW}[$STEP/$TOTAL_STEPS] Running tests...${NC}"
     if ! OUTPUT=$(cargo test --quiet 2>&1); then
         echo "$OUTPUT"
         echo -e "${RED}ERROR: Tests failed.${NC}"
         exit 1
     fi
     echo -e "${GREEN}✓ Tests OK${NC}"
-
 else
     echo "No Rust or TOML files staged, skipping Rust checks."
+fi
+
+# --- Web checks ---
+if $HAS_WEB; then
+    STEP=$((STEP + 1))
+    echo -e "\n${YELLOW}[$STEP/$TOTAL_STEPS] Auto-formatting web code...${NC}"
+    (cd web && npm run format > /dev/null 2>&1)
+    git add -u > /dev/null 2>&1
+    echo -e "${GREEN}✓ Formatting applied${NC}"
+
+    STEP=$((STEP + 1))
+    echo -e "\n${YELLOW}[$STEP/$TOTAL_STEPS] Linting web code...${NC}"
+    if ! OUTPUT=$(cd web && npm run lint 2>&1); then
+        echo "$OUTPUT"
+        echo -e "${RED}ERROR: ESLint found issues.${NC}"
+        exit 1
+    fi
+    echo -e "${GREEN}✓ Lint OK${NC}"
+
+    STEP=$((STEP + 1))
+    echo -e "\n${YELLOW}[$STEP/$TOTAL_STEPS] Type-checking web code...${NC}"
+    if ! OUTPUT=$(cd web && npm run check 2>&1); then
+        echo "$OUTPUT"
+        echo -e "${RED}ERROR: svelte-check found issues.${NC}"
+        exit 1
+    fi
+    echo -e "${GREEN}✓ Type check OK${NC}"
+else
+    [ -z "$STAGED_WEB_FILES" ] && echo "No web files staged, skipping web checks."
 fi
 
 # Check for common issues in Rust files only

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -12,14 +12,27 @@ NC='\033[0m'
 
 echo -e "${YELLOW}Running pre-push checks...${NC}"
 
-# Full test suite (including ignored tests if any)
-echo -e "\n${YELLOW}Running full test suite...${NC}"
+# Full Rust test suite
+echo -e "\n${YELLOW}[1/2] Running full test suite...${NC}"
 if ! OUTPUT=$(cargo test --all-targets --quiet 2>&1); then
     echo "$OUTPUT"
     echo -e "${RED}ERROR: Tests failed. Push aborted.${NC}"
     exit 1
 fi
 echo -e "${GREEN}✓ All tests passed${NC}"
+
+# Web type check
+if [ -d "web/node_modules" ]; then
+    echo -e "\n${YELLOW}[2/2] Running web type check...${NC}"
+    if ! OUTPUT=$(cd web && npm run check 2>&1); then
+        echo "$OUTPUT"
+        echo -e "${RED}ERROR: svelte-check failed. Push aborted.${NC}"
+        exit 1
+    fi
+    echo -e "${GREEN}✓ Web type check OK${NC}"
+else
+    echo -e "\n${YELLOW}[2/2] Skipping web type check (node_modules not installed)${NC}"
+fi
 
 # Check for uncommitted changes (sanity check)
 if ! git diff --quiet || ! git diff --cached --quiet; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,39 @@ jobs:
           echo "| Clippy | ${{ steps.clippy.outcome }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Tests | ${{ steps.test.outcome }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Deny | ${{ steps.deny.outcome }} |" >> "$GITHUB_STEP_SUMMARY"
+
+  web-check:
+    name: Web Check
+    runs-on: [self-hosted, kubernetes, lab]
+
+    defaults:
+      run:
+        working-directory: web
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: npm ci
+
+      - name: Check formatting
+        id: format
+        run: npm run format:check
+
+      - name: Lint
+        id: lint
+        run: npm run lint
+
+      - name: Type check
+        id: typecheck
+        run: npm run check
+
+      - name: Build summary
+        if: always()
+        run: |
+          echo '## Web CI Results' >> "$GITHUB_STEP_SUMMARY"
+          echo '' >> "$GITHUB_STEP_SUMMARY"
+          echo '| Check | Status |' >> "$GITHUB_STEP_SUMMARY"
+          echo '|-------|--------|' >> "$GITHUB_STEP_SUMMARY"
+          echo "| Format | ${{ steps.format.outcome }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Lint | ${{ steps.lint.outcome }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Type Check | ${{ steps.typecheck.outcome }} |" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,21 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+      - name: Install web dependencies
+        run: cd web && npm ci
+
+      - name: Web format check
+        id: web_format
+        run: cd web && npm run format:check
+
+      - name: Web lint
+        id: web_lint
+        run: cd web && npm run lint
+
+      - name: Web type check
+        id: web_typecheck
+        run: cd web && npm run check
+
       - name: Check formatting
         id: fmt
         run: cargo fmt --check
@@ -57,6 +72,9 @@ jobs:
           echo '' >> "$GITHUB_STEP_SUMMARY"
           echo '| Check | Status |' >> "$GITHUB_STEP_SUMMARY"
           echo '|-------|--------|' >> "$GITHUB_STEP_SUMMARY"
+          echo "| Web Format | ${{ steps.web_format.outcome }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Web Lint | ${{ steps.web_lint.outcome }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Web Types | ${{ steps.web_typecheck.outcome }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Format | ${{ steps.fmt.outcome }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Clippy | ${{ steps.clippy.outcome }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Tests | ${{ steps.test.outcome }} |" >> "$GITHUB_STEP_SUMMARY"
@@ -91,6 +109,15 @@ jobs:
       - name: Install Rust toolchain (macOS)
         if: runner.os == 'macOS'
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Node.js (macOS)
+        if: runner.os == 'macOS'
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: Build web assets
+        run: cd web && npm ci && npm run build
 
       - name: Add target
         if: matrix.cross

--- a/web/.prettierrc
+++ b/web/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "useTabs": false,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "plugins": ["prettier-plugin-svelte"],
+  "overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }]
+}

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -1,0 +1,206 @@
+// @ts-check
+
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+import svelte from "eslint-plugin-svelte";
+import svelteParser from "svelte-eslint-parser";
+import prettier from "eslint-config-prettier";
+import globals from "globals";
+
+export default tseslint.config(
+  // ── Global ignores ──────────────────────────────────────────────────
+  {
+    ignores: ["dist/**", "node_modules/**", "*.config.js", "*.config.ts"],
+  },
+
+  // ── Base presets ────────────────────────────────────────────────────
+  js.configs.recommended,
+  ...tseslint.configs.strictTypeChecked,
+  ...svelte.configs["flat/recommended"],
+  prettier,
+
+  // ── TypeScript files ────────────────────────────────────────────────
+  {
+    files: ["src/**/*.ts"],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      // ── Deny: catches real bugs, prevents shortcuts ───────────────
+      "no-console": "error",
+      "no-debugger": "error",
+      "no-alert": "error",
+      "no-warning-comments": [
+        "error",
+        { terms: ["todo", "fixme", "hack", "xxx"], location: "start" },
+      ],
+      "prefer-const": "error",
+      "no-var": "error",
+      eqeqeq: ["error", "always", { null: "ignore" }],
+      "no-implicit-coercion": "error",
+      "no-param-reassign": "error",
+      "no-nested-ternary": "error",
+
+      // TypeScript deny rules
+      "@typescript-eslint/no-explicit-any": "error",
+      "@typescript-eslint/no-unsafe-assignment": "error",
+      "@typescript-eslint/no-unsafe-call": "error",
+      "@typescript-eslint/no-unsafe-member-access": "error",
+      "@typescript-eslint/no-unsafe-return": "error",
+      "@typescript-eslint/no-unsafe-argument": "error",
+      "@typescript-eslint/no-floating-promises": "error",
+      "@typescript-eslint/no-misused-promises": "error",
+      "@typescript-eslint/only-throw-error": "error",
+      "@typescript-eslint/no-non-null-assertion": "error",
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
+      "@typescript-eslint/no-shadow": "error",
+      "@typescript-eslint/consistent-type-imports": [
+        "error",
+        { prefer: "type-imports" },
+      ],
+      "@typescript-eslint/restrict-template-expressions": [
+        "error",
+        { allowNumber: true },
+      ],
+
+      // ── Pedantic: stricter discipline ─────────────────────────────
+      "@typescript-eslint/explicit-function-return-type": [
+        "error",
+        { allowExpressions: true },
+      ],
+      "@typescript-eslint/strict-boolean-expressions": [
+        "error",
+        {
+          allowNullableBoolean: true,
+          allowNullableString: true,
+          allowNullableNumber: false,
+          allowAny: false,
+        },
+      ],
+      "@typescript-eslint/switch-exhaustiveness-check": "error",
+      "@typescript-eslint/prefer-nullish-coalescing": [
+        "error",
+        { ignorePrimitives: { string: true } },
+      ],
+      "@typescript-eslint/prefer-optional-chain": "error",
+      "@typescript-eslint/no-unnecessary-condition": "error",
+      "@typescript-eslint/no-dynamic-delete": "off",
+      "@typescript-eslint/naming-convention": [
+        "error",
+        {
+          selector: "typeLike",
+          format: ["PascalCase"],
+        },
+      ],
+
+      // Allow empty catch blocks (used for graceful fallbacks)
+      "no-empty": ["error", { allowEmptyCatch: true }],
+    },
+  },
+
+  // ── Svelte files ────────────────────────────────────────────────────
+  {
+    files: ["src/**/*.svelte", "src/**/*.svelte.ts"],
+    languageOptions: {
+      globals: globals.browser,
+      parser: svelteParser,
+      parserOptions: {
+        parser: tseslint.parser,
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+        extraFileExtensions: [".svelte"],
+      },
+    },
+    rules: {
+      // ── Deny rules (same as TS) ──────────────────────────────────
+      "no-console": "error",
+      "no-debugger": "error",
+      "no-alert": "error",
+      "no-warning-comments": [
+        "error",
+        { terms: ["todo", "fixme", "hack", "xxx"], location: "start" },
+      ],
+      "no-var": "error",
+      eqeqeq: ["error", "always", { null: "ignore" }],
+      "no-implicit-coercion": "error",
+      "no-nested-ternary": "error",
+
+      "@typescript-eslint/no-explicit-any": "error",
+      "@typescript-eslint/no-unsafe-assignment": "error",
+      "@typescript-eslint/no-unsafe-call": "error",
+      "@typescript-eslint/no-unsafe-member-access": "error",
+      "@typescript-eslint/no-unsafe-return": "error",
+      "@typescript-eslint/no-unsafe-argument": "error",
+      "@typescript-eslint/no-floating-promises": "error",
+      "@typescript-eslint/no-misused-promises": "error",
+      "@typescript-eslint/only-throw-error": "error",
+      "@typescript-eslint/no-non-null-assertion": "error",
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
+      "@typescript-eslint/no-shadow": "error",
+      "@typescript-eslint/consistent-type-imports": [
+        "error",
+        { prefer: "type-imports" },
+      ],
+      "@typescript-eslint/restrict-template-expressions": [
+        "error",
+        { allowNumber: true },
+      ],
+
+      // ── Pedantic (subset — skip rules that fight runes) ──────────
+      "@typescript-eslint/switch-exhaustiveness-check": "error",
+      "@typescript-eslint/prefer-nullish-coalescing": [
+        "error",
+        { ignorePrimitives: { string: true } },
+      ],
+      "@typescript-eslint/prefer-optional-chain": "error",
+      "@typescript-eslint/no-dynamic-delete": "off",
+      "@typescript-eslint/naming-convention": [
+        "error",
+        {
+          selector: "typeLike",
+          format: ["PascalCase"],
+        },
+      ],
+
+      // ── Svelte-specific overrides (rules that fight runes) ───────
+      "prefer-const": "off",
+      "no-undef-init": "off",
+      "no-unused-expressions": "off",
+      "@typescript-eslint/no-unused-expressions": "off",
+      "no-param-reassign": "off",
+      "@typescript-eslint/explicit-function-return-type": "off",
+      "@typescript-eslint/strict-boolean-expressions": "off",
+      "@typescript-eslint/no-unnecessary-condition": "off",
+      "@typescript-eslint/no-unnecessary-type-arguments": "off",
+      "@typescript-eslint/no-confusing-void-expression": "off",
+      "@typescript-eslint/no-unsafe-assignment": "off",
+      "@typescript-eslint/no-unsafe-member-access": "off",
+      "@typescript-eslint/no-unsafe-call": "off",
+      "@typescript-eslint/no-unsafe-return": "off",
+      "@typescript-eslint/no-unsafe-argument": "off",
+      "@typescript-eslint/no-useless-default-assignment": "off",
+
+      // Allow empty catch blocks (used for graceful fallbacks)
+      "no-empty": ["error", { allowEmptyCatch: true }],
+
+      // ── Svelte plugin rules ──────────────────────────────────────
+      "svelte/no-at-html-tags": "error",
+      "svelte/require-each-key": "error",
+      "svelte/valid-compile": [
+        "error",
+        { ignoreWarnings: true },
+      ],
+      "svelte/no-dom-manipulating": "warn",
+      "svelte/no-reactive-reassign": "warn",
+    },
+  },
+);

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,9 +11,21 @@
         "smol-toml": "^1.6.0"
       },
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "@sveltejs/vite-plugin-svelte": "^5.0.0",
+        "@typescript-eslint/eslint-plugin": "^8.56.1",
+        "@typescript-eslint/parser": "^8.56.1",
+        "eslint": "^10.0.2",
+        "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-svelte": "^3.15.0",
+        "globals": "^17.4.0",
+        "prettier": "^3.8.1",
+        "prettier-plugin-svelte": "^3.5.1",
         "svelte": "^5.0.0",
+        "svelte-check": "^4.4.4",
+        "svelte-eslint-parser": "^1.5.1",
         "typescript": "^5.0.0",
+        "typescript-eslint": "^8.56.1",
         "vite": "^6.0.0"
       }
     },
@@ -457,6 +469,173 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.2.tgz",
+      "integrity": "sha512-YF+fE6LV4v5MGWRGj7G404/OZzGNepVF8fxk7jqmqo3lrza7a0uUcDnROGRBG1WFC1omYUS/Wp1f42i0M+3Q3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.2",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.2.tgz",
+      "integrity": "sha512-a5MxrdDXEvqnIq+LisyCX6tQMPF/dSJpCfBgBauY+pNZ28yCtSsTvyTYrMhaI+LK26bVyCJfJkT0u8KIj2i1dQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.0.tgz",
+      "integrity": "sha512-/nr9K9wkr3P1EzFTdFdMoLuo1PmIxjmwvPozwoSodjNBdefGujXQUF93u1DDZpEaTuDvMsIQddsd35BwtrW9Xw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.2.tgz",
+      "integrity": "sha512-HOy56KJt48Bx8KmJ+XGQNSUMT/6dZee/M54XyUyuvTvPXJmsERRvBchsUVx1UMe1WwIH49XLAczNC7V2INsuUw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.0.tgz",
+      "integrity": "sha512-bIZEUzOI1jkhviX2cp5vNyXQc6olzb2ohewQubuYlMXZ2Q/XjBO0x0XhGPvc9fjSIiUN0vw+0hq53BJ4eQSJKQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -909,10 +1088,24 @@
         "vite": "^6.0.0"
       }
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
     },
@@ -922,6 +1115,239 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz",
+      "integrity": "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/type-utils": "8.56.1",
+        "@typescript-eslint/utils": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.56.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz",
+      "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
+      "integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.56.1",
+        "@typescript-eslint/types": "^8.56.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
+      "integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
+      "integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.1.tgz",
+      "integrity": "sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1",
+        "@typescript-eslint/utils": "8.56.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
+      "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
+      "integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.56.1",
+        "@typescript-eslint/tsconfig-utils": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
+      "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
+      "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -934,6 +1360,33 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/aria-query": {
@@ -956,6 +1409,45 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -964,6 +1456,34 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/debug": {
@@ -983,6 +1503,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
@@ -1043,12 +1570,243 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.2.tgz",
+      "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.2",
+        "@eslint/config-helpers": "^0.5.2",
+        "@eslint/core": "^1.1.0",
+        "@eslint/plugin-kit": "^0.6.0",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.1",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.1.1",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-svelte": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-3.15.0.tgz",
+      "integrity": "sha512-QKB7zqfuB8aChOfBTComgDptMf2yxiJx7FE04nneCmtQzgTHvY8UJkuh8J2Rz7KB9FFV9aTHX6r7rdYGvG8T9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.6.1",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "esutils": "^2.0.3",
+        "globals": "^16.0.0",
+        "known-css-properties": "^0.37.0",
+        "postcss": "^8.4.49",
+        "postcss-load-config": "^3.1.4",
+        "postcss-safe-parser": "^7.0.0",
+        "semver": "^7.6.3",
+        "svelte-eslint-parser": "^1.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.1 || ^9.0.0 || ^10.0.0",
+        "svelte": "^3.37.0 || ^4.0.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "svelte": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-svelte/node_modules/globals": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.1.tgz",
+      "integrity": "sha512-GaUN0sWim5qc8KVErfPBWmc31LEsOkrUJbvJZV+xuL3u2phMUK4HIvXlWAakfC8W4nzlK+chPEAkYOYb5ZScIw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/esm-env": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
       "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/espree": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.1.1.tgz",
+      "integrity": "sha512-AVHPqQoZYc+RUM4/3Ly5udlZY/U4LS8pIG05jEjWM2lQMU/oaZ7qshzAl2YP1tfNmXfftH3ohurfwNAug+MnsQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/esrap": {
       "version": "2.2.3",
@@ -1059,6 +1817,60 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
       }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1078,6 +1890,57 @@
         }
       }
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.4.tgz",
+      "integrity": "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1093,6 +1956,75 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.4.0.tgz",
+      "integrity": "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-reference": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
@@ -1101,6 +2033,44 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.6"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
       }
     },
     "node_modules/kleur": {
@@ -1113,12 +2083,59 @@
         "node": ">=6"
       }
     },
+    "node_modules/known-css-properties": {
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.37.0.tgz",
+      "integrity": "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/locate-character": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
       "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -1128,6 +2145,32 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ms": {
@@ -1154,6 +2197,83 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/picocolors": {
@@ -1205,6 +2325,175 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-load-config": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.4.tgz",
+      "integrity": "sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^2.0.5",
+        "yaml": "^1.10.2"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": ">=8.0.9",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "postcss": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-load-config/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postcss-safe-parser": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz",
+      "integrity": "sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss-safe-parser"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.31"
+      }
+    },
+    "node_modules/postcss-scss": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.9.tgz",
+      "integrity": "sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss-scss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.29"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-svelte": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.5.1.tgz",
+      "integrity": "sha512-65+fr5+cgIKWKiqM1Doum4uX6bY8iFCdztvvp2RcF+AJoieaw9kJOFMNcJo/bkmKYsxFaM9OsVZK/gWauG/5mg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "prettier": "^3.0.0",
+        "svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
@@ -1248,6 +2537,55 @@
         "@rollup/rollup-win32-x64-gnu": "4.59.0",
         "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/smol-toml": {
@@ -1300,6 +2638,109 @@
         "node": ">=18"
       }
     },
+    "node_modules/svelte-check": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.4.4.tgz",
+      "integrity": "sha512-F1pGqXc710Oi/wTI4d/x7d6lgPwwfx1U6w3Q35n4xsC2e8C/yN2sM1+mWxjlMcpAfWucjlq4vPi+P4FZ8a14sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "chokidar": "^4.0.1",
+        "fdir": "^6.2.0",
+        "picocolors": "^1.0.0",
+        "sade": "^1.7.4"
+      },
+      "bin": {
+        "svelte-check": "bin/svelte-check"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "svelte": "^4.0.0 || ^5.0.0-next.0",
+        "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/svelte-eslint-parser": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-1.5.1.tgz",
+      "integrity": "sha512-UbY7DYoDg+x4AKLUcX5xWuEWylgmm8ZD2Z89YT/AK6Wm/ckeMTnOMwr6AVC99znXbRC26xzWEPhSgmB62E07Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-scope": "^8.2.0",
+        "eslint-visitor-keys": "^4.0.0",
+        "espree": "^10.0.0",
+        "postcss": "^8.4.49",
+        "postcss-scss": "^4.0.9",
+        "postcss-selector-parser": "^7.0.0",
+        "semver": "^7.7.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0",
+        "pnpm": "10.30.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      },
+      "peerDependencies": {
+        "svelte": "^3.37.0 || ^4.0.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "svelte": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/svelte-eslint-parser/node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/svelte-eslint-parser/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/svelte-eslint-parser/node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -1317,6 +2758,32 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
+      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -1330,6 +2797,47 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.56.1.tgz",
+      "integrity": "sha512-U4lM6pjmBX7J5wk4szltF7I1cGBHXZopnAXCMXb3+fZ3B/0Z3hq3wS/CCUB2NZBNAExK92mCU2tEohWuwVMsDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.56.1",
+        "@typescript-eslint/parser": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1",
+        "@typescript-eslint/utils": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "6.4.1",
@@ -1424,6 +2932,63 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zimmerframe": {

--- a/web/package.json
+++ b/web/package.json
@@ -6,12 +6,29 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "check": "svelte-check --tsconfig ./tsconfig.json",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write 'src/**/*.{ts,svelte,js,json,css}'",
+    "format:check": "prettier --check 'src/**/*.{ts,svelte,js,json,css}'"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@sveltejs/vite-plugin-svelte": "^5.0.0",
+    "@typescript-eslint/eslint-plugin": "^8.56.1",
+    "@typescript-eslint/parser": "^8.56.1",
+    "eslint": "^10.0.2",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-svelte": "^3.15.0",
+    "globals": "^17.4.0",
+    "prettier": "^3.8.1",
+    "prettier-plugin-svelte": "^3.5.1",
     "svelte": "^5.0.0",
+    "svelte-check": "^4.4.4",
+    "svelte-eslint-parser": "^1.5.1",
     "typescript": "^5.0.0",
+    "typescript-eslint": "^8.56.1",
     "vite": "^6.0.0"
   },
   "dependencies": {

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -44,7 +44,11 @@
       <span class="header-title">Residuum</span>
     </div>
   </div>
-  <Setup onComplete={() => { mode = "running"; }} />
+  <Setup
+    onComplete={() => {
+      mode = "running";
+    }}
+  />
 {:else}
   <Header
     status={ws.status}
@@ -54,7 +58,11 @@
     onToggleSettings={handleToggleSettings}
   />
   {#if showSettings}
-    <Settings onClose={() => { showSettings = false; }} />
+    <Settings
+      onClose={() => {
+        showSettings = false;
+      }}
+    />
   {:else}
     <Chat />
   {/if}

--- a/web/src/Chat.svelte
+++ b/web/src/Chat.svelte
@@ -48,13 +48,6 @@
 </script>
 
 <div class="chat-view">
-  <ChatFeed
-    items={ws.feed}
-    isProcessing={ws.isProcessing}
-    verbose={ws.verbose}
-  />
-  <ChatInput
-    onSend={handleSend}
-    disabled={ws.status !== "connected"}
-  />
+  <ChatFeed items={ws.feed} isProcessing={ws.isProcessing} verbose={ws.verbose} />
+  <ChatInput onSend={handleSend} disabled={ws.status !== "connected"} />
 </div>

--- a/web/src/Settings.svelte
+++ b/web/src/Settings.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import type { SettingsSection, McpServerEntry, SettingsProviderEntry, SettingsModelAssignments } from "./lib/types";
+  import type {
+    SettingsSection,
+    McpServerEntry,
+    SettingsProviderEntry,
+    SettingsModelAssignments,
+  } from "./lib/types";
   import {
     fetchConfigRaw,
     fetchProvidersRaw,
@@ -59,7 +64,7 @@
   let mcpServers = $state<McpServerEntry[]>([]);
 
   // Secrets tracking
-  let existingSecrets = $state<string[]>([]);
+  let _existingSecrets = $state<string[]>([]);
 
   // ── Sidebar ────────────────────────────────────────────────────────
 
@@ -84,11 +89,11 @@
       rawConfig = cfgRaw;
       rawProviders = provRaw;
       rawMcp = mcpRaw;
-      existingSecrets = secrets;
+      _existingSecrets = secrets;
 
       parseAllToForm();
-    } catch (err) {
-      validationMsg = `Failed to load settings: ${err}`;
+    } catch (err: unknown) {
+      validationMsg = `Failed to load settings: ${String(err)}`;
       validationKind = "error";
     } finally {
       loading = false;
@@ -146,8 +151,8 @@
       }
       validationMsg = "Reloaded from disk.";
       validationKind = "success";
-    } catch (err) {
-      validationMsg = `Reload failed: ${err}`;
+    } catch (err: unknown) {
+      validationMsg = `Reload failed: ${String(err)}`;
       validationKind = "error";
     } finally {
       loading = false;
@@ -176,22 +181,22 @@
       // Validate providers first (config validation reads it from disk)
       const provResult = await validateProviders(provToml);
       if (!provResult.valid) {
-        validationMsg = `providers.toml: ${provResult.error}`;
+        validationMsg = `providers.toml: ${provResult.error ?? "unknown error"}`;
         validationKind = "error";
         return;
       }
 
       const cfgResult = await validateConfig(cfgToml);
       if (!cfgResult.valid) {
-        validationMsg = `config.toml: ${cfgResult.error}`;
+        validationMsg = `config.toml: ${cfgResult.error ?? "unknown error"}`;
         validationKind = "error";
         return;
       }
 
       validationMsg = "Configuration is valid.";
       validationKind = "success";
-    } catch (err) {
-      validationMsg = `Validation error: ${err}`;
+    } catch (err: unknown) {
+      validationMsg = `Validation error: ${String(err)}`;
       validationKind = "error";
     } finally {
       saving = false;
@@ -225,21 +230,21 @@
       // Save providers.toml first (config validation reads it from disk)
       const provResult = await putProvidersRaw(provToml);
       if (!provResult.valid) {
-        validationMsg = `providers.toml: ${provResult.error}`;
+        validationMsg = `providers.toml: ${provResult.error ?? "unknown error"}`;
         validationKind = "error";
         return;
       }
 
       const cfgResult = await putConfigRaw(cfgToml);
       if (!cfgResult.valid) {
-        validationMsg = `config.toml: ${cfgResult.error}`;
+        validationMsg = `config.toml: ${cfgResult.error ?? "unknown error"}`;
         validationKind = "error";
         return;
       }
 
       const mcpResult = await putMcpRaw(mcpJson);
       if (!mcpResult.valid) {
-        validationMsg = `mcp.json: ${mcpResult.error}`;
+        validationMsg = `mcp.json: ${mcpResult.error ?? "unknown error"}`;
         validationKind = "error";
         return;
       }
@@ -251,8 +256,8 @@
 
       validationMsg = "Settings saved and applied.";
       validationKind = "success";
-    } catch (err) {
-      validationMsg = `Save failed: ${err}`;
+    } catch (err: unknown) {
+      validationMsg = `Save failed: ${String(err)}`;
       validationKind = "error";
     } finally {
       saving = false;
@@ -263,7 +268,10 @@
 
   async function storeNewSecrets() {
     // Collect secrets that need storing (non-empty, non-secret: values)
-    const secretOps: { field: "discord_token" | "telegram_token" | "webhook_secret"; name: string }[] = [];
+    const secretOps: {
+      field: "discord_token" | "telegram_token" | "webhook_secret";
+      name: string;
+    }[] = [];
 
     const secretFields = [
       { field: "discord_token" as const, name: "discord" },
@@ -282,7 +290,7 @@
     const provKeyOps: { idx: number; name: string }[] = [];
     for (let i = 0; i < providerEntries.length; i++) {
       const p = providerEntries[i];
-      if (p.apiKey && !p.apiKey.startsWith("secret:") && p.type !== "ollama") {
+      if (p?.apiKey && !p.apiKey.startsWith("secret:") && p.type !== "ollama") {
         provKeyOps.push({ idx: i, name: p.name });
       }
     }
@@ -294,8 +302,10 @@
     }
 
     for (const { idx, name } of provKeyOps) {
-      const result = await storeSecret(name, providerEntries[idx].apiKey);
-      providerEntries[idx].apiKey = result.reference;
+      const entry = providerEntries[idx];
+      if (!entry) continue;
+      const result = await storeSecret(name, entry.apiKey);
+      entry.apiKey = result.reference;
     }
   }
 </script>
@@ -319,11 +329,13 @@
   <div class="settings-body">
     {#if !advancedMode}
       <div class="settings-sidebar">
-        {#each sections as sec}
+        {#each sections as sec (sec.id)}
           <button
             class="settings-sidebar-btn"
             class:active={activeSection === sec.id}
-            onclick={() => { activeSection = sec.id; }}
+            onclick={() => {
+              activeSection = sec.id;
+            }}
           >
             {sec.label}
           </button>
@@ -337,9 +349,27 @@
       {:else if advancedMode}
         <!-- Advanced tabbed editor -->
         <div class="advanced-tabs">
-          <button class="advanced-tab" class:active={advancedTab === "config"} onclick={() => { advancedTab = "config"; }}>config.toml</button>
-          <button class="advanced-tab" class:active={advancedTab === "providers"} onclick={() => { advancedTab = "providers"; }}>providers.toml</button>
-          <button class="advanced-tab" class:active={advancedTab === "mcp"} onclick={() => { advancedTab = "mcp"; }}>mcp.json</button>
+          <button
+            class="advanced-tab"
+            class:active={advancedTab === "config"}
+            onclick={() => {
+              advancedTab = "config";
+            }}>config.toml</button
+          >
+          <button
+            class="advanced-tab"
+            class:active={advancedTab === "providers"}
+            onclick={() => {
+              advancedTab = "providers";
+            }}>providers.toml</button
+          >
+          <button
+            class="advanced-tab"
+            class:active={advancedTab === "mcp"}
+            onclick={() => {
+              advancedTab = "mcp";
+            }}>mcp.json</button
+          >
         </div>
         {#if advancedTab === "config"}
           <textarea class="toml-editor" bind:value={editConfig}></textarea>

--- a/web/src/Setup.svelte
+++ b/web/src/Setup.svelte
@@ -19,7 +19,7 @@
   let step = $state(0);
   let catalog = $state<McpCatalogEntry[]>([]);
 
-  let state = $state<SetupWizardState>({
+  let wizardState = $state<SetupWizardState>({
     userName: "",
     timezone: "",
     selectedProviders: ["anthropic"] as ProviderKey[],
@@ -48,7 +48,7 @@
 
   onMount(async () => {
     const [tz, cat] = await Promise.all([fetchTimezone(), fetchMcpCatalog()]);
-    state.timezone = tz;
+    wizardState.timezone = tz;
     catalog = cat;
   });
 
@@ -65,27 +65,23 @@
   <div class="setup-body">
     <div class="setup-card">
       <div class="setup-step-indicator">
-        {#each Array(TOTAL_STEPS) as _, i}
-          <div
-            class="step-dot"
-            class:active={i === step}
-            class:done={i < step}
-          ></div>
+        {#each Array(TOTAL_STEPS) as _, i (i)}
+          <div class="step-dot" class:active={i === step} class:done={i < step}></div>
         {/each}
       </div>
 
       {#if step === 0}
-        <Welcome wizardState={state} onNext={next} />
+        <Welcome {wizardState} onNext={next} />
       {:else if step === 1}
-        <Providers wizardState={state} onNext={next} onBack={back} />
+        <Providers {wizardState} onNext={next} onBack={back} />
       {:else if step === 2}
-        <Roles wizardState={state} onNext={next} onBack={back} />
+        <Roles {wizardState} onNext={next} onBack={back} />
       {:else if step === 3}
-        <MCP wizardState={state} {catalog} onNext={next} onBack={back} />
+        <MCP {wizardState} {catalog} onNext={next} onBack={back} />
       {:else if step === 4}
-        <Integrations wizardState={state} onNext={next} onBack={back} />
+        <Integrations {wizardState} onNext={next} onBack={back} />
       {:else if step === 5}
-        <Review wizardState={state} onBack={back} {onComplete} />
+        <Review {wizardState} onBack={back} {onComplete} />
       {/if}
     </div>
   </div>

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -1,1517 +1,1640 @@
 /* ── Residuum Web UI — Stone + Vein Theme ─────────────────────────────── */
 
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=JetBrains+Mono:wght@400;500&family=Literata:ital,opsz,wght@0,7..72,300..700;1,7..72,300..700&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=JetBrains+Mono:wght@400;500&family=Literata:ital,opsz,wght@0,7..72,300..700;1,7..72,300..700&display=swap");
 
 :root {
-    /* Stone + Vein palette */
-    --bg-deep: #0e0e10;
-    --bg-surface: #161618;
-    --bg-raised: #1c1c1f;
-    --bg-input: #141416;
+  /* Stone + Vein palette */
+  --bg-deep: #0e0e10;
+  --bg-surface: #161618;
+  --bg-raised: #1c1c1f;
+  --bg-input: #141416;
 
-    --border: #2a2a2e;
-    --border-subtle: #222225;
+  --border: #2a2a2e;
+  --border-subtle: #222225;
 
-    --text: #e8e8ea;
-    --text-muted: #9a9a9f;
-    --text-dim: #6a6a6f;
+  --text: #e8e8ea;
+  --text-muted: #9a9a9f;
+  --text-dim: #6a6a6f;
 
-    --ember: #3b8bdb;
-    --ember-bright: #5aa3f0;
-    --ember-glow: rgba(59, 139, 219, 0.15);
-    --ember-dim: #2a6cb5;
+  --ember: #3b8bdb;
+  --ember-bright: #5aa3f0;
+  --ember-glow: rgba(59, 139, 219, 0.15);
+  --ember-dim: #2a6cb5;
 
-    --steel: #6b7a4a;
-    --steel-dim: #7a7d6e;
+  --steel: #6b7a4a;
+  --steel-dim: #7a7d6e;
 
-    --error: #c0392b;
-    --error-bg: rgba(192, 57, 43, 0.1);
-    --success: #2ecc71;
+  --error: #c0392b;
+  --error-bg: rgba(192, 57, 43, 0.1);
+  --success: #2ecc71;
 
-    /* Card tints */
-    --card-user: rgba(107, 122, 74, 0.14);
-    --card-assistant: rgba(59, 139, 219, 0.10);
-    --card-shadow: 0 1px 4px rgba(0, 0, 0, 0.25), 0 0 1px rgba(0, 0, 0, 0.15);
-    --card-shadow-hover: 0 2px 8px rgba(0, 0, 0, 0.35), 0 0 1px rgba(0, 0, 0, 0.2);
+  /* Card tints */
+  --card-user: rgba(107, 122, 74, 0.14);
+  --card-assistant: rgba(59, 139, 219, 0.1);
+  --card-shadow: 0 1px 4px rgba(0, 0, 0, 0.25), 0 0 1px rgba(0, 0, 0, 0.15);
+  --card-shadow-hover: 0 2px 8px rgba(0, 0, 0, 0.35), 0 0 1px rgba(0, 0, 0, 0.2);
 
-    /* Glow effects */
-    --ember-ring: 0 0 0 1px rgba(59, 139, 219, 0.2), 0 0 0 3px rgba(59, 139, 219, 0.07);
-    --input-inset: inset 0 1px 3px rgba(0, 0, 0, 0.3);
+  /* Glow effects */
+  --ember-ring: 0 0 0 1px rgba(59, 139, 219, 0.2), 0 0 0 3px rgba(59, 139, 219, 0.07);
+  --input-inset: inset 0 1px 3px rgba(0, 0, 0, 0.3);
 
-    /* Typography */
-    --font-display: 'Cinzel', 'Georgia', serif;
-    --font-body: 'Literata', 'Georgia', serif;
-    --font-mono: 'JetBrains Mono', 'Fira Code', 'SF Mono', 'Cascadia Code', 'Consolas', monospace;
+  /* Typography */
+  --font-display: "Cinzel", "Georgia", serif;
+  --font-body: "Literata", "Georgia", serif;
+  --font-mono: "JetBrains Mono", "Fira Code", "SF Mono", "Cascadia Code", "Consolas", monospace;
 
-    /* Sizing */
-    --chat-max-width: 760px;
-    --header-height: 52px;
-    --input-height: 56px;
-    --radius: 6px;
-    --radius-sm: 4px;
+  /* Sizing */
+  --chat-max-width: 760px;
+  --header-height: 52px;
+  --input-height: 56px;
+  --radius: 6px;
+  --radius-sm: 4px;
 
-    /* Motion */
-    --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
+  /* Motion */
+  --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 /* ── Reset ─────────────────────────────────────────────────────────────── */
 
-*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
 
-html, body {
-    height: 100%;
-    font-family: var(--font-body);
-    font-size: 15px;
-    font-weight: 400;
-    line-height: 1.6;
-    color: var(--text);
-    background: var(--bg-deep);
-    -webkit-font-smoothing: antialiased;
+html,
+body {
+  height: 100%;
+  font-family: var(--font-body);
+  font-size: 15px;
+  font-weight: 400;
+  line-height: 1.6;
+  color: var(--text);
+  background: var(--bg-deep);
+  -webkit-font-smoothing: antialiased;
 }
 
 /* ── Grain texture overlay ─────────────────────────────────────────────── */
 
 body::before {
-    content: '';
-    position: fixed;
-    inset: 0;
-    pointer-events: none;
-    z-index: 9999;
-    opacity: 0.025;
-    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
-    background-size: 256px 256px;
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 9999;
+  opacity: 0.025;
+  background: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  background-size: 256px 256px;
 }
 
 /* ── Layout ────────────────────────────────────────────────────────────── */
 
 #app {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }
 
 /* ── Header ────────────────────────────────────────────────────────────── */
 
 .header {
-    display: flex;
-    align-items: center;
-    height: var(--header-height);
-    padding: 0 16px;
-    border-bottom: 1px solid var(--border-subtle);
-    background: linear-gradient(180deg, #1a1a1e 0%, var(--bg-surface) 100%);
-    box-shadow: 0 1px 6px rgba(0, 0, 0, 0.3), 0 1px 0 rgba(59, 139, 219, 0.08);
-    flex-shrink: 0;
-    gap: 10px;
-    position: relative;
-    z-index: 10;
+  display: flex;
+  align-items: center;
+  height: var(--header-height);
+  padding: 0 16px;
+  border-bottom: 1px solid var(--border-subtle);
+  background: linear-gradient(180deg, #1a1a1e 0%, var(--bg-surface) 100%);
+  box-shadow:
+    0 1px 6px rgba(0, 0, 0, 0.3),
+    0 1px 0 rgba(59, 139, 219, 0.08);
+  flex-shrink: 0;
+  gap: 10px;
+  position: relative;
+  z-index: 10;
 }
 
 .header-brand {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
 }
 
 .header-icon {
-    width: 28px;
-    height: 28px;
-    border-radius: var(--radius-sm);
-    background: var(--ember-glow);
-    border: 1px solid var(--ember-dim);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 16px;
-    color: var(--ember);
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-sm);
+  background: var(--ember-glow);
+  border: 1px solid var(--ember-dim);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  color: var(--ember);
 }
 
 .header-title {
-    font-family: var(--font-display);
-    font-size: 16px;
-    font-weight: 700;
-    letter-spacing: 0.06em;
-    color: var(--text);
+  font-family: var(--font-display);
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: var(--text);
 }
 
 .header-status {
-    font-size: 11px;
-    color: var(--text-dim);
-    padding: 2px 8px;
-    border-radius: 10px;
-    border: 1px solid var(--border-subtle);
+  font-size: 11px;
+  color: var(--text-dim);
+  padding: 2px 8px;
+  border-radius: 10px;
+  border: 1px solid var(--border-subtle);
 }
 
-.header-status.connected { color: var(--success); border-color: rgba(46, 204, 113, 0.3); }
-.header-status.disconnected { color: var(--error); border-color: rgba(192, 57, 43, 0.3); }
-.header-status.connecting { color: var(--ember); border-color: rgba(59, 139, 219, 0.3); }
+.header-status.connected {
+  color: var(--success);
+  border-color: rgba(46, 204, 113, 0.3);
+}
+.header-status.disconnected {
+  color: var(--error);
+  border-color: rgba(192, 57, 43, 0.3);
+}
+.header-status.connecting {
+  color: var(--ember);
+  border-color: rgba(59, 139, 219, 0.3);
+}
 
 .header-actions {
-    display: flex;
-    gap: 6px;
+  display: flex;
+  gap: 6px;
 }
 
 .icon-btn {
-    width: 34px;
-    height: 34px;
-    border-radius: var(--radius-sm);
-    border: 1px solid var(--border-subtle);
-    background: transparent;
-    color: var(--text-muted);
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 16px;
-    transition: all 0.15s;
+  width: 34px;
+  height: 34px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-subtle);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  transition: all 0.15s;
 }
 
 .icon-btn:hover {
-    background: var(--bg-raised);
-    color: var(--text);
-    border-color: var(--border);
+  background: var(--bg-raised);
+  color: var(--text);
+  border-color: var(--border);
 }
 
 .icon-btn.active {
-    background: var(--ember-glow);
-    color: var(--ember);
-    border-color: var(--ember-dim);
+  background: var(--ember-glow);
+  color: var(--ember);
+  border-color: var(--ember-dim);
 }
 
 /* ── Chat view ─────────────────────────────────────────────────────────── */
 
 .chat-view {
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-    overflow: hidden;
-    position: relative;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  overflow: hidden;
+  position: relative;
 }
 
 .chat-feed {
-    flex: 1;
-    overflow-y: auto;
-    padding: 16px 16px 96px;
-    scroll-behavior: smooth;
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 16px 96px;
+  scroll-behavior: smooth;
 }
 
 .chat-feed-inner {
-    max-width: var(--chat-max-width);
-    margin: 0 auto;
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
+  max-width: var(--chat-max-width);
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
 /* ── Messages ──────────────────────────────────────────────────────────── */
 
 .msg {
-    padding: 12px 16px;
-    border-radius: var(--radius);
-    max-width: 100%;
-    word-wrap: break-word;
-    overflow-wrap: break-word;
-    animation: msg-enter 0.35s var(--ease-out-expo) both;
-    position: relative;
+  padding: 12px 16px;
+  border-radius: var(--radius);
+  max-width: 100%;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  animation: msg-enter 0.35s var(--ease-out-expo) both;
+  position: relative;
 }
 
 @keyframes msg-enter {
-    from {
-        opacity: 0;
-        transform: translateY(6px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .msg-user {
-    background: var(--card-user);
-    border: 1px solid rgba(107, 122, 74, 0.25);
-    margin-top: 10px;
-    box-shadow: var(--card-shadow);
-    align-self: flex-end;
-    max-width: 80%;
-    border-radius: 18px 18px 4px 18px;
+  background: var(--card-user);
+  border: 1px solid rgba(107, 122, 74, 0.25);
+  margin-top: 10px;
+  box-shadow: var(--card-shadow);
+  align-self: flex-end;
+  max-width: 80%;
+  border-radius: 18px 18px 4px 18px;
 }
 
 .msg-assistant {
-    background: var(--card-assistant);
-    border: 1px solid rgba(59, 139, 219, 0.18);
-    box-shadow: var(--card-shadow);
-    align-self: flex-start;
-    border-radius: 18px 18px 18px 4px;
+  background: var(--card-assistant);
+  border: 1px solid rgba(59, 139, 219, 0.18);
+  box-shadow: var(--card-shadow);
+  align-self: flex-start;
+  border-radius: 18px 18px 18px 4px;
 }
 
 .msg-system {
-    font-size: 12px;
-    color: var(--text-dim);
-    padding: 6px 14px;
-    margin-top: 8px;
-    font-style: italic;
-    border-left: 3px solid var(--border-subtle);
+  font-size: 12px;
+  color: var(--text-dim);
+  padding: 6px 14px;
+  margin-top: 8px;
+  font-style: italic;
+  border-left: 3px solid var(--border-subtle);
 }
 
 .msg-divider {
-    font-size: 11px;
-    color: var(--text-dim);
-    text-align: center;
-    padding: 4px 0;
-    margin: 12px 0;
-    border-top: 1px solid var(--border-subtle);
-    border-bottom: 1px solid var(--border-subtle);
-    letter-spacing: 0.5px;
+  font-size: 11px;
+  color: var(--text-dim);
+  text-align: center;
+  padding: 4px 0;
+  margin: 12px 0;
+  border-top: 1px solid var(--border-subtle);
+  border-bottom: 1px solid var(--border-subtle);
+  letter-spacing: 0.5px;
 }
 
 .msg-error {
-    background: var(--error-bg);
-    border-left: 3px solid var(--error);
-    color: #e8a0a0;
-    margin-top: 8px;
+  background: var(--error-bg);
+  border-left: 3px solid var(--error);
+  color: #e8a0a0;
+  margin-top: 8px;
 }
 
 .msg-notice {
-    font-size: 12px;
-    font-family: var(--font-mono);
-    color: var(--text-muted);
-    padding: 6px 14px;
-    margin-top: 8px;
-    border-left: 3px solid var(--steel-dim);
-    white-space: pre-wrap;
+  font-size: 12px;
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  padding: 6px 14px;
+  margin-top: 8px;
+  border-left: 3px solid var(--steel-dim);
+  white-space: pre-wrap;
 }
 
 .msg-content {
-    line-height: 1.6;
+  line-height: 1.6;
 }
 
-.msg-content p { margin-bottom: 8px; }
-.msg-content p:last-child { margin-bottom: 0; }
+.msg-content p {
+  margin-bottom: 8px;
+}
+.msg-content p:last-child {
+  margin-bottom: 0;
+}
 
 .msg-content code {
-    font-family: var(--font-mono);
-    font-size: 0.9em;
-    background: var(--bg-deep);
-    padding: 1px 5px;
-    border-radius: 3px;
-    border: 1px solid var(--border-subtle);
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+  background: var(--bg-deep);
+  padding: 1px 5px;
+  border-radius: 3px;
+  border: 1px solid var(--border-subtle);
 }
 
 .msg-content pre {
-    margin: 8px 0;
-    padding: 10px 12px;
-    background: var(--bg-deep);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    overflow-x: auto;
-    font-family: var(--font-mono);
-    font-size: 12.5px;
-    line-height: 1.5;
+  margin: 8px 0;
+  padding: 10px 12px;
+  background: var(--bg-deep);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  line-height: 1.5;
 }
 
 .msg-content pre code {
-    background: none;
-    padding: 0;
-    border: none;
-    font-size: inherit;
+  background: none;
+  padding: 0;
+  border: none;
+  font-size: inherit;
 }
 
 .msg-content h2,
 .msg-content h3,
 .msg-content h4 {
-    font-family: var(--font-display);
-    letter-spacing: 0.03em;
-    margin: 12px 0 6px;
-    color: var(--text);
+  font-family: var(--font-display);
+  letter-spacing: 0.03em;
+  margin: 12px 0 6px;
+  color: var(--text);
 }
 
-.msg-content h2 { font-size: 1.15em; font-weight: 700; }
-.msg-content h3 { font-size: 1.05em; font-weight: 600; }
-.msg-content h4 { font-size: 1em; font-weight: 600; color: var(--text-muted); }
+.msg-content h2 {
+  font-size: 1.15em;
+  font-weight: 700;
+}
+.msg-content h3 {
+  font-size: 1.05em;
+  font-weight: 600;
+}
+.msg-content h4 {
+  font-size: 1em;
+  font-weight: 600;
+  color: var(--text-muted);
+}
 
 .msg-content blockquote {
-    border-left: 3px solid var(--ember-dim);
-    padding: 6px 12px;
-    margin: 8px 0;
-    color: var(--text-muted);
-    background: rgba(59, 139, 219, 0.03);
-    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  border-left: 3px solid var(--ember-dim);
+  padding: 6px 12px;
+  margin: 8px 0;
+  color: var(--text-muted);
+  background: rgba(59, 139, 219, 0.03);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
 }
 
 .msg-content ul,
 .msg-content ol {
-    padding-left: 20px;
-    margin: 6px 0;
+  padding-left: 20px;
+  margin: 6px 0;
 }
 
 .msg-content li {
-    margin-bottom: 3px;
+  margin-bottom: 3px;
 }
 
 .msg-content ul li::marker {
-    color: var(--ember-dim);
+  color: var(--ember-dim);
 }
 
 .msg-content ol li::marker {
-    color: var(--ember-dim);
-    font-weight: 600;
+  color: var(--ember-dim);
+  font-weight: 600;
 }
 
 .msg-content a {
-    color: var(--ember-bright);
-    text-decoration: none;
-    border-bottom: 1px solid transparent;
-    transition: border-color 0.15s;
+  color: var(--ember-bright);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color 0.15s;
 }
 
 .msg-content a:hover {
-    border-bottom-color: var(--ember-bright);
+  border-bottom-color: var(--ember-bright);
 }
 
 .msg-content hr {
-    border: none;
-    height: 1px;
-    background: linear-gradient(90deg, transparent, var(--border), transparent);
-    margin: 12px 0;
+  border: none;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--border), transparent);
+  margin: 12px 0;
 }
 
 /* ── Tool calls ────────────────────────────────────────────────────────── */
 
 .tool-group {
-    margin-top: 4px;
+  margin-top: 4px;
 }
 
 .tool-item {
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    margin-bottom: 4px;
-    overflow: hidden;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  margin-bottom: 4px;
+  overflow: hidden;
 }
 
 .tool-header {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 6px 10px;
-    background: var(--bg-surface);
-    cursor: pointer;
-    font-size: 12px;
-    font-family: var(--font-mono);
-    color: var(--text-muted);
-    user-select: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  background: var(--bg-surface);
+  cursor: pointer;
+  font-size: 12px;
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  user-select: none;
 }
 
-.tool-header:hover { background: var(--bg-raised); }
+.tool-header:hover {
+  background: var(--bg-raised);
+}
 
 .tool-chevron {
-    font-size: 10px;
-    transition: transform 0.15s;
-    color: var(--text-dim);
+  font-size: 10px;
+  transition: transform 0.15s;
+  color: var(--text-dim);
 }
 
-.tool-item.open .tool-chevron { transform: rotate(90deg); }
+.tool-item.open .tool-chevron {
+  transform: rotate(90deg);
+}
 
-.tool-name { color: var(--ember); font-weight: 500; }
+.tool-name {
+  color: var(--ember);
+  font-weight: 500;
+}
 
-.tool-status { margin-left: auto; font-size: 11px; }
-.tool-status.ok { color: var(--success); }
-.tool-status.err { color: var(--error); }
+.tool-status {
+  margin-left: auto;
+  font-size: 11px;
+}
+.tool-status.ok {
+  color: var(--success);
+}
+.tool-status.err {
+  color: var(--error);
+}
 
 .tool-body {
-    display: none;
-    padding: 8px 10px;
-    font-family: var(--font-mono);
-    font-size: 12px;
-    line-height: 1.45;
-    background: var(--bg-deep);
-    max-height: 300px;
-    overflow-y: auto;
-    white-space: pre-wrap;
-    color: var(--text-muted);
-    border-top: 1px solid var(--border-subtle);
+  display: none;
+  padding: 8px 10px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.45;
+  background: var(--bg-deep);
+  max-height: 300px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  color: var(--text-muted);
+  border-top: 1px solid var(--border-subtle);
 }
 
-.tool-item.open .tool-body { display: block; }
+.tool-item.open .tool-body {
+  display: block;
+}
 
 /* ── Thinking indicator (vein-pulse bars) ─────────────────────────────── */
 
 .thinking {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    padding: 10px 14px;
-    color: var(--text-dim);
-    font-size: 13px;
-    animation: msg-enter 0.3s var(--ease-out-expo) both;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  color: var(--text-dim);
+  font-size: 13px;
+  animation: msg-enter 0.3s var(--ease-out-expo) both;
 }
 
 .thinking-bars {
-    display: flex;
-    align-items: flex-end;
-    gap: 3px;
-    height: 16px;
+  display: flex;
+  align-items: flex-end;
+  gap: 3px;
+  height: 16px;
 }
 
 .thinking-bars span {
-    display: block;
-    width: 3px;
-    border-radius: 1.5px;
-    background: var(--ember);
-    animation: vein-pulse 1.2s ease-in-out infinite;
+  display: block;
+  width: 3px;
+  border-radius: 1.5px;
+  background: var(--ember);
+  animation: vein-pulse 1.2s ease-in-out infinite;
 }
 
 .thinking-bars span:nth-child(1) {
-    animation-delay: 0s;
-    height: 8px;
+  animation-delay: 0s;
+  height: 8px;
 }
 
 .thinking-bars span:nth-child(2) {
-    animation-delay: 0.15s;
-    height: 14px;
+  animation-delay: 0.15s;
+  height: 14px;
 }
 
 .thinking-bars span:nth-child(3) {
-    animation-delay: 0.3s;
-    height: 10px;
+  animation-delay: 0.3s;
+  height: 10px;
 }
 
 @keyframes vein-pulse {
-    0%, 100% {
-        opacity: 0.35;
-        height: 4px;
-        background: var(--ember-dim);
-    }
-    50% {
-        opacity: 1;
-        height: 16px;
-        background: var(--ember-bright);
-    }
+  0%,
+  100% {
+    opacity: 0.35;
+    height: 4px;
+    background: var(--ember-dim);
+  }
+  50% {
+    opacity: 1;
+    height: 16px;
+    background: var(--ember-bright);
+  }
 }
 
 /* ── Input area ────────────────────────────────────────────────────────── */
 
 .chat-input-area {
-    position: absolute;
-    bottom: 16px;
-    left: 50%;
-    transform: translateX(-50%);
-    width: calc(100% - 32px);
-    max-width: var(--chat-max-width);
-    padding: 0;
-    background: transparent;
-    flex-shrink: 0;
-    z-index: 20;
+  position: absolute;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: calc(100% - 32px);
+  max-width: var(--chat-max-width);
+  padding: 0;
+  background: transparent;
+  flex-shrink: 0;
+  z-index: 20;
 }
 
 .chat-input-wrap {
-    display: flex;
-    gap: 8px;
-    align-items: flex-end;
-    background: var(--bg-surface);
-    border: 1px solid var(--border);
-    border-radius: 16px;
-    padding: 8px 8px 8px 4px;
-    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(255, 255, 255, 0.03);
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 8px 8px 8px 4px;
+  box-shadow:
+    0 4px 24px rgba(0, 0, 0, 0.4),
+    0 0 0 1px rgba(255, 255, 255, 0.03);
 }
 
 .chat-input {
-    flex: 1;
-    min-height: 44px;
-    max-height: 160px;
-    padding: 10px 14px;
-    font-family: var(--font-body);
-    font-size: 14px;
-    color: var(--text);
-    background: transparent;
-    border: none;
-    border-radius: 12px;
-    resize: none;
-    outline: none;
-    line-height: 1.5;
-    transition: background 0.2s;
+  flex: 1;
+  min-height: 44px;
+  max-height: 160px;
+  padding: 10px 14px;
+  font-family: var(--font-body);
+  font-size: 14px;
+  color: var(--text);
+  background: transparent;
+  border: none;
+  border-radius: 12px;
+  resize: none;
+  outline: none;
+  line-height: 1.5;
+  transition: background 0.2s;
 }
 
 .chat-input:focus {
-    background: rgba(255, 255, 255, 0.02);
+  background: rgba(255, 255, 255, 0.02);
 }
 
-.chat-input::placeholder { color: var(--text-dim); }
+.chat-input::placeholder {
+  color: var(--text-dim);
+}
 
 .send-btn {
-    height: 44px;
-    padding: 0 20px;
-    font-family: var(--font-display);
-    font-size: 13px;
-    font-weight: 600;
-    letter-spacing: 0.04em;
-    color: var(--bg-deep);
-    background: var(--ember);
-    border: none;
-    border-radius: 12px;
-    cursor: pointer;
-    box-shadow: 0 2px 6px rgba(59, 139, 219, 0.25);
-    transition: all 0.2s var(--ease-out-expo);
-    white-space: nowrap;
+  height: 44px;
+  padding: 0 20px;
+  font-family: var(--font-display);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--bg-deep);
+  background: var(--ember);
+  border: none;
+  border-radius: 12px;
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(59, 139, 219, 0.25);
+  transition: all 0.2s var(--ease-out-expo);
+  white-space: nowrap;
 }
 
 .send-btn:hover {
-    background: var(--ember-bright);
-    box-shadow: 0 4px 12px rgba(59, 139, 219, 0.35);
-    transform: translateY(-1px);
+  background: var(--ember-bright);
+  box-shadow: 0 4px 12px rgba(59, 139, 219, 0.35);
+  transform: translateY(-1px);
 }
 
 .send-btn:active {
-    transform: translateY(0);
-    box-shadow: 0 1px 3px rgba(59, 139, 219, 0.2);
+  transform: translateY(0);
+  box-shadow: 0 1px 3px rgba(59, 139, 219, 0.2);
 }
 
 .send-btn:disabled {
-    opacity: 0.4;
-    cursor: not-allowed;
-    box-shadow: none;
-    transform: none;
+  opacity: 0.4;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
 }
 
 /* ── Scrollbar ─────────────────────────────────────────────────────────── */
 
-::-webkit-scrollbar { width: 6px; }
-::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
-::-webkit-scrollbar-thumb:hover { background: var(--text-dim); }
+::-webkit-scrollbar {
+  width: 6px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 3px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: var(--text-dim);
+}
 
 /* ── Buttons ───────────────────────────────────────────────────────────── */
 
 .btn {
-    padding: 8px 16px;
-    font-family: var(--font-body);
-    font-size: 13px;
-    font-weight: 600;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: all 0.15s;
-    border: 1px solid transparent;
+  padding: 8px 16px;
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 600;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: all 0.15s;
+  border: 1px solid transparent;
 }
 
 .btn-primary {
-    background: var(--ember);
-    color: var(--bg-deep);
+  background: var(--ember);
+  color: var(--bg-deep);
 }
-.btn-primary:hover { background: var(--ember-bright); }
+.btn-primary:hover {
+  background: var(--ember-bright);
+}
 
 .btn-secondary {
-    background: transparent;
-    color: var(--text-muted);
-    border-color: var(--border);
+  background: transparent;
+  color: var(--text-muted);
+  border-color: var(--border);
 }
 .btn-secondary:hover {
-    background: var(--bg-raised);
-    color: var(--text);
+  background: var(--bg-raised);
+  color: var(--text);
 }
 
 .btn-danger {
-    background: transparent;
-    color: var(--error);
-    border-color: var(--error);
+  background: transparent;
+  color: var(--error);
+  border-color: var(--error);
 }
 .btn-danger:hover {
-    background: var(--error-bg);
+  background: var(--error-bg);
 }
 
 .btn-sm {
-    padding: 3px 10px;
-    font-size: 11px;
+  padding: 3px 10px;
+  font-size: 11px;
 }
 
 .btn:disabled {
-    opacity: 0.4;
-    cursor: not-allowed;
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 /* ── Form fields ──────────────────────────────────────────────────────── */
 
 .settings-field {
-    margin-bottom: 12px;
+  margin-bottom: 12px;
 }
 
 .settings-field label {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    font-size: 12px;
-    color: var(--text-muted);
-    margin-bottom: 4px;
-    font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-bottom: 4px;
+  font-weight: 500;
 }
 
 .settings-field input,
 .settings-field select {
-    width: 100%;
-    padding: 8px 12px;
-    font-family: var(--font-body);
-    font-size: 13px;
-    color: var(--text);
-    background: var(--bg-input);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-    outline: none;
-    transition: border-color 0.15s, box-shadow 0.15s;
+  width: 100%;
+  padding: 8px 12px;
+  font-family: var(--font-body);
+  font-size: 13px;
+  color: var(--text);
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  outline: none;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
 }
 
 .settings-field input:focus,
 .settings-field select:focus {
-    border-color: var(--ember-dim);
-    box-shadow: 0 0 0 1px rgba(59, 139, 219, 0.15), 0 0 8px rgba(59, 139, 219, 0.06);
+  border-color: var(--ember-dim);
+  box-shadow:
+    0 0 0 1px rgba(59, 139, 219, 0.15),
+    0 0 8px rgba(59, 139, 219, 0.06);
 }
 
 .settings-field input[type="password"] {
-    font-family: var(--font-mono);
-    letter-spacing: 0.05em;
+  font-family: var(--font-mono);
+  letter-spacing: 0.05em;
 }
 
 .settings-field .field-hint {
-    font-size: 11px;
-    color: var(--text-dim);
-    margin-top: 3px;
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-top: 3px;
 }
 
 /* ── Validation feedback ─────────────────────────────────────────────── */
 
 .validation-msg {
-    font-size: 12px;
-    margin-top: 8px;
-    padding: 8px 10px;
-    border-radius: var(--radius-sm);
+  font-size: 12px;
+  margin-top: 8px;
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
 }
 
 .validation-msg.error {
-    color: #e8a0a0;
-    background: var(--error-bg);
-    border: 1px solid rgba(192, 57, 43, 0.3);
+  color: #e8a0a0;
+  background: var(--error-bg);
+  border: 1px solid rgba(192, 57, 43, 0.3);
 }
 
 .validation-msg.success {
-    color: var(--success);
-    background: rgba(46, 204, 113, 0.08);
-    border: 1px solid rgba(46, 204, 113, 0.2);
+  color: var(--success);
+  background: rgba(46, 204, 113, 0.08);
+  border: 1px solid rgba(46, 204, 113, 0.2);
 }
 
 /* ── Setup wizard ─────────────────────────────────────────────────────── */
 
 .setup-view {
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-    overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  overflow: hidden;
 }
 
 .setup-body {
-    flex: 1;
-    overflow-y: auto;
-    display: flex;
-    align-items: flex-start;
-    justify-content: center;
-    padding: 32px 16px;
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 32px 16px;
 }
 
 .setup-card {
-    width: 100%;
-    max-width: 580px;
-    background: var(--bg-surface);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    padding: 28px;
+  width: 100%;
+  max-width: 580px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 28px;
 }
 
 .setup-card h2 {
-    font-family: var(--font-display);
-    font-size: 18px;
-    font-weight: 600;
-    margin-bottom: 4px;
+  font-family: var(--font-display);
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 4px;
 }
 
 .setup-card .subtitle {
-    color: var(--text-muted);
-    font-size: 13px;
-    margin-bottom: 20px;
+  color: var(--text-muted);
+  font-size: 13px;
+  margin-bottom: 20px;
 }
 
 .setup-step-indicator {
-    display: flex;
-    gap: 6px;
-    margin-bottom: 24px;
+  display: flex;
+  gap: 6px;
+  margin-bottom: 24px;
 }
 
 .step-dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    background: var(--border);
-    transition: background 0.2s;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--border);
+  transition: background 0.2s;
 }
 
-.step-dot.active { background: var(--ember); }
-.step-dot.done { background: var(--ember-dim); }
+.step-dot.active {
+  background: var(--ember);
+}
+.step-dot.done {
+  background: var(--ember-dim);
+}
 
 .setup-nav {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-top: 24px;
-    gap: 8px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 24px;
+  gap: 8px;
 }
 
 .setup-nav-hint {
-    font-size: 11px;
-    color: var(--text-dim);
-    text-align: center;
-    flex: 1;
+  font-size: 11px;
+  color: var(--text-dim);
+  text-align: center;
+  flex: 1;
 }
 
 /* ── Provider selection ───────────────────────────────────────────────── */
 
 .provider-option {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    padding: 10px 14px;
-    background: var(--bg-input);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    margin-bottom: 8px;
-    transition: all 0.15s;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  margin-bottom: 8px;
+  transition: all 0.15s;
 }
 
 .provider-option:hover {
-    border-color: var(--ember-dim);
-    background: var(--bg-raised);
+  border-color: var(--ember-dim);
+  background: var(--bg-raised);
 }
 
 .provider-option.selected {
-    border-color: var(--ember);
-    background: var(--ember-glow);
+  border-color: var(--ember);
+  background: var(--ember-glow);
 }
 
 .provider-option .provider-name {
-    font-weight: 600;
-    font-size: 14px;
+  font-weight: 600;
+  font-size: 14px;
 }
 
 .provider-option .provider-desc {
-    font-size: 12px;
-    color: var(--text-muted);
+  font-size: 12px;
+  color: var(--text-muted);
 }
 
 .provider-check {
-    width: 20px;
-    height: 20px;
-    border-radius: var(--radius-sm);
-    border: 1px solid var(--border);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 13px;
-    color: var(--ember);
-    flex-shrink: 0;
-    transition: all 0.15s;
+  width: 20px;
+  height: 20px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  color: var(--ember);
+  flex-shrink: 0;
+  transition: all 0.15s;
 }
 
 .provider-option.selected .provider-check {
-    background: var(--ember-glow);
-    border-color: var(--ember);
+  background: var(--ember-glow);
+  border-color: var(--ember);
 }
 
 /* ── Provider config sections ─────────────────────────────────────────── */
 
 .provider-configs {
-    margin-top: 16px;
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
+  margin-top: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .provider-config-section {
-    padding: 14px;
-    background: var(--bg-deep);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
+  padding: 14px;
+  background: var(--bg-deep);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
 }
 
 .provider-config-header {
-    font-size: 13px;
-    font-weight: 600;
-    color: var(--text);
-    margin-bottom: 10px;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
 /* ── Embedding warning ────────────────────────────────────────────────── */
 
 .provider-warning {
-    display: flex;
-    align-items: flex-start;
-    gap: 8px;
-    padding: 10px 12px;
-    margin-top: 12px;
-    font-size: 12px;
-    line-height: 1.5;
-    color: var(--ember-bright);
-    background: rgba(59, 139, 219, 0.06);
-    border: 1px solid rgba(59, 139, 219, 0.2);
-    border-radius: var(--radius-sm);
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 10px 12px;
+  margin-top: 12px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--ember-bright);
+  background: rgba(59, 139, 219, 0.06);
+  border: 1px solid rgba(59, 139, 219, 0.2);
+  border-radius: var(--radius-sm);
 }
 
 .provider-warning-icon {
-    font-size: 15px;
-    flex-shrink: 0;
-    line-height: 1.3;
+  font-size: 15px;
+  flex-shrink: 0;
+  line-height: 1.3;
 }
 
 /* ── Roles sections (model assignment step) ───────────────────────────── */
 
 .roles-section {
-    margin-bottom: 18px;
+  margin-bottom: 18px;
 }
 
 .roles-section-label {
-    font-size: 12px;
-    font-weight: 600;
-    color: var(--ember);
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    margin-bottom: 6px;
-    padding-bottom: 4px;
-    border-bottom: 1px solid var(--border-subtle);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--ember);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 6px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--border-subtle);
 }
 
 .roles-section-hint {
-    font-size: 11px;
-    color: var(--text-dim);
-    margin-bottom: 8px;
-    line-height: 1.4;
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-bottom: 8px;
+  line-height: 1.4;
 }
 
 /* ── Role rows ────────────────────────────────────────────────────────── */
 
 .role-row {
-    padding: 10px;
-    margin-bottom: 8px;
-    background: var(--bg-deep);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
+  padding: 10px;
+  margin-bottom: 8px;
+  background: var(--bg-deep);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
 }
 
 .role-row-label {
-    font-size: 12px;
-    font-weight: 600;
-    color: var(--text-muted);
-    margin-bottom: 8px;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    display: flex;
-    align-items: center;
-    gap: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+  margin-bottom: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 
 .role-row-fields {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 8px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
 }
 
 .role-row-fields .settings-field {
-    margin-bottom: 0;
+  margin-bottom: 0;
 }
 
 /* ── Role tooltips (#19) ──────────────────────────────────────────────── */
 
 .role-tooltip {
-    position: relative;
-    display: inline-flex;
-    align-items: center;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
 }
 
 .role-tooltip-icon {
-    width: 14px;
-    height: 14px;
-    border-radius: 50%;
-    border: 1px solid var(--border);
-    font-size: 10px;
-    font-weight: 700;
-    color: var(--text-dim);
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    cursor: help;
-    flex-shrink: 0;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--text-dim);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: help;
+  flex-shrink: 0;
 }
 
 .role-tooltip-text {
-    visibility: hidden;
-    opacity: 0;
-    position: absolute;
-    bottom: calc(100% + 6px);
-    left: 50%;
-    transform: translateX(-50%);
-    width: 240px;
-    padding: 8px 10px;
-    font-size: 11px;
-    font-weight: 400;
-    line-height: 1.5;
-    text-transform: none;
-    letter-spacing: 0;
-    color: var(--text);
-    background: var(--bg-raised);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
-    z-index: 100;
-    transition: opacity 0.15s, visibility 0.15s;
-    pointer-events: none;
+  visibility: hidden;
+  opacity: 0;
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  width: 240px;
+  padding: 8px 10px;
+  font-size: 11px;
+  font-weight: 400;
+  line-height: 1.5;
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--text);
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  z-index: 100;
+  transition:
+    opacity 0.15s,
+    visibility 0.15s;
+  pointer-events: none;
 }
 
 .role-tooltip:hover .role-tooltip-text {
-    visibility: visible;
-    opacity: 1;
+  visibility: visible;
+  opacity: 1;
 }
 
 /* ── Model select ─────────────────────────────────────────────────────── */
 
 .model-select-wrap {
-    position: relative;
+  position: relative;
 }
 
 .model-select-wrap select {
-    width: 100%;
+  width: 100%;
 }
 
 .model-other-input {
-    width: 100%;
-    margin-top: 6px;
-    padding: 8px 12px;
-    font-family: var(--font-mono);
-    font-size: 13px;
-    color: var(--text);
-    background: var(--bg-input);
-    border: 1px solid var(--ember-dim);
-    border-radius: var(--radius-sm);
-    outline: none;
-    transition: border-color 0.15s, box-shadow 0.15s;
+  width: 100%;
+  margin-top: 6px;
+  padding: 8px 12px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--text);
+  background: var(--bg-input);
+  border: 1px solid var(--ember-dim);
+  border-radius: var(--radius-sm);
+  outline: none;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
 }
 
 .model-other-input:focus {
-    border-color: var(--ember);
-    box-shadow: 0 0 0 1px rgba(59, 139, 219, 0.15), 0 0 8px rgba(59, 139, 219, 0.06);
+  border-color: var(--ember);
+  box-shadow:
+    0 0 0 1px rgba(59, 139, 219, 0.15),
+    0 0 8px rgba(59, 139, 219, 0.06);
 }
 
 .model-other-input::placeholder {
-    color: var(--text-dim);
+  color: var(--text-dim);
 }
 
 .model-error {
-    font-size: 11px;
-    color: var(--error);
-    margin-top: 3px;
+  font-size: 11px;
+  color: var(--error);
+  margin-top: 3px;
 }
 
 /* ── MCP catalog items ────────────────────────────────────────────────── */
 
 .mcp-item {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 12px;
-    padding: 10px 14px;
-    background: var(--bg-input);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-    margin-bottom: 8px;
-    transition: all 0.15s;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  margin-bottom: 8px;
+  transition: all 0.15s;
 }
 
-.mcp-item:hover { border-color: var(--border); background: var(--bg-raised); }
-.mcp-item.added { border-color: var(--ember-dim); background: var(--ember-glow); }
-.mcp-item.pending { border-color: var(--ember-dim); }
+.mcp-item:hover {
+  border-color: var(--border);
+  background: var(--bg-raised);
+}
+.mcp-item.added {
+  border-color: var(--ember-dim);
+  background: var(--ember-glow);
+}
+.mcp-item.pending {
+  border-color: var(--ember-dim);
+}
 
-.mcp-info { flex: 1; }
+.mcp-info {
+  flex: 1;
+}
 
 .mcp-info .mcp-name {
-    font-weight: 600;
-    font-size: 13px;
+  font-weight: 600;
+  font-size: 13px;
 }
 
 .mcp-info .mcp-desc {
-    font-size: 12px;
-    color: var(--text-muted);
+  font-size: 12px;
+  color: var(--text-muted);
 }
 
 .mcp-add-btn {
-    padding: 4px 12px;
-    font-size: 12px;
-    font-weight: 600;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    border: 1px solid var(--border);
-    background: transparent;
-    color: var(--text-muted);
-    transition: all 0.15s;
+  padding: 4px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-muted);
+  transition: all 0.15s;
 }
 
-.mcp-add-btn:hover { background: var(--bg-raised); color: var(--text); }
-.mcp-item.added .mcp-add-btn { color: var(--ember); border-color: var(--ember-dim); }
+.mcp-add-btn:hover {
+  background: var(--bg-raised);
+  color: var(--text);
+}
+.mcp-item.added .mcp-add-btn {
+  color: var(--ember);
+  border-color: var(--ember-dim);
+}
 
 .mcp-inline-inputs {
-    width: 100%;
-    padding-top: 8px;
-    border-top: 1px solid var(--border);
-    margin-top: 4px;
+  width: 100%;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+  margin-top: 4px;
 }
 
 .mcp-inline-inputs .mcp-input-field {
-    margin-bottom: 8px;
+  margin-bottom: 8px;
 }
 
 .mcp-inline-inputs .mcp-input-field label {
-    font-size: 11px;
-    color: var(--text-muted);
-    margin-bottom: 2px;
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-bottom: 2px;
 }
 
 .mcp-inline-inputs .mcp-input-field input {
-    font-size: 12px;
-    padding: 5px 8px;
+  font-size: 12px;
+  padding: 5px 8px;
 }
 
 .mcp-inline-inputs .mcp-input-field input.input-error {
-    border-color: var(--error);
+  border-color: var(--error);
 }
 
 .mcp-inline-actions {
-    display: flex;
-    gap: 8px;
-    justify-content: flex-end;
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
 }
 
 /* ── TOML editor ──────────────────────────────────────────────────────── */
 
 .toml-editor {
-    width: 100%;
-    min-height: 400px;
-    padding: 12px;
-    font-family: var(--font-mono);
-    font-size: 12.5px;
-    line-height: 1.5;
-    color: var(--text);
-    background: var(--bg-deep);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-    resize: vertical;
-    outline: none;
-    tab-size: 4;
-    box-shadow: var(--input-inset);
+  width: 100%;
+  min-height: 400px;
+  padding: 12px;
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--text);
+  background: var(--bg-deep);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  resize: vertical;
+  outline: none;
+  tab-size: 4;
+  box-shadow: var(--input-inset);
 }
 
 .toml-editor:focus {
-    border-color: var(--ember-dim);
-    box-shadow: var(--input-inset), 0 0 0 1px rgba(59, 139, 219, 0.15), 0 0 8px rgba(59, 139, 219, 0.06);
+  border-color: var(--ember-dim);
+  box-shadow:
+    var(--input-inset),
+    0 0 0 1px rgba(59, 139, 219, 0.15),
+    0 0 8px rgba(59, 139, 219, 0.06);
 }
 
 /* ── Review summary ───────────────────────────────────────────────────── */
 
 .review-summary {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    margin-bottom: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 16px;
 }
 
 .review-item {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 8px 12px;
-    background: var(--bg-deep);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+  background: var(--bg-deep);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
 }
 
 .review-label {
-    font-size: 12px;
-    font-weight: 600;
-    color: var(--text-muted);
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 .review-value {
-    font-size: 13px;
-    color: var(--text);
-    font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--text);
+  font-family: var(--font-mono);
 }
 
 /* ── Integration cards (#21) ──────────────────────────────────────────── */
 
 .integration-card {
-    padding: 16px;
-    background: var(--bg-input);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-    margin-bottom: 12px;
+  padding: 16px;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  margin-bottom: 12px;
 }
 
 .integration-header {
-    font-weight: 600;
-    font-size: 14px;
-    margin-bottom: 4px;
+  font-weight: 600;
+  font-size: 14px;
+  margin-bottom: 4px;
 }
 
 .integration-desc {
-    font-size: 12px;
-    color: var(--text-muted);
-    margin-bottom: 12px;
-    line-height: 1.4;
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-bottom: 12px;
+  line-height: 1.4;
 }
 
 .skip-hint {
-    font-size: 11px;
-    color: var(--text-dim);
-    text-align: center;
-    margin-top: 8px;
+  font-size: 11px;
+  color: var(--text-dim);
+  text-align: center;
+  margin-top: 8px;
 }
 
 /* ── Settings view ────────────────────────────────────────────────────── */
 
 .settings-view {
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-    overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  overflow: hidden;
 }
 
 .settings-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 12px 20px;
-    border-bottom: 1px solid var(--border-subtle);
-    background: var(--bg-surface);
-    flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 20px;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-surface);
+  flex-shrink: 0;
 }
 
 .settings-title {
-    font-family: var(--font-display);
-    font-size: 16px;
-    font-weight: 600;
-    letter-spacing: 0.04em;
+  font-family: var(--font-display);
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
 }
 
 .settings-header-actions {
-    display: flex;
-    align-items: center;
-    gap: 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .settings-body {
-    display: flex;
-    flex: 1;
-    overflow: hidden;
+  display: flex;
+  flex: 1;
+  overflow: hidden;
 }
 
 .settings-sidebar {
-    width: 160px;
-    flex-shrink: 0;
-    border-right: 1px solid var(--border-subtle);
-    background: var(--bg-surface);
-    padding: 12px 0;
-    overflow-y: auto;
+  width: 160px;
+  flex-shrink: 0;
+  border-right: 1px solid var(--border-subtle);
+  background: var(--bg-surface);
+  padding: 12px 0;
+  overflow-y: auto;
 }
 
 .settings-sidebar-btn {
-    display: block;
-    width: 100%;
-    padding: 8px 20px;
-    font-family: var(--font-body);
-    font-size: 13px;
-    font-weight: 500;
-    color: var(--text-muted);
-    background: transparent;
-    border: none;
-    text-align: left;
-    cursor: pointer;
-    transition: all 0.15s;
-    border-left: 3px solid transparent;
+  display: block;
+  width: 100%;
+  padding: 8px 20px;
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-muted);
+  background: transparent;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  transition: all 0.15s;
+  border-left: 3px solid transparent;
 }
 
 .settings-sidebar-btn:hover {
-    color: var(--text);
-    background: var(--bg-raised);
+  color: var(--text);
+  background: var(--bg-raised);
 }
 
 .settings-sidebar-btn.active {
-    color: var(--ember);
-    border-left-color: var(--ember);
-    background: var(--ember-glow);
+  color: var(--ember);
+  border-left-color: var(--ember);
+  background: var(--ember-glow);
 }
 
 .settings-content {
-    flex: 1;
-    overflow-y: auto;
-    padding: 20px 24px;
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px 24px;
 }
 
 .settings-footer {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 10px 20px;
-    border-top: 1px solid var(--border-subtle);
-    background: var(--bg-surface);
-    flex-shrink: 0;
-    gap: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 20px;
+  border-top: 1px solid var(--border-subtle);
+  background: var(--bg-surface);
+  flex-shrink: 0;
+  gap: 12px;
 }
 
 .settings-footer-left {
-    display: flex;
-    gap: 8px;
+  display: flex;
+  gap: 8px;
 }
 
 .settings-footer-right {
-    display: flex;
-    align-items: center;
-    gap: 12px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 .settings-footer .validation-msg {
-    margin-top: 0;
-    white-space: nowrap;
-    max-width: 400px;
-    overflow: hidden;
-    text-overflow: ellipsis;
+  margin-top: 0;
+  white-space: nowrap;
+  max-width: 400px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /* ── Settings sections & groups ──────────────────────────────────────── */
 
 .settings-section {
-    max-width: 640px;
+  max-width: 640px;
 }
 
 .settings-group {
-    margin-bottom: 24px;
+  margin-bottom: 24px;
 }
 
 .settings-group-label {
-    font-size: 12px;
-    font-weight: 600;
-    color: var(--ember);
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    margin-bottom: 12px;
-    padding-bottom: 6px;
-    border-bottom: 1px solid var(--border-subtle);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--ember);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 12px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--border-subtle);
 }
 
 /* ── Advanced mode tabs ──────────────────────────────────────────────── */
 
 .advanced-tabs {
-    display: flex;
-    gap: 0;
-    margin-bottom: 12px;
-    border-bottom: 1px solid var(--border);
+  display: flex;
+  gap: 0;
+  margin-bottom: 12px;
+  border-bottom: 1px solid var(--border);
 }
 
 .advanced-tab {
-    padding: 8px 16px;
-    font-family: var(--font-mono);
-    font-size: 12px;
-    font-weight: 500;
-    color: var(--text-muted);
-    background: transparent;
-    border: none;
-    border-bottom: 2px solid transparent;
-    cursor: pointer;
-    transition: all 0.15s;
+  padding: 8px 16px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-muted);
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  transition: all 0.15s;
 }
 
 .advanced-tab:hover {
-    color: var(--text);
+  color: var(--text);
 }
 
 .advanced-tab.active {
-    color: var(--ember);
-    border-bottom-color: var(--ember);
+  color: var(--ember);
+  border-bottom-color: var(--ember);
 }
 
 /* ── Provider entry ──────────────────────────────────────────────────── */
 
 .provider-entry {
-    padding: 14px;
-    background: var(--bg-deep);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    margin-bottom: 10px;
-    display: flex;
-    align-items: flex-start;
-    gap: 12px;
+  padding: 14px;
+  background: var(--bg-deep);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  margin-bottom: 10px;
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
 }
 
 .provider-entry-fields {
-    flex: 1;
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 8px;
+  flex: 1;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
 }
 
 .provider-entry-fields .settings-field {
-    margin-bottom: 0;
+  margin-bottom: 0;
 }
 
 /* ── Secret stored badge ─────────────────────────────────────────────── */
 
 .secret-stored {
-    display: flex;
-    align-items: center;
-    gap: 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .secret-badge {
-    font-size: 12px;
-    color: var(--success);
-    padding: 4px 10px;
-    background: rgba(46, 204, 113, 0.08);
-    border: 1px solid rgba(46, 204, 113, 0.2);
-    border-radius: var(--radius-sm);
+  font-size: 12px;
+  color: var(--success);
+  padding: 4px 10px;
+  background: rgba(46, 204, 113, 0.08);
+  border: 1px solid rgba(46, 204, 113, 0.2);
+  border-radius: var(--radius-sm);
 }
 
 /* ── MCP server entry ────────────────────────────────────────────────── */
 
 .mcp-server-entry {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 10px 14px;
-    background: var(--bg-deep);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    margin-bottom: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  background: var(--bg-deep);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  margin-bottom: 6px;
 }
 
 .mcp-server-info {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 
 .mcp-server-name {
-    font-weight: 600;
-    font-size: 13px;
+  font-weight: 600;
+  font-size: 13px;
 }
 
 .mcp-server-cmd {
-    font-family: var(--font-mono);
-    font-size: 11px;
-    color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-dim);
 }
 
 .mcp-add-form {
-    padding: 14px;
-    background: var(--bg-deep);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    margin-top: 8px;
+  padding: 14px;
+  background: var(--bg-deep);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  margin-top: 8px;
 }
 
 /* ── Toggle switch ───────────────────────────────────────────────────── */
 
 .toggle-switch {
-    position: relative;
-    display: inline-block;
-    width: 32px;
-    height: 18px;
-    flex-shrink: 0;
+  position: relative;
+  display: inline-block;
+  width: 32px;
+  height: 18px;
+  flex-shrink: 0;
 }
 
 .toggle-switch input {
-    opacity: 0;
-    width: 0;
-    height: 0;
-    position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+  position: absolute;
 }
 
 .toggle-slider {
-    position: absolute;
-    cursor: pointer;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: var(--border);
-    border-radius: 9px;
-    transition: background 0.2s;
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: var(--border);
+  border-radius: 9px;
+  transition: background 0.2s;
 }
 
 .toggle-slider::before {
-    content: '';
-    position: absolute;
-    width: 14px;
-    height: 14px;
-    left: 2px;
-    bottom: 2px;
-    background: var(--text-muted);
-    border-radius: 50%;
-    transition: transform 0.2s, background 0.2s;
+  content: "";
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  left: 2px;
+  bottom: 2px;
+  background: var(--text-muted);
+  border-radius: 50%;
+  transition:
+    transform 0.2s,
+    background 0.2s;
 }
 
 .toggle-switch input:checked + .toggle-slider {
-    background: var(--ember-dim);
+  background: var(--ember-dim);
 }
 
 .toggle-switch input:checked + .toggle-slider::before {
-    transform: translateX(14px);
-    background: var(--ember-bright);
+  transform: translateX(14px);
+  background: var(--ember-bright);
 }
 
 /* ── Skills dir entries ──────────────────────────────────────────────── */
 
 .skill-dir-entry {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 6px 10px;
-    background: var(--bg-deep);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius-sm);
-    margin-bottom: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 10px;
+  background: var(--bg-deep);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  margin-bottom: 4px;
 }
 
 .skill-dir-path {
-    font-family: var(--font-mono);
-    font-size: 12px;
-    color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text);
 }
 
 .skill-dir-add {
-    display: flex;
-    gap: 8px;
-    margin-top: 8px;
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
 }
 
 .skill-dir-add input {
-    flex: 1;
+  flex: 1;
 }
 
 /* ── Responsive ────────────────────────────────────────────────────────── */
 
 @media (max-width: 600px) {
-    .chat-input-area { width: calc(100% - 16px); bottom: 8px; }
-    .chat-input-wrap { flex-direction: column; border-radius: 12px; }
-    .send-btn { width: 100%; height: 42px; }
-    .msg-user { max-width: 90%; }
-    .setup-card { padding: 20px; }
-    .role-row-fields { grid-template-columns: 1fr; }
-    .settings-sidebar { width: 120px; }
-    .settings-content { padding: 16px; }
-    .provider-entry-fields { grid-template-columns: 1fr; }
-    .settings-footer { flex-direction: column; gap: 8px; }
+  .chat-input-area {
+    width: calc(100% - 16px);
+    bottom: 8px;
+  }
+  .chat-input-wrap {
+    flex-direction: column;
+    border-radius: 12px;
+  }
+  .send-btn {
+    width: 100%;
+    height: 42px;
+  }
+  .msg-user {
+    max-width: 90%;
+  }
+  .setup-card {
+    padding: 20px;
+  }
+  .role-row-fields {
+    grid-template-columns: 1fr;
+  }
+  .settings-sidebar {
+    width: 120px;
+  }
+  .settings-content {
+    padding: 16px;
+  }
+  .provider-entry-fields {
+    grid-template-columns: 1fr;
+  }
+  .settings-footer {
+    flex-direction: column;
+    gap: 8px;
+  }
 }

--- a/web/src/components/ChatFeed.svelte
+++ b/web/src/components/ChatFeed.svelte
@@ -10,7 +10,11 @@
   import ToolGroup from "./ToolGroup.svelte";
   import ThinkingIndicator from "./ThinkingIndicator.svelte";
 
-  let { items, isProcessing, verbose }: {
+  let {
+    items,
+    isProcessing,
+    verbose,
+  }: {
     items: FeedItem[];
     isProcessing: boolean;
     verbose: boolean;
@@ -20,7 +24,7 @@
 
   function scrollToBottom() {
     if (!feedEl) return;
-    requestAnimationFrame(() => {
+    window.requestAnimationFrame(() => {
       if (feedEl) feedEl.scrollTop = feedEl.scrollHeight;
     });
   }
@@ -29,7 +33,7 @@
     // scroll when items change
     items.length;
     isProcessing;
-    tick().then(scrollToBottom);
+    void tick().then(scrollToBottom);
   });
 </script>
 

--- a/web/src/components/ChatInput.svelte
+++ b/web/src/components/ChatInput.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
-  let { onSend, disabled = false }: { onSend: (text: string) => void; disabled?: boolean } = $props();
+  let { onSend, disabled = false }: { onSend: (text: string) => void; disabled?: boolean } =
+    $props();
   let value = $state("");
   let textarea: HTMLTextAreaElement | undefined = $state();
 
   function autoResize() {
     if (!textarea) return;
     textarea.style.height = "auto";
-    textarea.style.height = Math.min(textarea.scrollHeight, 160) + "px";
+    textarea.style.height = `${Math.min(textarea.scrollHeight, 160)}px`;
   }
 
   function handleKeydown(e: KeyboardEvent) {
@@ -43,8 +44,6 @@
       onkeydown={handleKeydown}
       oninput={autoResize}
     ></textarea>
-    <button class="send-btn" onclick={submit} disabled={disabled || !value.trim()}>
-      Send
-    </button>
+    <button class="send-btn" onclick={submit} disabled={disabled || !value.trim()}> Send </button>
   </div>
 </div>

--- a/web/src/components/Header.svelte
+++ b/web/src/components/Header.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
   import type { ConnectionStatus } from "../lib/types";
 
-  let { status, verbose, showSettings, onToggleVerbose, onToggleSettings }: {
+  let {
+    status,
+    verbose,
+    showSettings,
+    onToggleVerbose,
+    onToggleSettings,
+  }: {
     status: ConnectionStatus;
     verbose: boolean;
     showSettings: boolean;

--- a/web/src/components/MessageAssistant.svelte
+++ b/web/src/components/MessageAssistant.svelte
@@ -5,5 +5,6 @@
 </script>
 
 <div class="msg msg-assistant">
+  <!-- eslint-disable svelte/no-at-html-tags -->
   <div class="msg-content">{@html renderMarkdown(content)}</div>
 </div>

--- a/web/src/components/MessageUser.svelte
+++ b/web/src/components/MessageUser.svelte
@@ -5,5 +5,6 @@
 </script>
 
 <div class="msg msg-user">
+  <!-- eslint-disable svelte/no-at-html-tags -->
   <div class="msg-content">{@html escapeHtml(content)}</div>
 </div>

--- a/web/src/components/ThinkingIndicator.svelte
+++ b/web/src/components/ThinkingIndicator.svelte
@@ -1,3 +1,5 @@
+<script lang="ts"></script>
+
 <div class="thinking">
   <span class="thinking-bars">
     <span></span>

--- a/web/src/components/ToolGroup.svelte
+++ b/web/src/components/ToolGroup.svelte
@@ -2,8 +2,7 @@
   import type { ToolCallState } from "../lib/types";
   import ToolItem from "./ToolItem.svelte";
 
-  let { calls, verbose }: { calls: ToolCallState[]; verbose: boolean } =
-    $props();
+  let { calls, verbose }: { calls: ToolCallState[]; verbose: boolean } = $props();
 </script>
 
 {#if verbose}

--- a/web/src/components/ToolItem.svelte
+++ b/web/src/components/ToolItem.svelte
@@ -11,19 +11,18 @@
     onclick={() => (open = !open)}
     role="button"
     tabindex="0"
-    onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') open = !open; }}
+    onkeydown={(e) => {
+      if (e.key === "Enter" || e.key === " ") open = !open;
+    }}
   >
     <span class="tool-chevron">&#9654;</span>
     <span class="tool-name">{call.name}</span>
-    <span
-      class="tool-status"
-      class:ok={call.status === "done"}
-      class:err={call.status === "error"}
-    >
+    <span class="tool-status" class:ok={call.status === "done"} class:err={call.status === "error"}>
       {call.status === "running" ? "running..." : call.status}
     </span>
   </div>
   <div class="tool-body">
-    {call.arguments}{#if call.result}{"\n"}{call.result}{/if}
+    {call.arguments}{#if call.result}
+      {call.result}{/if}
   </div>
 </div>

--- a/web/src/components/settings/Integrations.svelte
+++ b/web/src/components/settings/Integrations.svelte
@@ -23,18 +23,31 @@
     <div class="settings-group-label">Discord</div>
     <div class="integration-card">
       <div class="integration-desc">
-        Connect a Discord bot so your agent can communicate via DMs.
-        Create a bot at <a href="https://discord.com/developers/applications" target="_blank" rel="noopener">discord.com/developers</a>.
+        Connect a Discord bot so your agent can communicate via DMs. Create a bot at <a
+          href="https://discord.com/developers/applications"
+          target="_blank"
+          rel="noopener">discord.com/developers</a
+        >.
       </div>
       <div class="settings-field">
-        <label>Bot Token</label>
+        <label for="integ-discord-token">Bot Token</label>
         {#if fields.discord_token.startsWith("secret:")}
           <div class="secret-stored">
             <span class="secret-badge">Stored securely</span>
-            <button class="btn btn-sm btn-secondary" onclick={() => { fields.discord_token = ""; }}>Change</button>
+            <button
+              class="btn btn-sm btn-secondary"
+              onclick={() => {
+                fields.discord_token = "";
+              }}>Change</button
+            >
           </div>
         {:else}
-          <input type="password" bind:value={fields.discord_token} placeholder="Discord bot token" />
+          <input
+            id="integ-discord-token"
+            type="password"
+            bind:value={fields.discord_token}
+            placeholder="Discord bot token"
+          />
         {/if}
       </div>
     </div>
@@ -44,18 +57,31 @@
     <div class="settings-group-label">Telegram</div>
     <div class="integration-card">
       <div class="integration-desc">
-        Connect a Telegram bot for DM-based interaction.
-        Create a bot via <a href="https://t.me/BotFather" target="_blank" rel="noopener">@BotFather</a>.
+        Connect a Telegram bot for DM-based interaction. Create a bot via <a
+          href="https://t.me/BotFather"
+          target="_blank"
+          rel="noopener">@BotFather</a
+        >.
       </div>
       <div class="settings-field">
-        <label>Bot Token</label>
+        <label for="integ-telegram-token">Bot Token</label>
         {#if fields.telegram_token.startsWith("secret:")}
           <div class="secret-stored">
             <span class="secret-badge">Stored securely</span>
-            <button class="btn btn-sm btn-secondary" onclick={() => { fields.telegram_token = ""; }}>Change</button>
+            <button
+              class="btn btn-sm btn-secondary"
+              onclick={() => {
+                fields.telegram_token = "";
+              }}>Change</button
+            >
           </div>
         {:else}
-          <input type="password" bind:value={fields.telegram_token} placeholder="Telegram bot token" />
+          <input
+            id="integ-telegram-token"
+            type="password"
+            bind:value={fields.telegram_token}
+            placeholder="Telegram bot token"
+          />
         {/if}
       </div>
     </div>
@@ -64,9 +90,7 @@
   <div class="settings-group">
     <div class="settings-group-label">Webhook</div>
     <div class="integration-card">
-      <div class="integration-desc">
-        Enable an HTTP webhook endpoint for external integrations.
-      </div>
+      <div class="integration-desc">Enable an HTTP webhook endpoint for external integrations.</div>
       <div class="settings-field">
         <label>
           <span class="toggle-switch">
@@ -78,14 +102,24 @@
       </div>
       {#if fields.webhook_enabled}
         <div class="settings-field">
-          <label>Secret</label>
+          <label for="integ-webhook-secret">Secret</label>
           {#if fields.webhook_secret.startsWith("secret:")}
             <div class="secret-stored">
               <span class="secret-badge">Stored securely</span>
-              <button class="btn btn-sm btn-secondary" onclick={() => { fields.webhook_secret = ""; }}>Change</button>
+              <button
+                class="btn btn-sm btn-secondary"
+                onclick={() => {
+                  fields.webhook_secret = "";
+                }}>Change</button
+              >
             </div>
           {:else}
-            <input type="password" bind:value={fields.webhook_secret} placeholder="Bearer token for authentication (optional)" />
+            <input
+              id="integ-webhook-secret"
+              type="password"
+              bind:value={fields.webhook_secret}
+              placeholder="Bearer token for authentication (optional)"
+            />
           {/if}
         </div>
       {/if}
@@ -95,17 +129,22 @@
   <div class="settings-group">
     <div class="settings-group-label">Skills</div>
     <div class="integration-card">
-      <div class="integration-desc">
-        Directories to scan for custom skills.
-      </div>
-      {#each fields.skills_dirs as dir, i}
+      <div class="integration-desc">Directories to scan for custom skills.</div>
+      {#each fields.skills_dirs as dir, i (dir)}
         <div class="skill-dir-entry">
           <span class="skill-dir-path">{dir}</span>
           <button class="btn btn-sm btn-danger" onclick={() => removeSkillDir(i)}>Remove</button>
         </div>
       {/each}
       <div class="skill-dir-add">
-        <input type="text" bind:value={newSkillDir} placeholder="Path to skills directory" onkeydown={(e) => { if (e.key === "Enter") addSkillDir(); }} />
+        <input
+          type="text"
+          bind:value={newSkillDir}
+          placeholder="Path to skills directory"
+          onkeydown={(e) => {
+            if (e.key === "Enter") addSkillDir();
+          }}
+        />
         <button class="btn btn-sm btn-secondary" onclick={addSkillDir}>Add</button>
       </div>
     </div>

--- a/web/src/components/settings/MCP.svelte
+++ b/web/src/components/settings/MCP.svelte
@@ -64,7 +64,7 @@
 
     let hasError = false;
     for (const req of srv.requires_input) {
-      const val = (pendingInputs[req.field] || "").trim();
+      const val = (pendingInputs[req.field] ?? "").trim();
       if (!val) {
         inputErrors[req.field] = true;
         hasError = true;
@@ -75,7 +75,7 @@
     const env = { ...(srv.env || {}) };
     for (const req of srv.requires_input) {
       const key = req.field.startsWith("env.") ? req.field.slice(4) : req.field;
-      env[key] = pendingInputs[req.field].trim();
+      env[key] = (pendingInputs[req.field] ?? "").trim();
     }
 
     servers.push({
@@ -128,7 +128,7 @@
       <p style="color:var(--text-dim); font-size:13px;">No MCP servers configured.</p>
     {/if}
 
-    {#each servers as srv, i}
+    {#each servers as srv, i (srv.name)}
       <div class="mcp-server-entry">
         <div class="mcp-server-info">
           <span class="mcp-server-name">{srv.name}</span>
@@ -141,28 +141,60 @@
     {#if showAddForm}
       <div class="mcp-add-form">
         <div class="settings-field">
-          <label>Name</label>
-          <input type="text" bind:value={newServer.name} placeholder="Server name" />
+          <label for="mcp-new-name">Name</label>
+          <input
+            id="mcp-new-name"
+            type="text"
+            bind:value={newServer.name}
+            placeholder="Server name"
+          />
         </div>
         <div class="settings-field">
-          <label>Command</label>
-          <input type="text" bind:value={newServer.command} placeholder="e.g. npx, uvx" />
+          <label for="mcp-new-command">Command</label>
+          <input
+            id="mcp-new-command"
+            type="text"
+            bind:value={newServer.command}
+            placeholder="e.g. npx, uvx"
+          />
         </div>
         <div class="settings-field">
-          <label>Arguments (space-separated)</label>
-          <input type="text" bind:value={newArgsStr} placeholder="e.g. -y @org/server" />
+          <label for="mcp-new-args">Arguments (space-separated)</label>
+          <input
+            id="mcp-new-args"
+            type="text"
+            bind:value={newArgsStr}
+            placeholder="e.g. -y @org/server"
+          />
         </div>
         <div class="settings-field">
-          <label>Environment (KEY=value, one per line)</label>
-          <textarea class="toml-editor" style="min-height:60px;" bind:value={newEnvStr} placeholder="API_KEY=abc123"></textarea>
+          <label for="mcp-new-env">Environment (KEY=value, one per line)</label>
+          <textarea
+            id="mcp-new-env"
+            class="toml-editor"
+            style="min-height:60px;"
+            bind:value={newEnvStr}
+            placeholder="API_KEY=abc123"
+          ></textarea>
         </div>
         <div class="mcp-inline-actions">
           <button class="btn btn-primary btn-sm" onclick={handleManualAdd}>Add</button>
-          <button class="btn btn-secondary btn-sm" onclick={() => { showAddForm = false; }}>Cancel</button>
+          <button
+            class="btn btn-secondary btn-sm"
+            onclick={() => {
+              showAddForm = false;
+            }}>Cancel</button
+          >
         </div>
       </div>
     {:else}
-      <button class="btn btn-secondary btn-sm" style="margin-top:8px;" onclick={() => { showAddForm = true; }}>+ Add Server</button>
+      <button
+        class="btn btn-secondary btn-sm"
+        style="margin-top:8px;"
+        onclick={() => {
+          showAddForm = true;
+        }}>+ Add Server</button
+      >
     {/if}
   </div>
 
@@ -174,7 +206,7 @@
     {#if catalog.length === 0}
       <p style="color:var(--text-dim); font-size:13px;">Loading catalog...</p>
     {:else}
-      {#each catalog as srv, i}
+      {#each catalog as srv, i (srv.name)}
         {@const added = isAdded(srv.name)}
         {@const isPending = pendingIdx === i}
         <div class="mcp-item" class:added class:pending={isPending}>
@@ -191,15 +223,18 @@
 
           {#if isPending && srv.requires_input.length > 0}
             <div class="mcp-inline-inputs">
-              {#each srv.requires_input as req}
+              {#each srv.requires_input as req (req.field)}
                 <div class="settings-field mcp-input-field">
-                  <label>{req.label}</label>
+                  <label for="mcp-input-{i}-{req.field}">{req.label}</label>
                   <input
+                    id="mcp-input-{i}-{req.field}"
                     type="text"
                     class:input-error={inputErrors[req.field]}
                     bind:value={pendingInputs[req.field]}
                     placeholder={req.label}
-                    oninput={() => { inputErrors[req.field] = false; }}
+                    oninput={() => {
+                      inputErrors[req.field] = false;
+                    }}
                   />
                 </div>
               {/each}

--- a/web/src/components/settings/Memory.svelte
+++ b/web/src/components/settings/Memory.svelte
@@ -8,23 +8,43 @@
   <div class="settings-group">
     <div class="settings-group-label">Observation Thresholds</div>
     <div class="settings-field">
-      <label>Observer Threshold (tokens)</label>
-      <input type="number" bind:value={fields.observer_threshold_tokens} placeholder="Default: 2000" />
+      <label for="mem-observer-threshold">Observer Threshold (tokens)</label>
+      <input
+        id="mem-observer-threshold"
+        type="number"
+        bind:value={fields.observer_threshold_tokens}
+        placeholder="Default: 2000"
+      />
       <span class="field-hint">Token count before the observer fires.</span>
     </div>
     <div class="settings-field">
-      <label>Reflector Threshold (tokens)</label>
-      <input type="number" bind:value={fields.reflector_threshold_tokens} placeholder="Default: 8000" />
+      <label for="mem-reflector-threshold">Reflector Threshold (tokens)</label>
+      <input
+        id="mem-reflector-threshold"
+        type="number"
+        bind:value={fields.reflector_threshold_tokens}
+        placeholder="Default: 8000"
+      />
       <span class="field-hint">Token count before the reflector compresses memories.</span>
     </div>
     <div class="settings-field">
-      <label>Observer Cooldown (seconds)</label>
-      <input type="number" bind:value={fields.observer_cooldown_secs} placeholder="Default: 120" />
+      <label for="mem-observer-cooldown">Observer Cooldown (seconds)</label>
+      <input
+        id="mem-observer-cooldown"
+        type="number"
+        bind:value={fields.observer_cooldown_secs}
+        placeholder="Default: 120"
+      />
       <span class="field-hint">Cooldown after soft threshold is crossed.</span>
     </div>
     <div class="settings-field">
-      <label>Observer Force Threshold (tokens)</label>
-      <input type="number" bind:value={fields.observer_force_threshold_tokens} placeholder="Default: 6000" />
+      <label for="mem-observer-force">Observer Force Threshold (tokens)</label>
+      <input
+        id="mem-observer-force"
+        type="number"
+        bind:value={fields.observer_force_threshold_tokens}
+        placeholder="Default: 6000"
+      />
       <span class="field-hint">Forces immediate observation, bypassing cooldown.</span>
     </div>
   </div>
@@ -32,23 +52,46 @@
   <div class="settings-group">
     <div class="settings-group-label">Search Tuning</div>
     <div class="settings-field">
-      <label>Vector Weight</label>
-      <input type="number" step="0.05" bind:value={fields.search_vector_weight} placeholder="Default: 0.6" />
+      <label for="mem-vector-weight">Vector Weight</label>
+      <input
+        id="mem-vector-weight"
+        type="number"
+        step="0.05"
+        bind:value={fields.search_vector_weight}
+        placeholder="Default: 0.6"
+      />
       <span class="field-hint">Weight for vector similarity in hybrid search (0.0-1.0).</span>
     </div>
     <div class="settings-field">
-      <label>Text Weight</label>
-      <input type="number" step="0.05" bind:value={fields.search_text_weight} placeholder="Default: 0.4" />
+      <label for="mem-text-weight">Text Weight</label>
+      <input
+        id="mem-text-weight"
+        type="number"
+        step="0.05"
+        bind:value={fields.search_text_weight}
+        placeholder="Default: 0.4"
+      />
       <span class="field-hint">Weight for BM25 text scores in hybrid search (0.0-1.0).</span>
     </div>
     <div class="settings-field">
-      <label>Min Score</label>
-      <input type="number" step="0.01" bind:value={fields.search_min_score} placeholder="Default: 0.3" />
+      <label for="mem-min-score">Min Score</label>
+      <input
+        id="mem-min-score"
+        type="number"
+        step="0.01"
+        bind:value={fields.search_min_score}
+        placeholder="Default: 0.3"
+      />
       <span class="field-hint">Minimum hybrid score threshold for results.</span>
     </div>
     <div class="settings-field">
-      <label>Candidate Multiplier</label>
-      <input type="number" bind:value={fields.search_candidate_multiplier} placeholder="Default: 3" />
+      <label for="mem-candidate-multiplier">Candidate Multiplier</label>
+      <input
+        id="mem-candidate-multiplier"
+        type="number"
+        bind:value={fields.search_candidate_multiplier}
+        placeholder="Default: 3"
+      />
       <span class="field-hint">Multiplier on limit for candidate retrieval before merge.</span>
     </div>
     <div class="settings-field">
@@ -63,8 +106,14 @@
     </div>
     {#if fields.search_temporal_decay}
       <div class="settings-field">
-        <label>Decay Half-Life (days)</label>
-        <input type="number" step="1" bind:value={fields.search_temporal_decay_half_life_days} placeholder="Default: 30" />
+        <label for="mem-decay-half-life">Decay Half-Life (days)</label>
+        <input
+          id="mem-decay-half-life"
+          type="number"
+          step="1"
+          bind:value={fields.search_temporal_decay_half_life_days}
+          placeholder="Default: 30"
+        />
         <span class="field-hint">Number of days for memory relevance to halve.</span>
       </div>
     {/if}

--- a/web/src/components/settings/Providers.svelte
+++ b/web/src/components/settings/Providers.svelte
@@ -29,11 +29,15 @@
 
   const roleTooltips: Record<string, string> = {
     main: "The primary model used for conversations and task execution.",
-    observer: "Watches conversations and extracts facts, preferences, and patterns for long-term memory.",
-    reflector: "Periodically reviews stored memories, consolidates duplicates, and resolves contradictions.",
+    observer:
+      "Watches conversations and extracts facts, preferences, and patterns for long-term memory.",
+    reflector:
+      "Periodically reviews stored memories, consolidates duplicates, and resolves contradictions.",
     pulse: "Drives proactive behavior — daily briefings, check-ins, and ambient monitoring tasks.",
-    embedding: "Generates vector embeddings for semantic memory search. Only some providers support this.",
-    "bg-small": "Used for lightweight background tasks like formatting, simple lookups, and notifications.",
+    embedding:
+      "Generates vector embeddings for semantic memory search. Only some providers support this.",
+    "bg-small":
+      "Used for lightweight background tasks like formatting, simple lookups, and notifications.",
     "bg-medium": "Used for moderate background tasks like summarization and analysis.",
     "bg-large": "Used for complex background tasks that need strong reasoning ability.",
   };
@@ -58,9 +62,9 @@
   // Extract provider from "provider/model" string
   function getProvider(role: string): string {
     const val = models[modelsKey(role)];
-    if (!val) return providers[0]?.name || "";
+    if (!val) return providers[0]?.name ?? "";
     const slash = val.indexOf("/");
-    return slash >= 0 ? val.slice(0, slash) : providers[0]?.name || "";
+    return slash >= 0 ? val.slice(0, slash) : (providers[0]?.name ?? "");
   }
 
   // Extract model from "provider/model" string
@@ -76,7 +80,7 @@
     models[key] = prov + "/";
     otherActive[role] = false;
     otherValues[role] = "";
-    loadModels(role);
+    void loadModels(role);
   }
 
   function setModel(role: string, value: string) {
@@ -107,19 +111,19 @@
 
     // Embedding uses hardcoded lists
     if (role === "embedding") {
-      const list = EMBEDDING_MODEL_LISTS[entry.type] || [];
+      const list = EMBEDDING_MODEL_LISTS[entry.type] ?? [];
       modelLists[role] = list;
       const current = getModel(role);
       if (!current && list.length > 0) {
-        const def = DEFAULT_EMBEDDING_MODELS[entry.type] || "";
+        const def = DEFAULT_EMBEDDING_MODELS[entry.type] ?? "";
         const found = list.some((m) => m.id === def);
-        setModel(role, found ? def : list[0].id);
+        setModel(role, found ? def : (list[0]?.id ?? ""));
       }
       return;
     }
 
     const apiKey = entry.type !== "ollama" ? entry.apiKey : undefined;
-    const url = entry.url || undefined;
+    const url = entry.url !== "" ? entry.url : undefined;
 
     modelLoading[role] = true;
     const result = await fetchModels(entry.type, apiKey, url);
@@ -128,14 +132,14 @@
 
     const current = getModel(role);
     if (!current && result.models.length > 0) {
-      const def = DEFAULT_MODELS[entry.type] || "";
+      const def = DEFAULT_MODELS[entry.type] ?? "";
       const found = result.models.some((m) => m.id === def);
-      setModel(role, found ? def : result.models[0].id);
+      setModel(role, found ? def : (result.models[0]?.id ?? ""));
     }
   }
 
-  const debouncedLoadModels = debounce((role: string) => {
-    loadModels(role);
+  const _debouncedLoadModels = debounce((role: string) => {
+    void loadModels(role);
   }, 500);
 
   function addProvider() {
@@ -163,13 +167,13 @@
       "bg-medium": "Medium",
       "bg-large": "Large",
     };
-    return labels[role] || role;
+    return labels[role] ?? role;
   }
 
   onMount(() => {
     if (providers.length === 0) return;
     for (const role of [...allRoles, "embedding", ...bgTiers]) {
-      loadModels(role);
+      void loadModels(role);
     }
   });
 </script>
@@ -178,38 +182,49 @@
   <div class="settings-group">
     <div class="settings-group-label">Provider Connections</div>
 
-    {#each providers as prov, i}
+    {#each providers as prov, i (i)}
       <div class="provider-entry">
         <div class="provider-entry-fields">
           <div class="settings-field">
-            <label>Name</label>
-            <input type="text" bind:value={prov.name} placeholder="e.g. anthropic" />
+            <label for="settings-prov-{i}-name">Name</label>
+            <input
+              id="settings-prov-{i}-name"
+              type="text"
+              bind:value={prov.name}
+              placeholder="e.g. anthropic"
+            />
           </div>
           <div class="settings-field">
-            <label>Type</label>
-            <select bind:value={prov.type}>
-              {#each Object.entries(providerTypes) as [val, label]}
+            <label for="settings-prov-{i}-type">Type</label>
+            <select id="settings-prov-{i}-type" bind:value={prov.type}>
+              {#each Object.entries(providerTypes) as [val, label] (val)}
                 <option value={val}>{label}</option>
               {/each}
             </select>
           </div>
           {#if prov.type !== "ollama"}
             <div class="settings-field">
-              <label>API Key</label>
+              <label for="settings-prov-{i}-apikey">API Key</label>
               {#if prov.apiKey.startsWith("secret:")}
                 <div class="secret-stored">
                   <span class="secret-badge">Stored securely</span>
-                  <button class="btn btn-sm btn-secondary" onclick={() => { prov.apiKey = ""; }}>Change</button>
+                  <button
+                    class="btn btn-sm btn-secondary"
+                    onclick={() => {
+                      prov.apiKey = "";
+                    }}>Change</button
+                  >
                 </div>
               {:else}
                 <input
+                  id="settings-prov-{i}-apikey"
                   type="password"
                   bind:value={prov.apiKey}
                   placeholder="API key"
                   onblur={() => {
                     invalidateProvider(prov.type);
                     for (const role of [...allRoles, "embedding", ...bgTiers]) {
-                      if (getProvider(role) === prov.name) debouncedLoadModels(role);
+                      if (getProvider(role) === prov.name) _debouncedLoadModels(role);
                     }
                   }}
                 />
@@ -217,8 +232,13 @@
             </div>
           {/if}
           <div class="settings-field">
-            <label>Base URL (optional)</label>
-            <input type="text" bind:value={prov.url} placeholder="Override base URL" />
+            <label for="settings-prov-{i}-url">Base URL (optional)</label>
+            <input
+              id="settings-prov-{i}-url"
+              type="text"
+              bind:value={prov.url}
+              placeholder="Override base URL"
+            />
           </div>
         </div>
         <button class="btn btn-sm btn-danger" onclick={() => removeProvider(i)}>Remove</button>
@@ -234,7 +254,7 @@
 
     <div class="roles-section">
       <div class="roles-section-label">Agent</div>
-      {#each ["main"] as role}
+      {#each ["main"] as role (role)}
         <div class="role-row">
           <div class="role-row-label">
             {roleLabel(role)}
@@ -245,20 +265,22 @@
           </div>
           <div class="role-row-fields">
             <div class="settings-field">
-              <label>Provider</label>
+              <label for="srole-{role}-provider">Provider</label>
               <select
+                id="srole-{role}-provider"
                 value={getProvider(role)}
                 onchange={(e) => setProvider(role, (e.target as HTMLSelectElement).value)}
               >
-                {#each providerNameOptions() as pk}
+                {#each providerNameOptions() as pk (pk)}
                   <option value={pk}>{pk}</option>
                 {/each}
               </select>
             </div>
             <div class="settings-field">
-              <label>Model</label>
+              <label for="srole-{role}-model">Model</label>
               <div class="model-select-wrap">
                 <select
+                  id="srole-{role}-model"
                   value={otherActive[role] ? "__other__" : getModel(role)}
                   onchange={(e) => setModel(role, (e.target as HTMLSelectElement).value)}
                   disabled={modelLoading[role]}
@@ -266,8 +288,8 @@
                   {#if modelLoading[role]}
                     <option value="">Loading...</option>
                   {:else}
-                    {#each modelLists[role] || [] as m}
-                      <option value={m.id}>{m.name || m.id}</option>
+                    {#each modelLists[role] ?? [] as m (m.id)}
+                      <option value={m.id}>{m.name ?? m.id}</option>
                     {/each}
                     <option value="__other__">Other...</option>
                   {/if}
@@ -277,7 +299,7 @@
                     class="model-other-input"
                     type="text"
                     placeholder="Enter model ID..."
-                    value={otherValues[role] || ""}
+                    value={otherValues[role] ?? ""}
                     oninput={(e) => setOtherModel(role, (e.target as HTMLInputElement).value)}
                   />
                 {/if}
@@ -290,7 +312,7 @@
 
     <div class="roles-section">
       <div class="roles-section-label">Subsystems</div>
-      {#each ["observer", "reflector", "pulse"] as role}
+      {#each ["observer", "reflector", "pulse"] as role (role)}
         <div class="role-row">
           <div class="role-row-label">
             {roleLabel(role)}
@@ -301,20 +323,22 @@
           </div>
           <div class="role-row-fields">
             <div class="settings-field">
-              <label>Provider</label>
+              <label for="srole-{role}-provider">Provider</label>
               <select
+                id="srole-{role}-provider"
                 value={getProvider(role)}
                 onchange={(e) => setProvider(role, (e.target as HTMLSelectElement).value)}
               >
-                {#each providerNameOptions() as pk}
+                {#each providerNameOptions() as pk (pk)}
                   <option value={pk}>{pk}</option>
                 {/each}
               </select>
             </div>
             <div class="settings-field">
-              <label>Model</label>
+              <label for="srole-{role}-model">Model</label>
               <div class="model-select-wrap">
                 <select
+                  id="srole-{role}-model"
                   value={otherActive[role] ? "__other__" : getModel(role)}
                   onchange={(e) => setModel(role, (e.target as HTMLSelectElement).value)}
                   disabled={modelLoading[role]}
@@ -322,8 +346,8 @@
                   {#if modelLoading[role]}
                     <option value="">Loading...</option>
                   {:else}
-                    {#each modelLists[role] || [] as m}
-                      <option value={m.id}>{m.name || m.id}</option>
+                    {#each modelLists[role] ?? [] as m (m.id)}
+                      <option value={m.id}>{m.name ?? m.id}</option>
                     {/each}
                     <option value="__other__">Other...</option>
                   {/if}
@@ -333,7 +357,7 @@
                     class="model-other-input"
                     type="text"
                     placeholder="Enter model ID..."
-                    value={otherValues[role] || ""}
+                    value={otherValues[role] ?? ""}
                     oninput={(e) => setOtherModel(role, (e.target as HTMLInputElement).value)}
                   />
                 {/if}
@@ -356,20 +380,25 @@
         </div>
         <div class="role-row-fields">
           <div class="settings-field">
-            <label>Provider</label>
+            <label for="srole-embedding-provider">Provider</label>
             <select
+              id="srole-embedding-provider"
               value={getProvider("embedding")}
               onchange={(e) => setProvider("embedding", (e.target as HTMLSelectElement).value)}
             >
-              {#each providerNameOptions().filter((n) => { const entry = providerEntry(n); return entry && EMBEDDING_PROVIDERS.includes(entry.type); }) as pk}
+              {#each providerNameOptions().filter((n) => {
+                const entry = providerEntry(n);
+                return entry && EMBEDDING_PROVIDERS.includes(entry.type);
+              }) as pk (pk)}
                 <option value={pk}>{pk}</option>
               {/each}
             </select>
           </div>
           <div class="settings-field">
-            <label>Model</label>
+            <label for="srole-embedding-model">Model</label>
             <div class="model-select-wrap">
               <select
+                id="srole-embedding-model"
                 value={otherActive["embedding"] ? "__other__" : getModel("embedding")}
                 onchange={(e) => setModel("embedding", (e.target as HTMLSelectElement).value)}
                 disabled={modelLoading["embedding"]}
@@ -377,8 +406,8 @@
                 {#if modelLoading["embedding"]}
                   <option value="">Loading...</option>
                 {:else}
-                  {#each modelLists["embedding"] || [] as m}
-                    <option value={m.id}>{m.name || m.id}</option>
+                  {#each modelLists["embedding"] ?? [] as m (m.id)}
+                    <option value={m.id}>{m.name ?? m.id}</option>
                   {/each}
                   <option value="__other__">Other...</option>
                 {/if}
@@ -388,7 +417,7 @@
                   class="model-other-input"
                   type="text"
                   placeholder="Enter model ID..."
-                  value={otherValues["embedding"] || ""}
+                  value={otherValues["embedding"] ?? ""}
                   oninput={(e) => setOtherModel("embedding", (e.target as HTMLInputElement).value)}
                 />
               {/if}
@@ -400,7 +429,7 @@
 
     <div class="roles-section">
       <div class="roles-section-label">Background Tasks</div>
-      {#each bgTiers as role}
+      {#each bgTiers as role (role)}
         <div class="role-row">
           <div class="role-row-label">
             {roleLabel(role)}
@@ -411,20 +440,22 @@
           </div>
           <div class="role-row-fields">
             <div class="settings-field">
-              <label>Provider</label>
+              <label for="srole-{role}-provider">Provider</label>
               <select
+                id="srole-{role}-provider"
                 value={getProvider(role)}
                 onchange={(e) => setProvider(role, (e.target as HTMLSelectElement).value)}
               >
-                {#each providerNameOptions() as pk}
+                {#each providerNameOptions() as pk (pk)}
                   <option value={pk}>{pk}</option>
                 {/each}
               </select>
             </div>
             <div class="settings-field">
-              <label>Model</label>
+              <label for="srole-{role}-model">Model</label>
               <div class="model-select-wrap">
                 <select
+                  id="srole-{role}-model"
                   value={otherActive[role] ? "__other__" : getModel(role)}
                   onchange={(e) => setModel(role, (e.target as HTMLSelectElement).value)}
                   disabled={modelLoading[role]}
@@ -432,8 +463,8 @@
                   {#if modelLoading[role]}
                     <option value="">Loading...</option>
                   {:else}
-                    {#each modelLists[role] || [] as m}
-                      <option value={m.id}>{m.name || m.id}</option>
+                    {#each modelLists[role] ?? [] as m (m.id)}
+                      <option value={m.id}>{m.name ?? m.id}</option>
                     {/each}
                     <option value="__other__">Other...</option>
                   {/if}
@@ -443,7 +474,7 @@
                     class="model-other-input"
                     type="text"
                     placeholder="Enter model ID..."
-                    value={otherValues[role] || ""}
+                    value={otherValues[role] ?? ""}
                     oninput={(e) => setOtherModel(role, (e.target as HTMLInputElement).value)}
                   />
                 {/if}

--- a/web/src/components/settings/Runtime.svelte
+++ b/web/src/components/settings/Runtime.svelte
@@ -8,36 +8,71 @@
   <div class="settings-group">
     <div class="settings-group-label">General</div>
     <div class="settings-field">
-      <label>Name</label>
-      <input type="text" bind:value={fields.name} placeholder="What the agent calls you" />
+      <label for="rt-name">Name</label>
+      <input
+        id="rt-name"
+        type="text"
+        bind:value={fields.name}
+        placeholder="What the agent calls you"
+      />
     </div>
     <div class="settings-field">
-      <label>Timezone</label>
-      <input type="text" bind:value={fields.timezone} placeholder="e.g. America/New_York" />
+      <label for="rt-timezone">Timezone</label>
+      <input
+        id="rt-timezone"
+        type="text"
+        bind:value={fields.timezone}
+        placeholder="e.g. America/New_York"
+      />
     </div>
     <div class="settings-field">
-      <label>Workspace Directory</label>
-      <input type="text" bind:value={fields.workspace_dir} placeholder="Default: ~/.residuum/workspace" />
+      <label for="rt-workspace-dir">Workspace Directory</label>
+      <input
+        id="rt-workspace-dir"
+        type="text"
+        bind:value={fields.workspace_dir}
+        placeholder="Default: ~/.residuum/workspace"
+      />
     </div>
     <div class="settings-field">
-      <label>Timeout (seconds)</label>
-      <input type="number" bind:value={fields.timeout_secs} placeholder="Default: 120" />
+      <label for="rt-timeout">Timeout (seconds)</label>
+      <input
+        id="rt-timeout"
+        type="number"
+        bind:value={fields.timeout_secs}
+        placeholder="Default: 120"
+      />
     </div>
     <div class="settings-field">
-      <label>Max Tokens</label>
-      <input type="number" bind:value={fields.max_tokens} placeholder="Default: 8192" />
+      <label for="rt-max-tokens">Max Tokens</label>
+      <input
+        id="rt-max-tokens"
+        type="number"
+        bind:value={fields.max_tokens}
+        placeholder="Default: 8192"
+      />
     </div>
   </div>
 
   <div class="settings-group">
     <div class="settings-group-label">Gateway</div>
     <div class="settings-field">
-      <label>Bind Address</label>
-      <input type="text" bind:value={fields.gateway_bind} placeholder="Default: 127.0.0.1" />
+      <label for="rt-gateway-bind">Bind Address</label>
+      <input
+        id="rt-gateway-bind"
+        type="text"
+        bind:value={fields.gateway_bind}
+        placeholder="Default: 127.0.0.1"
+      />
     </div>
     <div class="settings-field">
-      <label>Port</label>
-      <input type="number" bind:value={fields.gateway_port} placeholder="Default: 7700" />
+      <label for="rt-gateway-port">Port</label>
+      <input
+        id="rt-gateway-port"
+        type="number"
+        bind:value={fields.gateway_port}
+        placeholder="Default: 7700"
+      />
     </div>
   </div>
 
@@ -53,32 +88,63 @@
       </label>
     </div>
     <div class="settings-field">
-      <label>Max Concurrent Background Tasks</label>
-      <input type="number" bind:value={fields.bg_max_concurrent} placeholder="Default: 3" />
+      <label for="rt-bg-max-concurrent">Max Concurrent Background Tasks</label>
+      <input
+        id="rt-bg-max-concurrent"
+        type="number"
+        bind:value={fields.bg_max_concurrent}
+        placeholder="Default: 3"
+      />
     </div>
     <div class="settings-field">
-      <label>Transcript Retention (days)</label>
-      <input type="number" bind:value={fields.bg_transcript_retention_days} placeholder="Default: 7" />
+      <label for="rt-bg-transcript-retention">Transcript Retention (days)</label>
+      <input
+        id="rt-bg-transcript-retention"
+        type="number"
+        bind:value={fields.bg_transcript_retention_days}
+        placeholder="Default: 7"
+      />
     </div>
   </div>
 
   <div class="settings-group">
     <div class="settings-group-label">Retry</div>
     <div class="settings-field">
-      <label>Max Retries</label>
-      <input type="number" bind:value={fields.retry_max_retries} placeholder="Default: 3" />
+      <label for="rt-retry-max-retries">Max Retries</label>
+      <input
+        id="rt-retry-max-retries"
+        type="number"
+        bind:value={fields.retry_max_retries}
+        placeholder="Default: 3"
+      />
     </div>
     <div class="settings-field">
-      <label>Initial Delay (ms)</label>
-      <input type="number" bind:value={fields.retry_initial_delay_ms} placeholder="Default: 1000" />
+      <label for="rt-retry-initial-delay">Initial Delay (ms)</label>
+      <input
+        id="rt-retry-initial-delay"
+        type="number"
+        bind:value={fields.retry_initial_delay_ms}
+        placeholder="Default: 1000"
+      />
     </div>
     <div class="settings-field">
-      <label>Max Delay (ms)</label>
-      <input type="number" bind:value={fields.retry_max_delay_ms} placeholder="Default: 30000" />
+      <label for="rt-retry-max-delay">Max Delay (ms)</label>
+      <input
+        id="rt-retry-max-delay"
+        type="number"
+        bind:value={fields.retry_max_delay_ms}
+        placeholder="Default: 30000"
+      />
     </div>
     <div class="settings-field">
-      <label>Backoff Multiplier</label>
-      <input type="number" step="0.1" bind:value={fields.retry_backoff_multiplier} placeholder="Default: 2.0" />
+      <label for="rt-retry-backoff">Backoff Multiplier</label>
+      <input
+        id="rt-retry-backoff"
+        type="number"
+        step="0.1"
+        bind:value={fields.retry_backoff_multiplier}
+        placeholder="Default: 2.0"
+      />
     </div>
   </div>
 

--- a/web/src/components/setup/Integrations.svelte
+++ b/web/src/components/setup/Integrations.svelte
@@ -11,17 +11,23 @@
 </script>
 
 <h2>Integrations</h2>
-<p class="subtitle">Optionally connect Discord and/or Telegram bots. You can skip this and add them later.</p>
+<p class="subtitle">
+  Optionally connect Discord and/or Telegram bots. You can skip this and add them later.
+</p>
 
 <div class="integration-card">
   <div class="integration-header">Discord</div>
   <div class="integration-desc">
-    Connect a Discord bot so your agent can communicate via DMs.
-    Create a bot at <a href="https://discord.com/developers/applications" target="_blank" rel="noopener">discord.com/developers</a>.
+    Connect a Discord bot so your agent can communicate via DMs. Create a bot at <a
+      href="https://discord.com/developers/applications"
+      target="_blank"
+      rel="noopener">discord.com/developers</a
+    >.
   </div>
   <div class="settings-field">
-    <label>Bot Token</label>
+    <label for="setup-discord-token">Bot Token</label>
     <input
+      id="setup-discord-token"
       type="password"
       bind:value={wizardState.integrations.discordToken}
       placeholder="Discord bot token (optional)"
@@ -32,12 +38,16 @@
 <div class="integration-card">
   <div class="integration-header">Telegram</div>
   <div class="integration-desc">
-    Connect a Telegram bot for DM-based interaction.
-    Create a bot via <a href="https://t.me/BotFather" target="_blank" rel="noopener">@BotFather</a>.
+    Connect a Telegram bot for DM-based interaction. Create a bot via <a
+      href="https://t.me/BotFather"
+      target="_blank"
+      rel="noopener">@BotFather</a
+    >.
   </div>
   <div class="settings-field">
-    <label>Bot Token</label>
+    <label for="setup-telegram-token">Bot Token</label>
     <input
+      id="setup-telegram-token"
       type="password"
       bind:value={wizardState.integrations.telegramToken}
       placeholder="Telegram bot token (optional)"

--- a/web/src/components/setup/MCP.svelte
+++ b/web/src/components/setup/MCP.svelte
@@ -51,7 +51,7 @@
     // Validate all required inputs
     let hasError = false;
     for (const req of srv.requires_input) {
-      const val = (pendingInputs[req.field] || "").trim();
+      const val = (pendingInputs[req.field] ?? "").trim();
       if (!val) {
         inputErrors[req.field] = true;
         hasError = true;
@@ -63,7 +63,7 @@
     const env = { ...(srv.env || {}) };
     for (const req of srv.requires_input) {
       const key = req.field.startsWith("env.") ? req.field.slice(4) : req.field;
-      env[key] = pendingInputs[req.field].trim();
+      env[key] = (pendingInputs[req.field] ?? "").trim();
     }
 
     wizardState.mcpServers.push({
@@ -86,7 +86,7 @@
 {#if catalog.length === 0}
   <p style="color:var(--text-dim)">No catalog entries available.</p>
 {:else}
-  {#each catalog as srv, i}
+  {#each catalog as srv, i (srv.name)}
     {@const added = isAdded(srv.name)}
     {@const isPending = pendingIdx === i}
     <div class="mcp-item" class:added class:pending={isPending}>
@@ -103,15 +103,18 @@
 
       {#if isPending && srv.requires_input.length > 0}
         <div class="mcp-inline-inputs">
-          {#each srv.requires_input as req}
+          {#each srv.requires_input as req (req.field)}
             <div class="settings-field mcp-input-field">
-              <label>{req.label}</label>
+              <label for="mcp-setup-{i}-{req.field}">{req.label}</label>
               <input
+                id="mcp-setup-{i}-{req.field}"
                 type="text"
                 class:input-error={inputErrors[req.field]}
                 bind:value={pendingInputs[req.field]}
                 placeholder={req.label}
-                oninput={() => { inputErrors[req.field] = false; }}
+                oninput={() => {
+                  inputErrors[req.field] = false;
+                }}
               />
             </div>
           {/each}

--- a/web/src/components/setup/Providers.svelte
+++ b/web/src/components/setup/Providers.svelte
@@ -10,7 +10,10 @@
 
   let { wizardState, onNext, onBack }: Props = $props();
 
-  const providers: Record<ProviderKey, { name: string; desc: string; keyEnv: string; showUrl?: boolean }> = {
+  const providers: Record<
+    ProviderKey,
+    { name: string; desc: string; keyEnv: string; showUrl?: boolean }
+  > = {
     anthropic: {
       name: "Anthropic",
       desc: "Claude models (Sonnet, Haiku, Opus)",
@@ -42,7 +45,7 @@
       if (wizardState.selectedProviders.length <= 1) return;
       wizardState.selectedProviders.splice(idx, 1);
       if (wizardState.mainProvider === key) {
-        wizardState.mainProvider = wizardState.selectedProviders[0];
+        wizardState.mainProvider = wizardState.selectedProviders[0] ?? "anthropic";
       }
     } else {
       wizardState.selectedProviders.push(key);
@@ -50,7 +53,7 @@
   }
 
   let hasEmbeddingProvider = $derived(
-    wizardState.selectedProviders.some((p) => EMBEDDING_PROVIDERS.includes(p))
+    wizardState.selectedProviders.some((p) => EMBEDDING_PROVIDERS.includes(p)),
   );
 </script>
 
@@ -58,7 +61,7 @@
 <p class="subtitle">Select one or more LLM providers. You can mix providers across roles.</p>
 
 <div>
-  {#each providerKeys as key}
+  {#each providerKeys as key (key)}
     {@const p = providers[key]}
     {@const isSelected = wizardState.selectedProviders.includes(key)}
     <div
@@ -67,7 +70,12 @@
       onclick={() => toggleProvider(key)}
       role="button"
       tabindex="0"
-      onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggleProvider(key); } }}
+      onkeydown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          toggleProvider(key);
+        }
+      }}
     >
       <div class="provider-check">{isSelected ? "\u2713" : ""}</div>
       <div>
@@ -81,28 +89,42 @@
 {#if !hasEmbeddingProvider && wizardState.selectedProviders.length > 0}
   <div class="provider-warning">
     <span class="provider-warning-icon">&#9888;</span>
-    <span>None of the selected providers offer an embedding API.
-    Memory search works best with embeddings — consider adding OpenAI, Gemini, or Ollama.</span>
+    <span
+      >None of the selected providers offer an embedding API. Memory search works best with
+      embeddings — consider adding OpenAI, Gemini, or Ollama.</span
+    >
   </div>
 {/if}
 
 {#if wizardState.selectedProviders.length > 0}
   <div class="provider-configs">
-    {#each wizardState.selectedProviders as key}
+    {#each wizardState.selectedProviders as key (key)}
       {@const p = providers[key]}
       {@const cfg = wizardState.providerConfigs[key]}
       <div class="provider-config-section">
         <div class="provider-config-header">{p.name}</div>
         {#if key !== "ollama"}
           <div class="settings-field">
-            <label>API Key{p.keyEnv ? ` (or set ${p.keyEnv} env var)` : ""}</label>
-            <input type="password" bind:value={cfg.apiKey} placeholder="sk-..." />
+            <label for="prov-{key}-apikey"
+              >API Key{p.keyEnv ? ` (or set ${p.keyEnv} env var)` : ""}</label
+            >
+            <input
+              id="prov-{key}-apikey"
+              type="password"
+              bind:value={cfg.apiKey}
+              placeholder="sk-..."
+            />
           </div>
         {/if}
         {#if p.showUrl}
           <div class="settings-field">
-            <label>Base URL (leave blank for default)</label>
-            <input type="text" bind:value={cfg.url} placeholder="https://api.openai.com/v1" />
+            <label for="prov-{key}-url">Base URL (leave blank for default)</label>
+            <input
+              id="prov-{key}-url"
+              type="text"
+              bind:value={cfg.url}
+              placeholder="https://api.openai.com/v1"
+            />
           </div>
         {/if}
       </div>

--- a/web/src/components/setup/Review.svelte
+++ b/web/src/components/setup/Review.svelte
@@ -34,8 +34,10 @@
     // Role-specific API keys (if different from provider config)
     for (const role of ["observer", "reflector", "pulse"]) {
       const r = wizardState.roles[role];
+      if (!r) continue;
       const prov = r.provider || wizardState.mainProvider;
-      const provKey = wizardState.providerConfigs[prov as keyof typeof wizardState.providerConfigs]?.apiKey || "";
+      const provKey =
+        wizardState.providerConfigs[prov as keyof typeof wizardState.providerConfigs]?.apiKey || "";
       if (r.apiKey && r.apiKey !== provKey) {
         const name = `${role}_${prov}`;
         promises.push(
@@ -83,9 +85,7 @@
     // Generate all config files with secret references
     const configToml = generateConfigToml(wizardState);
     const providersToml = generateProvidersToml(wizardState);
-    const mcpJson = wizardState.mcpServers.length > 0
-      ? generateMcpJson(wizardState)
-      : undefined;
+    const mcpJson = wizardState.mcpServers.length > 0 ? generateMcpJson(wizardState) : undefined;
 
     try {
       const result = await completeSetup(configToml, providersToml, mcpJson);
@@ -94,7 +94,7 @@
         validationClass = "success";
         setTimeout(() => onComplete(), 1500);
       } else {
-        validationMsg = result.error || "Validation failed";
+        validationMsg = result.error ?? "Validation failed";
         validationClass = "error";
         saving = false;
       }
@@ -117,12 +117,15 @@
   </div>
   <div class="review-item">
     <span class="review-label">Main model</span>
-    <span class="review-value">{wizardState.mainProvider}/{wizardState.providerConfigs[wizardState.mainProvider].model || "default"}</span>
+    <span class="review-value"
+      >{wizardState.mainProvider}/{wizardState.providerConfigs[wizardState.mainProvider].model ||
+        "default"}</span
+    >
   </div>
   {#if wizardState.mcpServers.length > 0}
     <div class="review-item">
       <span class="review-label">MCP servers</span>
-      <span class="review-value">{wizardState.mcpServers.map(s => s.name).join(", ")}</span>
+      <span class="review-value">{wizardState.mcpServers.map((s) => s.name).join(", ")}</span>
     </div>
   {/if}
   {#if wizardState.integrations.discordToken || wizardState.integrations.telegramToken}
@@ -132,7 +135,9 @@
         {[
           wizardState.integrations.discordToken ? "Discord" : "",
           wizardState.integrations.telegramToken ? "Telegram" : "",
-        ].filter(Boolean).join(", ")}
+        ]
+          .filter(Boolean)
+          .join(", ")}
       </span>
     </div>
   {/if}

--- a/web/src/components/setup/Roles.svelte
+++ b/web/src/components/setup/Roles.svelte
@@ -28,11 +28,15 @@
 
   const roleTooltips: Record<string, string> = {
     main: "The primary model used for conversations and task execution.",
-    observer: "Watches conversations and extracts facts, preferences, and patterns for long-term memory.",
-    reflector: "Periodically reviews stored memories, consolidates duplicates, and resolves contradictions.",
+    observer:
+      "Watches conversations and extracts facts, preferences, and patterns for long-term memory.",
+    reflector:
+      "Periodically reviews stored memories, consolidates duplicates, and resolves contradictions.",
     pulse: "Drives proactive behavior — daily briefings, check-ins, and ambient monitoring tasks.",
-    embedding: "Generates vector embeddings for semantic memory search. Only some providers support this.",
-    "bg-small": "Used for lightweight background tasks like formatting, simple lookups, and notifications.",
+    embedding:
+      "Generates vector embeddings for semantic memory search. Only some providers support this.",
+    "bg-small":
+      "Used for lightweight background tasks like formatting, simple lookups, and notifications.",
     "bg-medium": "Used for moderate background tasks like summarization and analysis.",
     "bg-large": "Used for complex background tasks that need strong reasoning ability.",
   };
@@ -46,20 +50,20 @@
   function getRoleProvider(role: string): string {
     if (role === "main") return wizardState.mainProvider;
     if (role === "embedding") {
-      return wizardState.embeddingModel.provider || defaultEmbeddingProvider();
+      return wizardState.embeddingModel.provider ?? defaultEmbeddingProvider();
     }
     if (role.startsWith("bg-")) {
       const tier = role.slice(3);
-      return wizardState.backgroundModels[tier].provider || wizardState.mainProvider;
+      return wizardState.backgroundModels[tier]?.provider ?? wizardState.mainProvider;
     }
-    return wizardState.roles[role]?.provider || wizardState.mainProvider;
+    return wizardState.roles[role]?.provider ?? wizardState.mainProvider;
   }
 
   function getRoleModel(role: string): string {
     if (role === "main") return wizardState.providerConfigs[wizardState.mainProvider].model;
     if (role === "embedding") return wizardState.embeddingModel.model;
-    if (role.startsWith("bg-")) return wizardState.backgroundModels[role.slice(3)].model;
-    return wizardState.roles[role]?.model || "";
+    if (role.startsWith("bg-")) return wizardState.backgroundModels[role.slice(3)]?.model ?? "";
+    return wizardState.roles[role]?.model ?? "";
   }
 
   function setRoleProvider(role: string, prov: string) {
@@ -71,15 +75,21 @@
       wizardState.embeddingModel.model = "";
     } else if (role.startsWith("bg-")) {
       const tier = role.slice(3);
-      wizardState.backgroundModels[tier].provider = prov;
-      wizardState.backgroundModels[tier].model = "";
+      const bg = wizardState.backgroundModels[tier];
+      if (bg) {
+        bg.provider = prov;
+        bg.model = "";
+      }
     } else {
-      wizardState.roles[role].provider = prov;
-      wizardState.roles[role].model = "";
+      const r = wizardState.roles[role];
+      if (r) {
+        r.provider = prov;
+        r.model = "";
+      }
     }
     otherActive[role] = false;
     otherValues[role] = "";
-    loadModels(role);
+    void loadModels(role);
   }
 
   function setRoleModel(role: string, value: string) {
@@ -93,9 +103,11 @@
     } else if (role === "embedding") {
       wizardState.embeddingModel.model = value;
     } else if (role.startsWith("bg-")) {
-      wizardState.backgroundModels[role.slice(3)].model = value;
+      const bg = wizardState.backgroundModels[role.slice(3)];
+      if (bg) bg.model = value;
     } else {
-      wizardState.roles[role].model = value;
+      const r = wizardState.roles[role];
+      if (r) r.model = value;
     }
   }
 
@@ -106,30 +118,30 @@
     } else if (role === "embedding") {
       wizardState.embeddingModel.model = value;
     } else if (role.startsWith("bg-")) {
-      wizardState.backgroundModels[role.slice(3)].model = value;
+      const bg = wizardState.backgroundModels[role.slice(3)];
+      if (bg) bg.model = value;
     } else {
-      wizardState.roles[role].model = value;
+      const r = wizardState.roles[role];
+      if (r) r.model = value;
     }
   }
 
   function defaultEmbeddingProvider(): string {
     return (
-      wizardState.selectedProviders.find((p) => EMBEDDING_PROVIDERS.includes(p)) ||
-      EMBEDDING_PROVIDERS[0] ||
+      wizardState.selectedProviders.find((p) => EMBEDDING_PROVIDERS.includes(p)) ??
+      EMBEDDING_PROVIDERS[0] ??
       ""
     );
   }
 
   let hasEmbeddingProvider = $derived(
-    wizardState.selectedProviders.some((p) => EMBEDDING_PROVIDERS.includes(p))
+    wizardState.selectedProviders.some((p) => EMBEDDING_PROVIDERS.includes(p)),
   );
 
   let mainProviderOptions = $derived([...wizardState.selectedProviders]);
 
   let embeddingProviderOptions = $derived(
-    EMBEDDING_PROVIDERS.filter((p) =>
-      wizardState.selectedProviders.includes(p as ProviderKey)
-    )
+    EMBEDDING_PROVIDERS.filter((p) => wizardState.selectedProviders.includes(p as ProviderKey)),
   );
 
   async function loadModels(role: string) {
@@ -137,20 +149,20 @@
 
     // Embedding models are never returned by provider APIs — use hardcoded lists
     if (role === "embedding") {
-      const models = EMBEDDING_MODEL_LISTS[prov] || [];
+      const models = EMBEDDING_MODEL_LISTS[prov] ?? [];
       modelLists[role] = models;
       const current = getRoleModel(role);
       if (!current && models.length > 0) {
-        const defaultModel = DEFAULT_EMBEDDING_MODELS[prov] || "";
+        const defaultModel = DEFAULT_EMBEDDING_MODELS[prov] ?? "";
         const found = models.some((m) => m.id === defaultModel);
-        setRoleModel(role, found ? defaultModel : models[0].id);
+        setRoleModel(role, found ? defaultModel : (models[0]?.id ?? ""));
       }
       return;
     }
 
     const provCfg = wizardState.providerConfigs[prov as ProviderKey];
     const apiKey = prov !== "ollama" ? provCfg?.apiKey : undefined;
-    const url = provCfg?.url || undefined;
+    const url = provCfg?.url ?? undefined;
 
     modelLoading[role] = true;
     const result = await fetchModels(prov, apiKey, url);
@@ -160,23 +172,23 @@
     // Auto-select default if no model set
     const current = getRoleModel(role);
     if (!current && result.models.length > 0) {
-      const defaultModel = DEFAULT_MODELS[prov] || "";
+      const defaultModel = DEFAULT_MODELS[prov] ?? "";
       const found = result.models.some((m) => m.id === defaultModel);
-      setRoleModel(role, found ? defaultModel : result.models[0].id);
+      setRoleModel(role, found ? defaultModel : (result.models[0]?.id ?? ""));
     }
   }
 
-  const debouncedLoadModels = debounce((role: string) => {
-    loadModels(role);
+  const _debouncedLoadModels = debounce((role: string) => {
+    void loadModels(role);
   }, 500);
 
   const allRoles = ["main", "observer", "reflector", "pulse"];
   const bgTiers = ["small", "medium", "large"];
 
   onMount(() => {
-    for (const role of allRoles) loadModels(role);
-    if (hasEmbeddingProvider) loadModels("embedding");
-    for (const tier of bgTiers) loadModels(`bg-${tier}`);
+    for (const role of allRoles) void loadModels(role);
+    if (hasEmbeddingProvider) void loadModels("embedding");
+    for (const tier of bgTiers) void loadModels(`bg-${tier}`);
   });
 
   function roleRow(role: string): { label: string; providerOptions: string[] } {
@@ -187,7 +199,7 @@
       return {
         label: "Embedding",
         providerOptions: EMBEDDING_PROVIDERS.filter((p) =>
-          wizardState.selectedProviders.includes(p as ProviderKey)
+          wizardState.selectedProviders.includes(p as ProviderKey),
         ),
       };
     }
@@ -200,14 +212,16 @@
       "bg-large": "Large",
     };
     return {
-      label: labels[role] || role,
+      label: labels[role] ?? role,
       providerOptions: Object.keys(providers),
     };
   }
 </script>
 
 <h2>Assign Models</h2>
-<p class="subtitle">Choose which model to use for each role. All default to the main model if left unchanged.</p>
+<p class="subtitle">
+  Choose which model to use for each role. All default to the main model if left unchanged.
+</p>
 
 <!-- Agent section -->
 <div class="roles-section">
@@ -222,20 +236,22 @@
     </div>
     <div class="role-row-fields">
       <div class="settings-field">
-        <label>Provider</label>
+        <label for="role-main-provider">Provider</label>
         <select
+          id="role-main-provider"
           value={getRoleProvider("main")}
           onchange={(e) => setRoleProvider("main", (e.target as HTMLSelectElement).value)}
         >
-          {#each mainProviderOptions as pk}
+          {#each mainProviderOptions as pk (pk)}
             <option value={pk}>{providers[pk]}</option>
           {/each}
         </select>
       </div>
       <div class="settings-field">
-        <label>Model</label>
+        <label for="role-main-model">Model</label>
         <div class="model-select-wrap">
           <select
+            id="role-main-model"
             value={otherActive["main"] ? "__other__" : getRoleModel("main")}
             onchange={(e) => setRoleModel("main", (e.target as HTMLSelectElement).value)}
             disabled={modelLoading["main"]}
@@ -243,8 +259,8 @@
             {#if modelLoading["main"]}
               <option value="">Loading...</option>
             {:else}
-              {#each modelLists["main"] || [] as m}
-                <option value={m.id}>{m.name || m.id}</option>
+              {#each modelLists["main"] ?? [] as m (m.id)}
+                <option value={m.id}>{m.name ?? m.id}</option>
               {/each}
               <option value="__other__">Other...</option>
             {/if}
@@ -254,7 +270,7 @@
               class="model-other-input"
               type="text"
               placeholder="Enter model ID..."
-              value={otherValues["main"] || ""}
+              value={otherValues["main"] ?? ""}
               oninput={(e) => setOtherModel("main", (e.target as HTMLInputElement).value)}
             />
           {/if}
@@ -267,8 +283,10 @@
 <!-- Subsystems section -->
 <div class="roles-section">
   <div class="roles-section-label">Subsystems</div>
-  <p class="roles-section-hint">Memory and proactivity subsystems. These can use smaller, cheaper models.</p>
-  {#each ["observer", "reflector", "pulse"] as role}
+  <p class="roles-section-hint">
+    Memory and proactivity subsystems. These can use smaller, cheaper models.
+  </p>
+  {#each ["observer", "reflector", "pulse"] as role (role)}
     {@const info = roleRow(role)}
     <div class="role-row">
       <div class="role-row-label">
@@ -280,20 +298,22 @@
       </div>
       <div class="role-row-fields">
         <div class="settings-field">
-          <label>Provider</label>
+          <label for="role-{role}-provider">Provider</label>
           <select
+            id="role-{role}-provider"
             value={getRoleProvider(role)}
             onchange={(e) => setRoleProvider(role, (e.target as HTMLSelectElement).value)}
           >
-            {#each info.providerOptions as pk}
+            {#each info.providerOptions as pk (pk)}
               <option value={pk}>{providers[pk]}</option>
             {/each}
           </select>
         </div>
         <div class="settings-field">
-          <label>Model</label>
+          <label for="role-{role}-model">Model</label>
           <div class="model-select-wrap">
             <select
+              id="role-{role}-model"
               value={otherActive[role] ? "__other__" : getRoleModel(role)}
               onchange={(e) => setRoleModel(role, (e.target as HTMLSelectElement).value)}
               disabled={modelLoading[role]}
@@ -301,8 +321,8 @@
               {#if modelLoading[role]}
                 <option value="">Loading...</option>
               {:else}
-                {#each modelLists[role] || [] as m}
-                  <option value={m.id}>{m.name || m.id}</option>
+                {#each modelLists[role] ?? [] as m (m.id)}
+                  <option value={m.id}>{m.name ?? m.id}</option>
                 {/each}
                 <option value="__other__">Other...</option>
               {/if}
@@ -312,7 +332,7 @@
                 class="model-other-input"
                 type="text"
                 placeholder="Enter model ID..."
-                value={otherValues[role] || ""}
+                value={otherValues[role] ?? ""}
                 oninput={(e) => setOtherModel(role, (e.target as HTMLInputElement).value)}
               />
             {/if}
@@ -327,7 +347,9 @@
 {#if hasEmbeddingProvider}
   <div class="roles-section">
     <div class="roles-section-label">Embedding</div>
-    <p class="roles-section-hint">Used for semantic memory search. Anthropic does not offer embeddings.</p>
+    <p class="roles-section-hint">
+      Used for semantic memory search. Anthropic does not offer embeddings.
+    </p>
     <div class="role-row">
       <div class="role-row-label">
         Embedding
@@ -338,20 +360,22 @@
       </div>
       <div class="role-row-fields">
         <div class="settings-field">
-          <label>Provider</label>
+          <label for="role-embedding-provider">Provider</label>
           <select
+            id="role-embedding-provider"
             value={getRoleProvider("embedding")}
             onchange={(e) => setRoleProvider("embedding", (e.target as HTMLSelectElement).value)}
           >
-            {#each embeddingProviderOptions as pk}
+            {#each embeddingProviderOptions as pk (pk)}
               <option value={pk}>{providers[pk]}</option>
             {/each}
           </select>
         </div>
         <div class="settings-field">
-          <label>Model</label>
+          <label for="role-embedding-model">Model</label>
           <div class="model-select-wrap">
             <select
+              id="role-embedding-model"
               value={otherActive["embedding"] ? "__other__" : getRoleModel("embedding")}
               onchange={(e) => setRoleModel("embedding", (e.target as HTMLSelectElement).value)}
               disabled={modelLoading["embedding"]}
@@ -359,8 +383,8 @@
               {#if modelLoading["embedding"]}
                 <option value="">Loading...</option>
               {:else}
-                {#each modelLists["embedding"] || [] as m}
-                  <option value={m.id}>{m.name || m.id}</option>
+                {#each modelLists["embedding"] ?? [] as m (m.id)}
+                  <option value={m.id}>{m.name ?? m.id}</option>
                 {/each}
                 <option value="__other__">Other...</option>
               {/if}
@@ -370,7 +394,7 @@
                 class="model-other-input"
                 type="text"
                 placeholder="Enter model ID..."
-                value={otherValues["embedding"] || ""}
+                value={otherValues["embedding"] ?? ""}
                 oninput={(e) => setOtherModel("embedding", (e.target as HTMLInputElement).value)}
               />
             {/if}
@@ -384,8 +408,10 @@
 <!-- Background section -->
 <div class="roles-section">
   <div class="roles-section-label">Background Tasks</div>
-  <p class="roles-section-hint">Tiered models for background work. Tasks specify small, medium, or large.</p>
-  {#each bgTiers as tier}
+  <p class="roles-section-hint">
+    Tiered models for background work. Tasks specify small, medium, or large.
+  </p>
+  {#each bgTiers as tier (tier)}
     {@const role = `bg-${tier}`}
     {@const info = roleRow(role)}
     <div class="role-row">
@@ -398,20 +424,22 @@
       </div>
       <div class="role-row-fields">
         <div class="settings-field">
-          <label>Provider</label>
+          <label for="role-bg-{tier}-provider">Provider</label>
           <select
+            id="role-bg-{tier}-provider"
             value={getRoleProvider(role)}
             onchange={(e) => setRoleProvider(role, (e.target as HTMLSelectElement).value)}
           >
-            {#each info.providerOptions as pk}
+            {#each info.providerOptions as pk (pk)}
               <option value={pk}>{providers[pk]}</option>
             {/each}
           </select>
         </div>
         <div class="settings-field">
-          <label>Model</label>
+          <label for="role-bg-{tier}-model">Model</label>
           <div class="model-select-wrap">
             <select
+              id="role-bg-{tier}-model"
               value={otherActive[role] ? "__other__" : getRoleModel(role)}
               onchange={(e) => setRoleModel(role, (e.target as HTMLSelectElement).value)}
               disabled={modelLoading[role]}
@@ -419,8 +447,8 @@
               {#if modelLoading[role]}
                 <option value="">Loading...</option>
               {:else}
-                {#each modelLists[role] || [] as m}
-                  <option value={m.id}>{m.name || m.id}</option>
+                {#each modelLists[role] ?? [] as m (m.id)}
+                  <option value={m.id}>{m.name ?? m.id}</option>
                 {/each}
                 <option value="__other__">Other...</option>
               {/if}
@@ -430,7 +458,7 @@
                 class="model-other-input"
                 type="text"
                 placeholder="Enter model ID..."
-                value={otherValues[role] || ""}
+                value={otherValues[role] ?? ""}
                 oninput={(e) => setOtherModel(role, (e.target as HTMLInputElement).value)}
               />
             {/if}

--- a/web/src/components/setup/Welcome.svelte
+++ b/web/src/components/setup/Welcome.svelte
@@ -13,8 +13,9 @@
 <p class="subtitle">Let's get your agent configured. This will only take a minute.</p>
 
 <div class="settings-field">
-  <label>Your Name</label>
+  <label for="welcome-name">Your Name</label>
   <input
+    id="welcome-name"
     type="text"
     bind:value={wizardState.userName}
     placeholder="What should your agent call you?"
@@ -22,8 +23,9 @@
 </div>
 
 <div class="settings-field">
-  <label>Timezone (IANA format)</label>
+  <label for="welcome-timezone">Timezone (IANA format)</label>
   <input
+    id="welcome-timezone"
     type="text"
     bind:value={wizardState.timezone}
     placeholder="America/New_York"

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -14,13 +14,13 @@ import type {
 export async function fetchStatus(): Promise<StatusResponse> {
   const resp = await fetch("/api/status");
   if (!resp.ok) throw new Error(`status check failed: ${resp.status}`);
-  return resp.json();
+  return (await resp.json()) as StatusResponse;
 }
 
 export async function fetchChatHistory(): Promise<RecentMessage[]> {
   const resp = await fetch("/api/chat/history");
   if (!resp.ok) return [];
-  return resp.json();
+  return (await resp.json()) as RecentMessage[];
 }
 
 // ── Setup API wrappers ──────────────────────────────────────────────
@@ -29,7 +29,7 @@ export async function fetchTimezone(): Promise<string> {
   try {
     const resp = await fetch("/api/system/timezone");
     if (!resp.ok) throw new Error("failed");
-    const data: TimezoneResponse = await resp.json();
+    const data = (await resp.json()) as TimezoneResponse;
     return data.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone || "";
   } catch {
     return Intl.DateTimeFormat().resolvedOptions().timeZone || "";
@@ -50,23 +50,20 @@ export async function fetchProviderModels(
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
-  return resp.json();
+  return (await resp.json()) as ModelsResponse;
 }
 
 export async function fetchMcpCatalog(): Promise<McpCatalogEntry[]> {
   try {
     const resp = await fetch("/api/mcp-catalog");
     if (!resp.ok) return [];
-    return resp.json();
+    return (await resp.json()) as McpCatalogEntry[];
   } catch {
     return [];
   }
 }
 
-export async function storeSecret(
-  name: string,
-  value: string,
-): Promise<SecretResponse> {
+export async function storeSecret(name: string, value: string): Promise<SecretResponse> {
   const resp = await fetch("/api/secrets", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -76,7 +73,7 @@ export async function storeSecret(
     const text = await resp.text();
     throw new Error(`failed to store secret "${name}": ${text}`);
   }
-  return resp.json();
+  return (await resp.json()) as SecretResponse;
 }
 
 export async function completeSetup(
@@ -91,7 +88,7 @@ export async function completeSetup(
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),
   });
-  return resp.json();
+  return (await resp.json()) as ValidateResponse;
 }
 
 // ── Settings API wrappers ────────────────────────────────────────────
@@ -108,7 +105,7 @@ export async function putConfigRaw(toml: string): Promise<ValidateResponse> {
     headers: { "Content-Type": "text/plain" },
     body: toml,
   });
-  return resp.json();
+  return (await resp.json()) as ValidateResponse;
 }
 
 export async function validateConfig(toml: string): Promise<ValidateResponse> {
@@ -117,7 +114,7 @@ export async function validateConfig(toml: string): Promise<ValidateResponse> {
     headers: { "Content-Type": "text/plain" },
     body: toml,
   });
-  return resp.json();
+  return (await resp.json()) as ValidateResponse;
 }
 
 export async function fetchProvidersRaw(): Promise<string> {
@@ -132,7 +129,7 @@ export async function putProvidersRaw(toml: string): Promise<ValidateResponse> {
     headers: { "Content-Type": "text/plain" },
     body: toml,
   });
-  return resp.json();
+  return (await resp.json()) as ValidateResponse;
 }
 
 export async function validateProviders(toml: string): Promise<ValidateResponse> {
@@ -141,7 +138,7 @@ export async function validateProviders(toml: string): Promise<ValidateResponse>
     headers: { "Content-Type": "text/plain" },
     body: toml,
   });
-  return resp.json();
+  return (await resp.json()) as ValidateResponse;
 }
 
 export async function fetchMcpRaw(): Promise<string> {
@@ -156,13 +153,13 @@ export async function putMcpRaw(json: string): Promise<ValidateResponse> {
     headers: { "Content-Type": "application/json" },
     body: json,
   });
-  return resp.json();
+  return (await resp.json()) as ValidateResponse;
 }
 
 export async function listSecrets(): Promise<string[]> {
   const resp = await fetch("/api/secrets");
   if (!resp.ok) return [];
-  const data: SecretsListResponse = await resp.json();
+  const data = (await resp.json()) as SecretsListResponse;
   return data.names;
 }
 

--- a/web/src/lib/commands.ts
+++ b/web/src/lib/commands.ts
@@ -24,14 +24,11 @@ const HELP_TEXT = `Available commands:
   /reload        Reload gateway configuration
   /inbox <text>  Add a message to the inbox`;
 
-export function parseCommand(
-  input: string,
-  ctx: CommandContext,
-): CommandResult | null {
+export function parseCommand(input: string, ctx: CommandContext): CommandResult | null {
   if (!input.startsWith("/")) return null;
 
   const parts = input.split(/\s+/);
-  const cmd = parts[0].toLowerCase();
+  const cmd = (parts[0] ?? "/").toLowerCase();
   const args = parts.slice(1).join(" ");
 
   switch (cmd) {

--- a/web/src/lib/markdown.ts
+++ b/web/src/lib/markdown.ts
@@ -14,7 +14,7 @@ export function renderMarkdown(text: string): string {
   let html = escapeHtml(text);
 
   // Code blocks: ```lang\n...\n```
-  html = html.replace(/```(\w*)\n([\s\S]*?)```/g, (_m, _lang, code) => {
+  html = html.replace(/```(\w*)\n([\s\S]*?)```/g, (_m: string, _lang: string, code: string) => {
     return `<pre><code>${code.trim()}</code></pre>`;
   });
 
@@ -25,10 +25,7 @@ export function renderMarkdown(text: string): string {
   html = html.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
 
   // Italic: *...*
-  html = html.replace(
-    /(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g,
-    "<em>$1</em>",
-  );
+  html = html.replace(/(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g, "<em>$1</em>");
 
   // Links: [text](url)
   html = html.replace(
@@ -49,7 +46,7 @@ export function renderMarkdown(text: string): string {
   html = html.replace(/<\/blockquote>\n<blockquote>/g, "<br>");
 
   // Unordered lists: - item
-  html = html.replace(/(^|\n)(- .+(?:\n- .+)*)/g, (_m, pre, block) => {
+  html = html.replace(/(^|\n)(- .+(?:\n- .+)*)/g, (_m: string, pre: string, block: string) => {
     const items = block
       .split("\n")
       .map((line: string) => `<li>${line.replace(/^- /, "")}</li>`)
@@ -60,7 +57,7 @@ export function renderMarkdown(text: string): string {
   // Ordered lists: 1. item
   html = html.replace(
     /(^|\n)(\d+\. .+(?:\n\d+\. .+)*)/g,
-    (_m, pre, block) => {
+    (_m: string, pre: string, block: string) => {
       const items = block
         .split("\n")
         .map((line: string) => `<li>${line.replace(/^\d+\. /, "")}</li>`)
@@ -73,22 +70,13 @@ export function renderMarkdown(text: string): string {
   html = html.replace(/\n/g, "<br>");
 
   // Fix line breaks inside pre that got doubled
-  html = html.replace(
-    /<pre><code>([\s\S]*?)<\/code><\/pre>/g,
-    (_m, inner) => {
-      return `<pre><code>${inner.replace(/<br>/g, "\n")}</code></pre>`;
-    },
-  );
+  html = html.replace(/<pre><code>([\s\S]*?)<\/code><\/pre>/g, (_m: string, inner: string) => {
+    return `<pre><code>${inner.replace(/<br>/g, "\n")}</code></pre>`;
+  });
 
   // Clean up line breaks adjacent to block elements
-  html = html.replace(
-    /<br>(<\/?(?:h[234]|blockquote|ul|ol|li|hr|pre)>)/g,
-    "$1",
-  );
-  html = html.replace(
-    /(<\/?(?:h[234]|blockquote|ul|ol|li|hr|pre)>)<br>/g,
-    "$1",
-  );
+  html = html.replace(/<br>(<\/?(?:h[234]|blockquote|ul|ol|li|hr|pre)>)/g, "$1");
+  html = html.replace(/(<\/?(?:h[234]|blockquote|ul|ol|li|hr|pre)>)<br>/g, "$1");
 
   return html;
 }

--- a/web/src/lib/models.ts
+++ b/web/src/lib/models.ts
@@ -57,9 +57,7 @@ export const EMBEDDING_MODEL_LISTS: Record<string, ModelEntry[]> = {
     { id: "text-embedding-3-large", name: "text-embedding-3-large" },
     { id: "text-embedding-ada-002", name: "text-embedding-ada-002" },
   ],
-  gemini: [
-    { id: "gemini-embedding-001", name: "gemini-embedding-001" },
-  ],
+  gemini: [{ id: "gemini-embedding-001", name: "gemini-embedding-001" }],
   ollama: [
     { id: "nomic-embed-text", name: "nomic-embed-text" },
     { id: "mxbai-embed-large", name: "mxbai-embed-large" },
@@ -72,7 +70,7 @@ export const EMBEDDING_PROVIDERS = ["openai", "gemini", "ollama"];
 const cache: Record<string, FetchResult> = {};
 
 function cacheKey(provider: string, apiKey?: string, url?: string): string {
-  return `${provider}:${apiKey || ""}:${url || ""}`;
+  return `${provider}:${apiKey ?? ""}:${url ?? ""}`;
 }
 
 export async function fetchModels(
@@ -81,23 +79,24 @@ export async function fetchModels(
   url?: string,
 ): Promise<FetchResult> {
   const key = cacheKey(provider, apiKey, url);
-  if (cache[key]) return cache[key];
+  const cached = cache[key];
+  if (cached) return cached;
 
   try {
     const data = await fetchProviderModels(provider, apiKey, url);
-    if (data.models && data.models.length > 0) {
+    if (data.models.length > 0) {
       const result: FetchResult = { models: data.models, error: null };
       cache[key] = result;
       return result;
     }
     return {
-      models: FALLBACK_MODELS[provider] || [],
-      error: data.error || "no models returned",
+      models: FALLBACK_MODELS[provider] ?? [],
+      error: data.error ?? "no models returned",
     };
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     return {
-      models: FALLBACK_MODELS[provider] || [],
+      models: FALLBACK_MODELS[provider] ?? [],
       error: message,
     };
   }
@@ -117,13 +116,15 @@ export function invalidateAll(): void {
   }
 }
 
-export function debounce<T extends (...args: unknown[]) => void>(
-  fn: T,
+export function debounce<A extends unknown[]>(
+  fn: (...args: A) => void,
   ms: number,
-): (...args: Parameters<T>) => void {
+): (...args: A) => void {
   let timer: ReturnType<typeof setTimeout>;
-  return function (...args: Parameters<T>) {
+  return function (...args: A): void {
     clearTimeout(timer);
-    timer = setTimeout(() => fn(...args), ms);
+    timer = setTimeout(() => {
+      fn(...args);
+    }, ms);
   };
 }

--- a/web/src/lib/settings-toml.ts
+++ b/web/src/lib/settings-toml.ts
@@ -4,11 +4,7 @@
 // Uses smol-toml for parsing and line-building for serialization (matching toml.ts).
 
 import { parse as parseToml } from "smol-toml";
-import type {
-  McpServerEntry,
-  SettingsProviderEntry,
-  SettingsModelAssignments,
-} from "./types";
+import type { McpServerEntry, SettingsProviderEntry, SettingsModelAssignments } from "./types";
 
 // ── Config form fields (config.toml) ─────────────────────────────────
 
@@ -93,7 +89,9 @@ export function defaultConfigFields(): ConfigFields {
 
 // Helper to safely read nested TOML values
 function str(v: unknown): string {
-  return v == null ? "" : String(v);
+  if (v == null) return "";
+  if (typeof v === "object") return JSON.stringify(v);
+  return String(v as string | number | boolean);
 }
 
 function bool(v: unknown, fallback: boolean): boolean {
@@ -259,7 +257,9 @@ export function parseProvidersToml(raw: string): ProvidersFormState {
 /** Model values can be a string or array (failover). Show first entry for form. */
 function modelStr(v: unknown): string {
   if (Array.isArray(v)) return v.length > 0 ? String(v[0]) : "";
-  return v == null ? "" : String(v);
+  if (v == null) return "";
+  if (typeof v === "object") return JSON.stringify(v);
+  return String(v as string | number | boolean);
 }
 
 // ── MCP (mcp.json) ──────────────────────────────────────────────────
@@ -268,12 +268,12 @@ export function parseMcpJson(raw: string): McpServerEntry[] {
   if (!raw.trim()) return [];
   try {
     const doc = JSON.parse(raw) as Record<string, unknown>;
-    const servers = (doc.mcpServers || {}) as Record<string, Record<string, unknown>>;
+    const servers = (doc.mcpServers as Record<string, Record<string, unknown>> | undefined) ?? {};
     return Object.entries(servers).map(([name, srv]) => ({
       name,
       command: str(srv.command),
       args: Array.isArray(srv.args) ? (srv.args as string[]) : [],
-      env: (srv.env || {}) as Record<string, string>,
+      env: (srv.env ?? {}) as Record<string, string>,
     }));
   } catch {
     return [];
@@ -309,18 +309,24 @@ export function serializeConfigToml(f: ConfigFields): string {
 
   // memory
   const memLines: string[] = [];
-  if (f.observer_threshold_tokens) memLines.push(`observer_threshold_tokens = ${f.observer_threshold_tokens}`);
-  if (f.reflector_threshold_tokens) memLines.push(`reflector_threshold_tokens = ${f.reflector_threshold_tokens}`);
-  if (f.observer_cooldown_secs) memLines.push(`observer_cooldown_secs = ${f.observer_cooldown_secs}`);
-  if (f.observer_force_threshold_tokens) memLines.push(`observer_force_threshold_tokens = ${f.observer_force_threshold_tokens}`);
+  if (f.observer_threshold_tokens)
+    memLines.push(`observer_threshold_tokens = ${f.observer_threshold_tokens}`);
+  if (f.reflector_threshold_tokens)
+    memLines.push(`reflector_threshold_tokens = ${f.reflector_threshold_tokens}`);
+  if (f.observer_cooldown_secs)
+    memLines.push(`observer_cooldown_secs = ${f.observer_cooldown_secs}`);
+  if (f.observer_force_threshold_tokens)
+    memLines.push(`observer_force_threshold_tokens = ${f.observer_force_threshold_tokens}`);
 
   const searchLines: string[] = [];
   if (f.search_vector_weight) searchLines.push(`vector_weight = ${f.search_vector_weight}`);
   if (f.search_text_weight) searchLines.push(`text_weight = ${f.search_text_weight}`);
   if (f.search_min_score) searchLines.push(`min_score = ${f.search_min_score}`);
-  if (f.search_candidate_multiplier) searchLines.push(`candidate_multiplier = ${f.search_candidate_multiplier}`);
+  if (f.search_candidate_multiplier)
+    searchLines.push(`candidate_multiplier = ${f.search_candidate_multiplier}`);
   if (f.search_temporal_decay) searchLines.push(`temporal_decay = true`);
-  if (f.search_temporal_decay_half_life_days) searchLines.push(`temporal_decay_half_life_days = ${f.search_temporal_decay_half_life_days}`);
+  if (f.search_temporal_decay_half_life_days)
+    searchLines.push(`temporal_decay_half_life_days = ${f.search_temporal_decay_half_life_days}`);
 
   if (memLines.length > 0 || searchLines.length > 0) {
     lines.push("");
@@ -364,13 +370,19 @@ export function serializeConfigToml(f: ConfigFields): string {
   }
 
   // retry
-  if (f.retry_max_retries || f.retry_initial_delay_ms || f.retry_max_delay_ms || f.retry_backoff_multiplier) {
+  if (
+    f.retry_max_retries ||
+    f.retry_initial_delay_ms ||
+    f.retry_max_delay_ms ||
+    f.retry_backoff_multiplier
+  ) {
     lines.push("");
     lines.push("[retry]");
     if (f.retry_max_retries) lines.push(`max_retries = ${f.retry_max_retries}`);
     if (f.retry_initial_delay_ms) lines.push(`initial_delay_ms = ${f.retry_initial_delay_ms}`);
     if (f.retry_max_delay_ms) lines.push(`max_delay_ms = ${f.retry_max_delay_ms}`);
-    if (f.retry_backoff_multiplier) lines.push(`backoff_multiplier = ${f.retry_backoff_multiplier}`);
+    if (f.retry_backoff_multiplier)
+      lines.push(`backoff_multiplier = ${f.retry_backoff_multiplier}`);
   }
 
   // background
@@ -378,7 +390,8 @@ export function serializeConfigToml(f: ConfigFields): string {
     lines.push("");
     lines.push("[background]");
     if (f.bg_max_concurrent) lines.push(`max_concurrent = ${f.bg_max_concurrent}`);
-    if (f.bg_transcript_retention_days) lines.push(`transcript_retention_days = ${f.bg_transcript_retention_days}`);
+    if (f.bg_transcript_retention_days)
+      lines.push(`transcript_retention_days = ${f.bg_transcript_retention_days}`);
   }
 
   // agent
@@ -440,13 +453,14 @@ export function serializeProvidersToml(
 
 /** Serialize MCP servers back to mcp.json. */
 export function serializeMcpJson(servers: McpServerEntry[]): string {
-  const obj: Record<string, { command: string; args?: string[]; env?: Record<string, string> }> = {};
+  const obj: Record<string, { command: string; args?: string[]; env?: Record<string, string> }> =
+    {};
   for (const srv of servers) {
     const entry: { command: string; args?: string[]; env?: Record<string, string> } = {
       command: srv.command,
     };
-    if (srv.args && srv.args.length > 0) entry.args = srv.args;
-    if (srv.env && Object.keys(srv.env).length > 0) entry.env = srv.env;
+    if (srv.args.length > 0) entry.args = srv.args;
+    if (Object.keys(srv.env).length > 0) entry.env = srv.env;
     obj[srv.name] = entry;
   }
   return JSON.stringify({ mcpServers: obj }, null, 2) + "\n";

--- a/web/src/lib/toml.ts
+++ b/web/src/lib/toml.ts
@@ -14,7 +14,7 @@ export function generateConfigToml(state: SetupWizardState): string {
 
   // Discord (top-level section)
   if (state.integrations.discordToken) {
-    const ref = state.secretRefs["discord"] || state.integrations.discordToken;
+    const ref = state.secretRefs["discord"] ?? state.integrations.discordToken;
     lines.push("");
     lines.push("[discord]");
     lines.push(`token = "${ref}"`);
@@ -22,8 +22,7 @@ export function generateConfigToml(state: SetupWizardState): string {
 
   // Telegram (top-level section)
   if (state.integrations.telegramToken) {
-    const ref =
-      state.secretRefs["telegram"] || state.integrations.telegramToken;
+    const ref = state.secretRefs["telegram"] ?? state.integrations.telegramToken;
     lines.push("");
     lines.push("[telegram]");
     lines.push(`token = "${ref}"`);
@@ -38,10 +37,7 @@ export function generateProvidersToml(state: SetupWizardState): string {
   const lines: string[] = [];
 
   // Collect provider entries
-  const providerEntries: Record<
-    string,
-    { type: string; api_key: string; url: string | null }
-  > = {};
+  const providerEntries: Record<string, { type: string; api_key: string; url: string | null }> = {};
 
   for (const prov of state.selectedProviders) {
     const cfg = state.providerConfigs[prov];
@@ -59,6 +55,7 @@ export function generateProvidersToml(state: SetupWizardState): string {
   // Role providers (if different from selected ones)
   for (const role of ["observer", "reflector", "pulse"]) {
     const r = state.roles[role];
+    if (!r) continue;
     const prov = r.provider || state.mainProvider;
     if (!providerEntries[prov] && prov !== "ollama" && r.apiKey) {
       providerEntries[prov] = {
@@ -79,7 +76,7 @@ export function generateProvidersToml(state: SetupWizardState): string {
     }
     lines.push(`[providers.${name}]`);
     lines.push(`type = "${cfg.type}"`);
-    const keyRef = state.secretRefs[name] || cfg.api_key;
+    const keyRef = state.secretRefs[name] ?? cfg.api_key;
     lines.push(`api_key = "${keyRef}"`);
     if (cfg.url) lines.push(`url = "${cfg.url}"`);
     lines.push("");
@@ -87,13 +84,13 @@ export function generateProvidersToml(state: SetupWizardState): string {
 
   // Models section
   const mainCfg = state.providerConfigs[state.mainProvider];
-  const mainModel =
-    mainCfg.model || DEFAULT_MODELS[state.mainProvider] || "";
+  const mainModel = mainCfg.model || DEFAULT_MODELS[state.mainProvider] || "";
   lines.push("[models]");
   lines.push(`main = "${state.mainProvider}/${mainModel}"`);
 
   for (const role of ["observer", "reflector", "pulse"]) {
     const r = state.roles[role];
+    if (!r) continue;
     const prov = r.provider || state.mainProvider;
     if (r.model) {
       lines.push(`${role} = "${prov}/${r.model}"`);
@@ -102,15 +99,14 @@ export function generateProvidersToml(state: SetupWizardState): string {
 
   // Embedding model
   if (state.embeddingModel.provider && state.embeddingModel.model) {
-    lines.push(
-      `embedding = "${state.embeddingModel.provider}/${state.embeddingModel.model}"`,
-    );
+    lines.push(`embedding = "${state.embeddingModel.provider}/${state.embeddingModel.model}"`);
   }
 
   // Background model tiers (lives in providers.toml alongside other model config)
   const bgEntries: { tier: string; prov: string; model: string }[] = [];
   for (const tier of ["small", "medium", "large"]) {
     const bg = state.backgroundModels[tier];
+    if (!bg) continue;
     const prov = bg.provider || state.mainProvider;
     if (bg.model) {
       bgEntries.push({ tier, prov, model: bg.model });
@@ -139,8 +135,8 @@ export function generateMcpJson(state: SetupWizardState): string {
     const entry: { command: string; args?: string[]; env?: Record<string, string> } = {
       command: srv.command,
     };
-    if (srv.args && srv.args.length > 0) entry.args = srv.args;
-    if (srv.env && Object.keys(srv.env).length > 0) entry.env = srv.env;
+    if (srv.args.length > 0) entry.args = srv.args;
+    if (Object.keys(srv.env).length > 0) entry.env = srv.env;
     servers[srv.name] = entry;
   }
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -176,10 +176,7 @@ export interface DeleteSecretResponse {
 
 // ── Feed items (UI rendering) ────────────────────────────────────────
 
-export type ConnectionStatus =
-  | "connecting"
-  | "connected"
-  | "disconnected";
+export type ConnectionStatus = "connecting" | "connected" | "disconnected";
 
 export interface ToolCallState {
   id: string;

--- a/web/src/lib/ws.svelte.ts
+++ b/web/src/lib/ws.svelte.ts
@@ -1,5 +1,6 @@
 // ── Reactive WebSocket connection (Svelte 5 runes) ──────────────────
 
+import { SvelteMap } from "svelte/reactivity";
 import type {
   ClientMessage,
   ServerMessage,
@@ -26,7 +27,7 @@ class WsConnection {
   private reconnectDelay = 1000;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private pingTimer: ReturnType<typeof setInterval> | null = null;
-  private pendingToolCalls = new Map<string, ToolCallState>();
+  private pendingToolCalls = new SvelteMap<string, ToolCallState>();
 
   constructor() {
     try {
@@ -87,7 +88,7 @@ class WsConnection {
   }
 
   send(msg: ClientMessage): void {
-    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+    if (this.ws?.readyState === WebSocket.OPEN) {
       this.ws.send(JSON.stringify(msg));
     }
   }
@@ -113,6 +114,7 @@ class WsConnection {
   loadHistory(messages: RecentMessage[]): void {
     if (!messages.length) return;
 
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity -- local non-reactive scratch map
     const toolCallItems = new Map<string, ToolCallState>();
 
     for (const msg of messages) {
@@ -144,14 +146,17 @@ class WsConnection {
           if (msg.tool_call_id) {
             const call = toolCallItems.get(msg.tool_call_id);
             if (call && content) {
-              call.result = (call.result ? call.result + "\n" : "") +
-                "\u2500\u2500\u2500 result \u2500\u2500\u2500\n" + content;
+              call.result =
+                (call.result ? call.result + "\n" : "") +
+                "\u2500\u2500\u2500 result \u2500\u2500\u2500\n" +
+                content;
             }
             toolCallItems.delete(msg.tool_call_id);
           }
           break;
         }
-        // skip system
+        case "system":
+          break;
       }
     }
 
@@ -243,9 +248,7 @@ class WsConnection {
 
   private handleToolCall(msg: Extract<ServerMessage, { type: "tool_call" }>): void {
     const argsText =
-      typeof msg.arguments === "string"
-        ? msg.arguments
-        : JSON.stringify(msg.arguments, null, 2);
+      typeof msg.arguments === "string" ? msg.arguments : JSON.stringify(msg.arguments, null, 2);
 
     const call: ToolCallState = {
       id: msg.id,
@@ -256,7 +259,7 @@ class WsConnection {
 
     // Find or create a tool group at the end of the feed
     const last = this.feed[this.feed.length - 1];
-    if (last && last.kind === "tool-group") {
+    if (last?.kind === "tool-group") {
       last.calls.push(call);
     } else {
       this.feed.push({
@@ -269,18 +272,19 @@ class WsConnection {
     // Store the proxied reference from the $state feed so mutations
     // in handleToolResult go through Svelte's reactivity system
     const group = this.feed[this.feed.length - 1] as ToolGroupFeedItem;
-    this.pendingToolCalls.set(msg.id, group.calls[group.calls.length - 1]);
+    const lastCall = group.calls[group.calls.length - 1];
+    if (lastCall) this.pendingToolCalls.set(msg.id, lastCall);
   }
 
-  private handleToolResult(
-    msg: Extract<ServerMessage, { type: "tool_result" }>,
-  ): void {
+  private handleToolResult(msg: Extract<ServerMessage, { type: "tool_result" }>): void {
     const call = this.pendingToolCalls.get(msg.tool_call_id);
     if (call) {
       call.status = msg.is_error ? "error" : "done";
       if (msg.output) {
-        call.result = (call.result ? call.result + "\n" : "") +
-          "\u2500\u2500\u2500 result \u2500\u2500\u2500\n" + msg.output;
+        call.result =
+          (call.result ? call.result + "\n" : "") +
+          "\u2500\u2500\u2500 result \u2500\u2500\u2500\n" +
+          msg.output;
       }
       this.pendingToolCalls.delete(msg.tool_call_id);
     }

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -2,4 +2,6 @@ import "./app.css";
 import { mount } from "svelte";
 import App from "./App.svelte";
 
-mount(App, { target: document.getElementById("app")! });
+const target = document.getElementById("app");
+if (!target) throw new Error("missing #app element");
+mount(App, { target });

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -6,7 +6,10 @@
     "strict": true,
     "noEmit": true,
     "isolatedModules": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "noUncheckedIndexedAccess": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true
   },
   "include": ["src/**/*.ts", "src/**/*.svelte"]
 }


### PR DESCRIPTION
## Summary
- Add ESLint and Prettier configuration for the web UI (`web/`)
- Apply formatting to all existing web source files
- Integrate web checks (format, lint, type-check) into pre-commit and pre-push hooks with dynamic step numbering
- Add parallel `web-check` job to CI workflow
- Add web checks and `npm ci && npm run build` to release workflow (including `setup-node@v4` for macOS runner)
- Runner image updated separately in lab-iac with Node.js LTS

## Test plan
- [x] Pre-commit hook runs web format/lint/check when web files are staged
- [x] Pre-push hook runs svelte-check
- [ ] CI `web-check` job passes on this PR
- [ ] Release workflow verified via CI (same check steps)