### PR TITLE
fix: build web assets before Rust steps in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Build web assets
+        run: npm ci && npm run build
+        working-directory: web
+
       - name: Check formatting
         id: fmt
         run: cargo fmt --check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,9 @@ jobs:
         id: web_typecheck
         run: cd web && npm run check
 
+      - name: Build web assets
+        run: cd web && npm run build
+
       - name: Check formatting
         id: fmt
         run: cargo fmt --check


### PR DESCRIPTION
CI and release workflows were missing the web build step before running cargo clippy/test, causing build.rs to panic on missing web/dist/.