### PR TITLE
fix(cli): route WorkingIndicator output to stderr

### DIFF
--- a/src/interfaces/cli/indicator.rs
+++ b/src/interfaces/cli/indicator.rs
@@ -2,9 +2,12 @@
 
 use std::io::Write;
 
-/// Animated working indicator displayed on stdout while the agent is processing.
+/// Animated working indicator displayed on stderr while the agent is processing.
 ///
 /// Shows `Working.   (N tools)` with cycling dots, overwriting the same line.
+///
+/// Stderr is the correct stream for interactive UI chrome — using stdout would
+/// mix spinner escape codes into piped output (e.g. `residuum connect | jq`).
 pub struct WorkingIndicator {
     active: bool,
     tool_count: u32,
@@ -50,22 +53,24 @@ impl WorkingIndicator {
     ///
     /// The animation resumes on the next tick or redraw. Use this when printing
     /// intermediate content while the agent is still working.
+    #[expect(clippy::print_stderr, reason = "intentional: indicator is UI chrome on stderr")]
     pub fn clear_line(&mut self) {
         if self.active {
-            print!("\r\x1b[2K");
-            if std::io::stdout().flush().is_err() {
-                tracing::trace!("failed to flush stdout");
+            eprint!("\r\x1b[2K");
+            if std::io::stderr().flush().is_err() {
+                tracing::trace!("failed to flush stderr");
             }
         }
     }
 
     /// Clear the indicator line and mark inactive.
+    #[expect(clippy::print_stderr, reason = "intentional: indicator is UI chrome on stderr")]
     pub fn finish(&mut self) {
         if self.active {
             self.active = false;
-            print!("\r\x1b[2K");
-            if std::io::stdout().flush().is_err() {
-                tracing::trace!("failed to flush stdout");
+            eprint!("\r\x1b[2K");
+            if std::io::stderr().flush().is_err() {
+                tracing::trace!("failed to flush stderr");
             }
         }
     }
@@ -76,6 +81,7 @@ impl WorkingIndicator {
         self.active
     }
 
+    #[expect(clippy::print_stderr, reason = "intentional: indicator is UI chrome on stderr")]
     fn redraw(&self) {
         let dots = match self.dot_phase {
             0 => "   ",
@@ -88,9 +94,9 @@ impl WorkingIndicator {
         } else {
             String::new()
         };
-        print!("\x1b[2K\rWorking{dots}{tool_suffix}");
-        if std::io::stdout().flush().is_err() {
-            tracing::trace!("failed to flush stdout");
+        eprint!("\x1b[2K\rWorking{dots}{tool_suffix}");
+        if std::io::stderr().flush().is_err() {
+            tracing::trace!("failed to flush stderr");
         }
     }
 }


### PR DESCRIPTION
Fixes #89.

The animated spinner uses `print!`/`stdout().flush()` which corrupts piped output (e.g. `residuum connect | jq`). Interactive UI chrome — spinners, progress bars, ANSI escape codes — belongs on stderr so stdout stays clean for data.

## Changes

- Replace `print!`/`std::io::stdout().flush()` with `eprint!`/`std::io::stderr().flush()` in `clear_line()`, `finish()`, and `redraw()`
- Add `#[expect(clippy::print_stderr, reason = "intentional: indicator is UI chrome on stderr")]` on each method to satisfy the `print_stderr = "deny"` lint (per the approach suggested in #89)
- Update doc comments to reference stderr

## Testing

All 9 existing unit tests pass. Zero clippy warnings or errors.

```
test interfaces::cli::indicator::tests::clear_line_noop_when_inactive ... ok
test interfaces::cli::indicator::tests::clear_line_preserves_active ... ok
test interfaces::cli::indicator::tests::finish_clears_active ... ok
test interfaces::cli::indicator::tests::finish_noop_when_inactive ... ok
test interfaces::cli::indicator::tests::on_tool_call_increments_count ... ok
test interfaces::cli::indicator::tests::on_tool_call_noop_when_inactive ... ok
test interfaces::cli::indicator::tests::start_sets_active ... ok
test interfaces::cli::indicator::tests::starts_inactive ... ok
test interfaces::cli::indicator::tests::tick_cycles_dot_phase ... ok
test result: ok. 9 passed; 0 failed
```