### PR TITLE
fix: pre-release critical fixes

### DIFF
--- a/src/gateway/server/mod.rs
+++ b/src/gateway/server/mod.rs
@@ -199,6 +199,8 @@ struct GatewayRuntime {
     inbound_tx: mpsc::Sender<RoutedMessage>,
     reload_tx: tokio::sync::watch::Sender<ReloadSignal>,
     command_tx: mpsc::Sender<ServerCommand>,
+    /// Shared path policy for updating blocked paths on reload.
+    path_policy: crate::tools::SharedPathPolicy,
 }
 
 /// Apply an `ObserveAction` to the current observe deadline.
@@ -301,6 +303,7 @@ pub async fn run_gateway(cfg: Config) -> Result<GatewayExit, ResiduumError> {
     drop(webhook_inbound_tx);
     let config_api_state = web::ConfigApiState {
         config_dir: cfg.config_dir.clone(),
+        workspace_dir: parts.layout.root().to_path_buf(),
         memory_dir: Some(parts.layout.memory_dir()),
         reload_tx: Some(core.reload_tx.clone()),
         setup_done: None,
@@ -424,6 +427,7 @@ pub async fn run_gateway(cfg: Config) -> Result<GatewayExit, ResiduumError> {
         inbound_tx: rt_inbound_tx,
         reload_tx: rt_reload_tx,
         command_tx: rt_command_tx,
+        path_policy: parts.path_policy,
         cfg,
     };
 

--- a/src/gateway/server/reload.rs
+++ b/src/gateway/server/reload.rs
@@ -231,6 +231,7 @@ pub(super) async fn handle_root_reload(rt: &mut GatewayRuntime) {
                 };
                 let config_api_state = super::web::ConfigApiState {
                     config_dir: rt.config_dir.clone(),
+                    workspace_dir: rt.layout.root().to_path_buf(),
                     memory_dir: Some(rt.layout.memory_dir()),
                     reload_tx: Some(rt.reload_tx.clone()),
                     setup_done: None,
@@ -388,6 +389,27 @@ pub(super) async fn handle_root_reload(rt: &mut GatewayRuntime) {
         } else {
             tracing::info!("skills rescanned");
         }
+    }
+
+    // ── Agent ability gates ──────────────────────────────────────────────
+    if diff.agent_changed {
+        let mut blocked: Vec<std::path::PathBuf> = vec![
+            new_cfg.config_dir.join("config.toml"),
+            new_cfg.config_dir.join("config.example.toml"),
+            new_cfg.config_dir.join("providers.toml"),
+            new_cfg.config_dir.join("providers.example.toml"),
+        ];
+        if !new_cfg.agent.modify_mcp {
+            blocked.push(rt.layout.mcp_json());
+        }
+        if !new_cfg.agent.modify_channels {
+            blocked.push(rt.layout.channels_toml());
+        }
+        rt.path_policy
+            .write()
+            .await
+            .set_blocked_paths(blocked.into_iter().collect());
+        tracing::info!("agent ability gates updated");
     }
 
     // ── Store new config ────────────────────────────────────────────────

--- a/src/gateway/server/setup.rs
+++ b/src/gateway/server/setup.rs
@@ -45,8 +45,12 @@ pub async fn run_setup_server_at(config_dir: PathBuf) -> Result<SetupExit, Resid
     let (setup_done_tx, mut setup_done_rx) = tokio::sync::watch::channel(false);
     let setup_done_tx = Arc::new(setup_done_tx);
 
+    // During setup, workspace_dir defaults to config_dir/workspace since the user
+    // hasn't configured a custom workspace yet.
+    let workspace_dir = config_dir.join("workspace");
     let api_state = ConfigApiState {
         config_dir,
+        workspace_dir,
         memory_dir: None,
         reload_tx: None,
         setup_done: Some(Arc::clone(&setup_done_tx)),

--- a/src/gateway/server/startup.rs
+++ b/src/gateway/server/startup.rs
@@ -64,6 +64,7 @@ pub(super) struct GatewayComponents {
     pub(super) background_spawner: Arc<BackgroundTaskSpawner>,
     pub(super) background_result_rx: mpsc::Receiver<BackgroundResult>,
     pub(super) spawn_context: Arc<SpawnContext>,
+    pub(super) path_policy: crate::tools::SharedPathPolicy,
 }
 
 /// Model providers and memory pipeline observers built from config.
@@ -402,6 +403,7 @@ pub(super) async fn initialize(cfg: &Config) -> Result<GatewayComponents, Residu
         tz,
         valid_external_channels.clone(),
     );
+    let path_policy_for_runtime = Arc::clone(&path_policy);
     tools.register_project_tools(
         Arc::clone(&project_state),
         path_policy,
@@ -492,6 +494,7 @@ pub(super) async fn initialize(cfg: &Config) -> Result<GatewayComponents, Residu
         background_spawner,
         background_result_rx: bg_result_rx,
         spawn_context,
+        path_policy: path_policy_for_runtime,
     })
 }
 

--- a/src/gateway/server/web.rs
+++ b/src/gateway/server/web.rs
@@ -43,6 +43,8 @@ use embedded::WebAssets;
 pub(super) struct ConfigApiState {
     /// Path to the residuum config directory (`~/.residuum/`).
     pub config_dir: PathBuf,
+    /// Path to the workspace root directory (for resolving `mcp.json`, `channels.toml`, etc.).
+    pub workspace_dir: PathBuf,
     /// Path to the workspace memory directory (None in setup mode).
     pub memory_dir: Option<PathBuf>,
     /// Signal the running gateway to reload (None in setup mode).
@@ -268,11 +270,7 @@ async fn api_providers_validate(
 async fn api_mcp_raw_get(
     State(state): State<ConfigApiState>,
 ) -> Result<Response, (StatusCode, String)> {
-    let mcp_path = state
-        .config_dir
-        .join("workspace")
-        .join("config")
-        .join("mcp.json");
+    let mcp_path = crate::workspace::layout::WorkspaceLayout::new(&state.workspace_dir).mcp_json();
 
     let contents = match tokio::fs::read_to_string(&mcp_path).await {
         Ok(c) => c,
@@ -312,11 +310,7 @@ async fn api_mcp_raw_put(
         )
     })?;
 
-    let mcp_path = state
-        .config_dir
-        .join("workspace")
-        .join("config")
-        .join("mcp.json");
+    let mcp_path = crate::workspace::layout::WorkspaceLayout::new(&state.workspace_dir).mcp_json();
 
     if let Some(parent) = mcp_path.parent() {
         tokio::fs::create_dir_all(parent).await.ok();
@@ -997,6 +991,7 @@ mod tests {
     async fn chat_history_returns_empty_when_no_memory_dir() {
         let state = ConfigApiState {
             config_dir: PathBuf::from("/tmp/residuum-test-nonexistent"),
+            workspace_dir: PathBuf::from("/tmp/residuum-test-nonexistent/workspace"),
             memory_dir: None,
             reload_tx: None,
             setup_done: None,
@@ -1013,6 +1008,7 @@ mod tests {
     async fn chat_history_returns_empty_when_file_missing() {
         let state = ConfigApiState {
             config_dir: PathBuf::from("/tmp/residuum-test-nonexistent"),
+            workspace_dir: PathBuf::from("/tmp/residuum-test-nonexistent/workspace"),
             memory_dir: Some(PathBuf::from("/tmp/residuum-test-nonexistent-memory")),
             reload_tx: None,
             setup_done: None,
@@ -1030,6 +1026,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let state = ConfigApiState {
             config_dir: dir.path().to_path_buf(),
+            workspace_dir: dir.path().join("workspace"),
             memory_dir: None,
             reload_tx: None,
             setup_done: None,

--- a/src/tools/path_policy.rs
+++ b/src/tools/path_policy.rs
@@ -74,6 +74,16 @@ impl PathPolicy {
         self.active_project_root = root;
     }
 
+    /// Replace the set of unconditionally blocked paths.
+    ///
+    /// Called during config hot-reload when agent ability gates change.
+    pub fn set_blocked_paths(&mut self, paths: HashSet<PathBuf>) {
+        self.blocked_paths = paths
+            .into_iter()
+            .map(|p| canonicalize_for_check(&p))
+            .collect();
+    }
+
     /// Check whether a write to `path` is allowed under the current policy.
     ///
     /// Returns `Ok(())` if allowed, or `Err(reason)` if rejected.
@@ -374,6 +384,31 @@ mod tests {
         assert!(
             policy.check_write(&cfg_dir.join("config.toml")).is_err(),
             "config.toml should still be blocked"
+        );
+    }
+
+    #[test]
+    fn set_blocked_paths_updates_policy() {
+        let (_dir, ws, cfg_dir) = make_workspace_with_config();
+        let blocked: HashSet<PathBuf> = [cfg_dir.join("config.toml")].into_iter().collect();
+        let mut policy = PathPolicy::with_blocked_paths(ws.clone(), blocked);
+
+        // config.toml is blocked initially
+        assert!(policy.check_write(&cfg_dir.join("config.toml")).is_err());
+
+        // Replace blocked set with empty — config.toml should now be writable
+        policy.set_blocked_paths(HashSet::new());
+        assert!(
+            policy.check_write(&cfg_dir.join("config.toml")).is_ok(),
+            "config.toml should be writable after clearing blocked paths"
+        );
+
+        // Re-block config.toml
+        let new_blocked: HashSet<PathBuf> = [cfg_dir.join("config.toml")].into_iter().collect();
+        policy.set_blocked_paths(new_blocked);
+        assert!(
+            policy.check_write(&cfg_dir.join("config.toml")).is_err(),
+            "config.toml should be blocked again"
         );
     }
 

--- a/src/tools/projects.rs
+++ b/src/tools/projects.rs
@@ -79,6 +79,7 @@ impl Tool for ProjectActivateTool {
                 let project_root = active.project_root.clone();
                 let tools_list = active.frontmatter.tools.clone();
                 let project_name = active.name.clone();
+                let mut warnings: Vec<String> = Vec::new();
                 let mcp_servers = if active.frontmatter.mcp_servers.is_empty() {
                     Vec::new()
                 } else {
@@ -92,6 +93,7 @@ impl Tool for ProjectActivateTool {
                         Ok(resolved) => resolved,
                         Err(e) => {
                             tracing::warn!(project = %project_name, error = %e, "failed to resolve mcp server references");
+                            warnings.push(format!("warning: {e}"));
                             Vec::new()
                         }
                     }
@@ -120,6 +122,9 @@ impl Tool for ProjectActivateTool {
                     .await;
                 for (server_name, err) in &mcp_report.failures {
                     tracing::warn!(server = %server_name, error = %err, "mcp server failed to start");
+                    warnings.push(format!(
+                        "warning: mcp server '{server_name}' failed to start: {err}"
+                    ));
                 }
                 if mcp_report.started > 0 || mcp_report.stopped > 0 {
                     tracing::info!(
@@ -139,7 +144,12 @@ impl Tool for ProjectActivateTool {
                 {
                     tracing::warn!(error = %e, "failed to rescan skills after project activation");
                 }
-                Ok(ToolResult::success(manifest_summary))
+                let output = if warnings.is_empty() {
+                    manifest_summary
+                } else {
+                    format!("{manifest_summary}\n{}", warnings.join("\n"))
+                };
+                Ok(ToolResult::success(output))
             }
             Err(e) => Ok(ToolResult::error(e.to_string())),
         }


### PR DESCRIPTION
## Summary
- **PathPolicy hot-reload**: Agent ability gates (modify_mcp, modify_channels) now update on config reload instead of requiring a restart. Added `set_blocked_paths` to PathPolicy and wired it through GatewayRuntime.
- **Web API workspace path**: Replaced hardcoded `config_dir/workspace/config/mcp.json` with `WorkspaceLayout::mcp_json()` in all 3 API endpoints, fixing breakage for custom `RESIDUUM_WORKSPACE` users.
- **Silent MCP failures**: Project activation now surfaces MCP resolution errors and server start failures in the tool output, instead of silently swallowing them.

## Test plan
- [x] All 1,031 tests pass
- [x] Clippy clean
- [x] Pre-commit and pre-push hooks pass