### PR TITLE
feat: send file attachments via send_message

### DIFF
--- a/docs/systems-usage/notifications.md
+++ b/docs/systems-usage/notifications.md
@@ -29,6 +29,7 @@ The endpoint registry tracks all available I/O endpoints. The `list_endpoints` t
 Bidirectional channels (WebSocket, Discord, Telegram). The agent can:
 - `switch_endpoint` to redirect responses to a different interactive endpoint.
 - `send_message` to send a one-off message to any interactive endpoint.
+- `send_message` with `file_path` to deliver a file attachment. Images render inline, audio gets a native player, other files appear as downloads. Telegram allows up to 50 MB; Discord, WebSocket, and notification-only endpoints cap at 25 MB. File attachments require an interactive endpoint — notification-only endpoints reject them.
 
 ### Notification endpoints
 
@@ -66,7 +67,7 @@ Results delivered to `agent_wake` or `agent_feed` are not dropped if the agent i
 |------|---------|
 | `list_endpoints` | Show available interactive and notification endpoints. |
 | `switch_endpoint` | Redirect subsequent responses to a different interactive endpoint. Auto-clears when the user sends a message. |
-| `send_message` | One-off message to any interactive or notification endpoint. Does not change where turn responses go. |
+| `send_message` | One-off message and/or file attachment to any interactive or notification endpoint. Does not change where turn responses go. File attachments require an interactive endpoint. |
 
 ## HEARTBEAT_OK
 

--- a/mac/Residuum/Agents/AgentStore.swift
+++ b/mac/Residuum/Agents/AgentStore.swift
@@ -180,6 +180,15 @@ final class AgentStore {
             let msg = ChatMessage(role: .system, content: "Error: \(message)")
             tabs[tabIndex].messages.append(msg)
 
+        case .fileAttachment(_, let filename, let mimeType, let size, let urlPath, let caption):
+            // Pre-compute the absolute URL so views don't need host/port plumbed through them.
+            let port = tabs[tabIndex].port
+            let fullURL = "http://\(host):\(port)\(urlPath)"
+            let attachment = FileAttachmentData(filename: filename, mimeType: mimeType, size: size, url: fullURL)
+            let msg = ChatMessage(role: .assistant, content: caption ?? "", fileAttachment: attachment)
+            tabs[tabIndex].messages.append(msg)
+            tabs[tabIndex].isThinking = false
+
         case .reloading:
             let msg = ChatMessage(role: .system, content: "Reloading configuration…")
             tabs[tabIndex].messages.append(msg)

--- a/mac/Residuum/Agents/Message.swift
+++ b/mac/Residuum/Agents/Message.swift
@@ -1,5 +1,14 @@
 import Foundation
 
+/// File attachment metadata received from the daemon.
+struct FileAttachmentData {
+    let filename: String
+    let mimeType: String
+    let size: Int
+    /// Relative URL path, e.g. "/api/files/{id}".
+    let url: String
+}
+
 /// A single message in an agent's conversation.
 struct ChatMessage: Identifiable {
     let id: UUID
@@ -8,6 +17,8 @@ struct ChatMessage: Identifiable {
     var content: String
     /// Tool calls associated with this agent turn (assistant messages only).
     var toolCalls: [ToolCallData]
+    /// File attachment, if this message carries one.
+    var fileAttachment: FileAttachmentData?
 
     enum Role {
         case user
@@ -16,11 +27,12 @@ struct ChatMessage: Identifiable {
         case systemBlock  // blue-bordered monospace block — structured output (/help, /status)
     }
 
-    init(id: UUID = UUID(), role: Role, content: String, toolCalls: [ToolCallData] = []) {
+    init(id: UUID = UUID(), role: Role, content: String, toolCalls: [ToolCallData] = [], fileAttachment: FileAttachmentData? = nil) {
         self.id = id
         self.role = role
         self.content = content
         self.toolCalls = toolCalls
+        self.fileAttachment = fileAttachment
     }
 }
 

--- a/mac/Residuum/Connection/Protocol.swift
+++ b/mac/Residuum/Connection/Protocol.swift
@@ -70,6 +70,7 @@ enum ServerMessage: Decodable {
     case response(replyTo: String, content: String)
     case systemEvent(source: String, content: String)
     case broadcastResponse(content: String)
+    case fileAttachment(replyTo: String, filename: String, mimeType: String, size: Int, url: String, caption: String?)
     case error(replyTo: String?, message: String)
     case notice(message: String)
     case pong
@@ -84,6 +85,9 @@ enum ServerMessage: Decodable {
         case output
         case isError = "is_error"
         case source, content, message
+        case filename
+        case mimeType = "mime_type"
+        case size, url, caption
     }
 
     init(from decoder: Decoder) throws {
@@ -117,6 +121,15 @@ enum ServerMessage: Decodable {
             )
         case "broadcast_response":
             self = .broadcastResponse(content: try c.decode(String.self, forKey: .content))
+        case "file_attachment":
+            self = .fileAttachment(
+                replyTo: try c.decode(String.self, forKey: .replyTo),
+                filename: try c.decode(String.self, forKey: .filename),
+                mimeType: try c.decode(String.self, forKey: .mimeType),
+                size: try c.decode(Int.self, forKey: .size),
+                url: try c.decode(String.self, forKey: .url),
+                caption: try? c.decode(String.self, forKey: .caption)
+            )
         case "error":
             self = .error(
                 replyTo: try? c.decode(String.self, forKey: .replyTo),

--- a/mac/Residuum/Connection/Protocol.swift
+++ b/mac/Residuum/Connection/Protocol.swift
@@ -122,12 +122,21 @@ enum ServerMessage: Decodable {
         case "broadcast_response":
             self = .broadcastResponse(content: try c.decode(String.self, forKey: .content))
         case "file_attachment":
+            // size may arrive as u64 from Rust — decode as Int first, fall back to UInt64 → Int
+            let sizeValue: Int
+            if let s = try? c.decode(Int.self, forKey: .size) {
+                sizeValue = s
+            } else if let s = try? c.decode(UInt64.self, forKey: .size) {
+                sizeValue = Int(clamping: s)
+            } else {
+                sizeValue = 0
+            }
             self = .fileAttachment(
-                replyTo: try c.decode(String.self, forKey: .replyTo),
-                filename: try c.decode(String.self, forKey: .filename),
-                mimeType: try c.decode(String.self, forKey: .mimeType),
-                size: try c.decode(Int.self, forKey: .size),
-                url: try c.decode(String.self, forKey: .url),
+                replyTo: (try? c.decode(String.self, forKey: .replyTo)) ?? "",
+                filename: (try? c.decode(String.self, forKey: .filename)) ?? "unknown",
+                mimeType: (try? c.decode(String.self, forKey: .mimeType)) ?? "application/octet-stream",
+                size: sizeValue,
+                url: (try? c.decode(String.self, forKey: .url)) ?? "",
                 caption: try? c.decode(String.self, forKey: .caption)
             )
         case "error":

--- a/mac/Residuum/Views/FileAttachmentView.swift
+++ b/mac/Residuum/Views/FileAttachmentView.swift
@@ -1,32 +1,104 @@
+import AVKit
 import SwiftUI
 
-/// Renders a file attachment from the daemon: inline image, audio link, or download link.
+/// Renders a file attachment from the daemon: inline image, audio player, or download button.
 struct FileAttachmentView: View {
     let attachment: FileAttachmentData
 
+    private var resolvedURL: URL? {
+        URL(string: attachment.url)
+    }
+
     var body: some View {
-        if attachment.mimeType.hasPrefix("image/"), let url = URL(string: attachment.url) {
-            AsyncImage(url: url) { phase in
-                switch phase {
-                case .success(let image):
-                    image.resizable().scaledToFit()
-                case .failure:
-                    Label(attachment.filename, systemImage: "photo")
-                        .foregroundStyle(Style.textMuted)
-                default:
-                    ProgressView()
+        Group {
+            if let url = resolvedURL {
+                if attachment.mimeType.hasPrefix("image/") {
+                    AsyncImage(url: url) { phase in
+                        switch phase {
+                        case .success(let image):
+                            image.resizable().scaledToFit()
+                        case .failure:
+                            Label(attachment.filename, systemImage: "photo")
+                                .foregroundStyle(Style.textMuted)
+                        default:
+                            ProgressView()
+                        }
+                    }
+                    .frame(maxWidth: 300)
+                } else if attachment.mimeType.hasPrefix("audio/") {
+                    AudioPlayerView(url: url, filename: attachment.filename)
+                } else {
+                    DownloadButton(url: url, filename: attachment.filename, size: attachment.size)
                 }
-            }
-            .frame(maxWidth: 300)
-        } else if let url = URL(string: attachment.url) {
-            let icon = attachment.mimeType.hasPrefix("audio/") ? "play.circle" : "doc.arrow.down"
-            Link(destination: url) {
-                Label("\(attachment.filename) (\(formatSize(attachment.size)))", systemImage: icon)
+            } else {
+                Text("[\(attachment.filename)]")
                     .font(Style.literata(size: 13))
+                    .foregroundStyle(Style.textMuted)
+            }
+        }
+    }
+}
+
+/// Inline audio player using AVPlayer.
+private struct AudioPlayerView: View {
+    let url: URL
+    let filename: String
+    @State private var player: AVPlayer?
+    @State private var isPlaying = false
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Button {
+                if isPlaying {
+                    player?.pause()
+                } else {
+                    if player == nil {
+                        player = AVPlayer(url: url)
+                    }
+                    player?.play()
+                }
+                isPlaying.toggle()
+            } label: {
+                Image(systemName: isPlaying ? "pause.circle.fill" : "play.circle.fill")
+                    .font(.system(size: 24))
                     .foregroundStyle(Style.blue)
             }
             .buttonStyle(.plain)
+
+            Text(filename)
+                .font(Style.literata(size: 13))
+                .foregroundStyle(Style.textPrimary)
         }
+        .onDisappear {
+            player?.pause()
+            player = nil
+        }
+    }
+}
+
+/// Download button that presents a save panel.
+private struct DownloadButton: View {
+    let url: URL
+    let filename: String
+    let size: Int
+
+    var body: some View {
+        Button {
+            let panel = NSSavePanel()
+            panel.nameFieldStringValue = filename
+            panel.canCreateDirectories = true
+            if panel.runModal() == .OK, let dest = panel.url {
+                URLSession.shared.downloadTask(with: url) { tempURL, _, error in
+                    guard let tempURL, error == nil else { return }
+                    try? FileManager.default.moveItem(at: tempURL, to: dest)
+                }.resume()
+            }
+        } label: {
+            Label("\(filename) (\(formatSize(size)))", systemImage: "doc.arrow.down")
+                .font(Style.literata(size: 13))
+                .foregroundStyle(Style.blue)
+        }
+        .buttonStyle(.plain)
     }
 
     private func formatSize(_ bytes: Int) -> String {

--- a/mac/Residuum/Views/FileAttachmentView.swift
+++ b/mac/Residuum/Views/FileAttachmentView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+/// Renders a file attachment from the daemon: inline image, audio link, or download link.
+struct FileAttachmentView: View {
+    let attachment: FileAttachmentData
+
+    var body: some View {
+        if attachment.mimeType.hasPrefix("image/"), let url = URL(string: attachment.url) {
+            AsyncImage(url: url) { phase in
+                switch phase {
+                case .success(let image):
+                    image.resizable().scaledToFit()
+                case .failure:
+                    Label(attachment.filename, systemImage: "photo")
+                        .foregroundStyle(Style.textMuted)
+                default:
+                    ProgressView()
+                }
+            }
+            .frame(maxWidth: 300)
+        } else if let url = URL(string: attachment.url) {
+            let icon = attachment.mimeType.hasPrefix("audio/") ? "play.circle" : "doc.arrow.down"
+            Link(destination: url) {
+                Label("\(attachment.filename) (\(formatSize(attachment.size)))", systemImage: icon)
+                    .font(Style.literata(size: 13))
+                    .foregroundStyle(Style.blue)
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    private func formatSize(_ bytes: Int) -> String {
+        if bytes < 1024 { return "\(bytes) B" }
+        if bytes < 1024 * 1024 { return "\(bytes / 1024) KB" }
+        return "\(bytes / (1024 * 1024)) MB"
+    }
+}

--- a/mac/Residuum/Views/MessageRow.swift
+++ b/mac/Residuum/Views/MessageRow.swift
@@ -68,6 +68,9 @@ private struct AssistantMessage: View {
                     .lineSpacing(3)
                     .textSelection(.enabled)
             }
+            if let attachment = message.fileAttachment {
+                FileAttachmentView(attachment: attachment)
+            }
         }
     }
 }

--- a/mac/ResiduumChat.xcodeproj/project.pbxproj
+++ b/mac/ResiduumChat.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		2D9DCB2A45A4B2173BEE24FF /* ThinkingIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12C6CDF2B2255A7CC1485305 /* ThinkingIndicator.swift */; };
 		471EB58B22FB29BA279AC03D /* SlashCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0081499F5E80C12012D8D4A /* SlashCommandTests.swift */; };
 		4E1C2554DD42B0D7BDA29A22 /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBB5ACF50BA8D0E2905FBC98 /* ChatView.swift */; };
+		5C8E2F4A1B6D3907E4A2C8F1 /* FileAttachmentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7F1B2E8C4D6A9F0E5B7D12 /* FileAttachmentView.swift */; };
 		6B98649B887255D58E893763 /* AgentRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 198E5D123A71076F69BCC764 /* AgentRegistry.swift */; };
 		7BBD6868742F7CAD1F97E46C /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9491041429FFA0B66EA43DCE /* SettingsView.swift */; };
 		7BC6C4A223B7F3DE5C34A6CA /* TabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F7B942CB5709BCBE5D0B236 /* TabBar.swift */; };
@@ -54,6 +55,7 @@
 		243D33EC119ACFAC32918B28 /* SlashCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommand.swift; sourceTree = "<group>"; };
 		259162ABC7570E1D53C98020 /* PopoverView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopoverView.swift; sourceTree = "<group>"; };
 		2C3210127BCE6365B097B63B /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
+		3A7F1B2E8C4D6A9F0E5B7D12 /* FileAttachmentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileAttachmentView.swift; sourceTree = "<group>"; };
 		45C32C874812C49E181B02DC /* AgentRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRegistryTests.swift; sourceTree = "<group>"; };
 		46D89E61521A713B0635C84F /* ToolGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolGroup.swift; sourceTree = "<group>"; };
 		6B87D3031B744732F705ADC9 /* ResiduumChat.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ResiduumChat.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -143,6 +145,7 @@
 			children = (
 				EBB5ACF50BA8D0E2905FBC98 /* ChatView.swift */,
 				9B8C191C717F516024D9D1C3 /* CommandMenu.swift */,
+				3A7F1B2E8C4D6A9F0E5B7D12 /* FileAttachmentView.swift */,
 				9C5670F08A1555FE5B88EDF6 /* InputBar.swift */,
 				8DE89DA040ED84063735BAF0 /* MessageRow.swift */,
 				259162ABC7570E1D53C98020 /* PopoverView.swift */,
@@ -288,6 +291,7 @@
 				A83257E5BE148B9DC3C888CE /* AppDelegate.swift in Sources */,
 				4E1C2554DD42B0D7BDA29A22 /* ChatView.swift in Sources */,
 				D639E7C0A771C5282B665EE0 /* CommandMenu.swift in Sources */,
+				5C8E2F4A1B6D3907E4A2C8F1 /* FileAttachmentView.swift in Sources */,
 				BD6B18A7E1F04D4EDBC3D963 /* InputBar.swift in Sources */,
 				01E1DAE0A41D52D6BF3F29CF /* Message.swift in Sources */,
 				997C87B27EDAD4D400486CE3 /* MessageRow.swift in Sources */,

--- a/mac/ResiduumChat.xcodeproj/xcshareddata/xcschemes/ResiduumChat.xcscheme
+++ b/mac/ResiduumChat.xcodeproj/xcshareddata/xcschemes/ResiduumChat.xcscheme
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "2600"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES"
-      runPostActionsOnFailure = "NO">
+      buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -16,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "CA040690E53AC4DC6DC2BEC5"
-               BuildableName = "ResiduumChat.app"
+               BuildableName = "Residuum Chat.app"
                BlueprintName = "ResiduumChat"
                ReferencedContainer = "container:ResiduumChat.xcodeproj">
             </BuildableReference>
@@ -41,13 +40,12 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "CA040690E53AC4DC6DC2BEC5"
-            BuildableName = "ResiduumChat.app"
+            BuildableName = "Residuum Chat.app"
             BlueprintName = "ResiduumChat"
             ReferencedContainer = "container:ResiduumChat.xcodeproj">
          </BuildableReference>
@@ -65,8 +63,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <CommandLineArguments>
-      </CommandLineArguments>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -83,7 +79,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "CA040690E53AC4DC6DC2BEC5"
-            BuildableName = "ResiduumChat.app"
+            BuildableName = "Residuum Chat.app"
             BlueprintName = "ResiduumChat"
             ReferencedContainer = "container:ResiduumChat.xcodeproj">
          </BuildableReference>
@@ -100,7 +96,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "CA040690E53AC4DC6DC2BEC5"
-            BuildableName = "ResiduumChat.app"
+            BuildableName = "Residuum Chat.app"
             BlueprintName = "ResiduumChat"
             ReferencedContainer = "container:ResiduumChat.xcodeproj">
          </BuildableReference>

--- a/src/bus/broker.rs
+++ b/src/bus/broker.rs
@@ -262,6 +262,7 @@ mod tests {
             correlation_id: "c1".into(),
             content: "void".into(),
             timestamp: test_timestamp(),
+            attachment: None,
         };
 
         // Publishing to a topic with no subscribers should not error.
@@ -319,6 +320,7 @@ mod tests {
             correlation_id: "6".into(),
             content: "for response".into(),
             timestamp: test_timestamp(),
+            attachment: None,
         };
         pub_.publish(topics::Endpoint(ep), resp_event)
             .await
@@ -375,6 +377,7 @@ mod tests {
                 correlation_id: "c1".into(),
                 content: "hello".into(),
                 timestamp: test_timestamp(),
+                attachment: None,
             },
         )
         .await

--- a/src/bus/events.rs
+++ b/src/bus/events.rs
@@ -7,6 +7,7 @@ use chrono::NaiveDateTime;
 
 use crate::bus::types::PresetName;
 use crate::config::BackgroundModelTier;
+use crate::interfaces::attachment::FileAttachment;
 use crate::interfaces::types::MessageOrigin;
 use crate::models::ImageData;
 
@@ -118,6 +119,8 @@ pub struct ResponseEvent {
     pub content: String,
     /// Local timestamp.
     pub timestamp: NaiveDateTime,
+    /// Optional file attachment.
+    pub attachment: Option<FileAttachment>,
 }
 
 /// Push notification for notify channels.

--- a/src/gateway/event_loop/http.rs
+++ b/src/gateway/event_loop/http.rs
@@ -94,13 +94,21 @@ pub fn build_gateway_app(
 
     let tracing_router = tracing_api_router(tracing_api_state);
 
+    let file_router = axum::Router::new()
+        .route(
+            "/api/files/{id}",
+            get(crate::gateway::file_server::serve_file),
+        )
+        .with_state(state.file_registry.clone());
+
     let mut app = axum::Router::new()
         .route("/ws", get(ws_handler))
         .with_state(state);
     if let Some(wh) = webhook_router {
         app = app.merge(wh);
     }
-    app.merge(cloud_router)
+    app.merge(file_router)
+        .merge(cloud_router)
         .merge(update_router)
         .merge(tracing_router)
         .merge(web::config_api_router(config_api_state))

--- a/src/gateway/event_loop/run_loop.rs
+++ b/src/gateway/event_loop/run_loop.rs
@@ -73,6 +73,7 @@ struct SpawnedHandles {
     tunnel_status_rx: tokio::sync::watch::Receiver<crate::tunnel::TunnelStatus>,
     tracing_service: Arc<crate::tracing_service::TracingService>,
     sigterm: tokio::signal::unix::Signal,
+    file_registry: crate::gateway::file_server::FileRegistry,
 }
 
 /// Spawn the HTTP server, chat adapters, cloud tunnel, and workspace watcher.
@@ -95,6 +96,8 @@ async fn spawn_server_and_adapters(
         tokio::sync::watch::channel(crate::tunnel::TunnelStatus::Disconnected);
     let tunnel_status_tx = Arc::new(tunnel_status_tx);
 
+    let file_registry = crate::gateway::file_server::FileRegistry::new();
+    file_registry.spawn_cleanup_task();
     let state = GatewayState {
         reload_tx: core.reload_tx.clone(),
         command_tx: core.command_tx.clone(),
@@ -103,6 +106,7 @@ async fn spawn_server_and_adapters(
         tunnel_status_rx: tunnel_status_rx.clone(),
         publisher: core.publisher.clone(),
         bus_handle: core.bus_handle.clone(),
+        file_registry: file_registry.clone(),
     };
     let config_api_state = web::ConfigApiState {
         config_dir: cfg.config_dir.clone(),
@@ -158,6 +162,7 @@ async fn spawn_server_and_adapters(
         tunnel_status_rx,
         tracing_service,
         sigterm,
+        file_registry,
     })
 }
 
@@ -312,6 +317,7 @@ async fn build_runtime(
         telegram_shutdown_tx: spawned.adapters.telegram_shutdown_tx,
         reload_tx: core.reload_tx,
         command_tx: core.command_tx,
+        file_registry: spawned.file_registry,
         path_policy: parts.path_policy,
         tracing_service: spawned.tracing_service,
         update_status: update.status,

--- a/src/gateway/event_loop/turns.rs
+++ b/src/gateway/event_loop/turns.rs
@@ -306,6 +306,7 @@ pub async fn handle_inbound_message(
                                 correlation_id: reply_id.clone(),
                                 content: text.clone(),
                                 timestamp: crate::time::now_local(rt.tz),
+                                attachment: None,
                             },
                         )
                         .await

--- a/src/gateway/file_server.rs
+++ b/src/gateway/file_server.rs
@@ -66,13 +66,14 @@ impl FileRegistry {
         ))
     }
 
-    /// Remove all expired entries.
-    pub async fn sweep_expired(&self) {
+    /// Remove all expired entries. Returns `(removed, remaining)`.
+    pub async fn sweep_expired(&self) -> (usize, usize) {
         let now = Instant::now();
-        self.entries
-            .write()
-            .await
-            .retain(|_, entry| entry.expires_at > now);
+        let mut entries = self.entries.write().await;
+        let before = entries.len();
+        entries.retain(|_, entry| entry.expires_at > now);
+        let remaining = entries.len();
+        (before - remaining, remaining)
     }
 
     /// Spawn a background task that periodically sweeps expired entries.
@@ -83,12 +84,9 @@ impl FileRegistry {
                 tokio::time::interval(std::time::Duration::from_secs(CLEANUP_INTERVAL_SECS));
             loop {
                 interval.tick().await;
-                let count_before = registry.entries.read().await.len();
-                registry.sweep_expired().await;
-                let count_after = registry.entries.read().await.len();
-                let removed = count_before - count_after;
+                let (removed, remaining) = registry.sweep_expired().await;
                 if removed > 0 {
-                    tracing::debug!(removed, remaining = count_after, "swept expired file entries");
+                    tracing::debug!(removed, remaining, "swept expired file entries");
                 }
             }
         });
@@ -106,7 +104,7 @@ pub async fn serve_file(
     axum::extract::Path(id): axum::extract::Path<String>,
     axum::extract::State(registry): axum::extract::State<FileRegistry>,
 ) -> axum::response::Response {
-    use axum::http::{header, HeaderValue, StatusCode};
+    use axum::http::{HeaderValue, StatusCode, header};
     use axum::response::IntoResponse;
 
     let Some((path, mime_type, filename)) = registry.get(&id).await else {
@@ -118,7 +116,10 @@ pub async fn serve_file(
         return StatusCode::NOT_FOUND.into_response();
     };
 
-    let safe_filename: String = filename.chars().filter(|c| *c != '"' && *c != '\\').collect();
+    let safe_filename: String = filename
+        .chars()
+        .filter(|c| *c != '"' && *c != '\\')
+        .collect();
     let disposition = format!("inline; filename=\"{safe_filename}\"");
     let mut response = bytes.into_response();
     let headers = response.headers_mut();
@@ -177,7 +178,26 @@ mod tests {
                 },
             );
         }
-        registry.sweep_expired().await;
+        let (removed, remaining) = registry.sweep_expired().await;
+        assert_eq!(removed, 1, "one expired entry should be removed");
+        assert_eq!(remaining, 0, "no entries should remain");
         assert!(registry.get("expired-id").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn sweep_concurrent_register_does_not_underflow() {
+        // Regression: earlier implementation computed removed = before - after across
+        // separate lock acquisitions, which could underflow if a register raced in.
+        let registry = FileRegistry::new();
+        registry
+            .register(
+                PathBuf::from("/tmp/live.pdf"),
+                "application/pdf".to_string(),
+                "live.pdf".to_string(),
+            )
+            .await;
+        let (removed, remaining) = registry.sweep_expired().await;
+        assert_eq!(removed, 0, "no expired entries should be removed");
+        assert_eq!(remaining, 1, "live entry should remain");
     }
 }

--- a/src/gateway/file_server.rs
+++ b/src/gateway/file_server.rs
@@ -1,0 +1,182 @@
+//! File serving for WebSocket-connected clients.
+//!
+//! Registers files with a TTL and serves them via HTTP. WebSocket messages
+//! reference files by URL rather than embedding binary data.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+use tokio::time::Instant;
+
+/// How long a registered file remains available (1 hour).
+const FILE_TTL_SECS: u64 = 3600;
+
+/// How often the cleanup task sweeps expired entries (10 minutes).
+const CLEANUP_INTERVAL_SECS: u64 = 600;
+
+/// A registered file entry with expiration.
+struct FileEntry {
+    path: PathBuf,
+    mime_type: String,
+    filename: String,
+    expires_at: Instant,
+}
+
+/// Thread-safe registry of files available for HTTP serving.
+#[derive(Clone)]
+pub struct FileRegistry {
+    entries: Arc<RwLock<HashMap<String, FileEntry>>>,
+}
+
+impl FileRegistry {
+    /// Create a new empty file registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            entries: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Register a file and return its unique serving ID.
+    pub async fn register(&self, path: PathBuf, mime_type: String, filename: String) -> String {
+        let id = uuid::Uuid::new_v4().to_string();
+        let entry = FileEntry {
+            path,
+            mime_type,
+            filename,
+            expires_at: Instant::now() + std::time::Duration::from_secs(FILE_TTL_SECS),
+        };
+        self.entries.write().await.insert(id.clone(), entry);
+        id
+    }
+
+    /// Look up a file by ID. Returns `(path, mime_type, filename)` if found and not expired.
+    pub async fn get(&self, id: &str) -> Option<(PathBuf, String, String)> {
+        let entries = self.entries.read().await;
+        let entry = entries.get(id)?;
+        if entry.expires_at < Instant::now() {
+            return None;
+        }
+        Some((
+            entry.path.clone(),
+            entry.mime_type.clone(),
+            entry.filename.clone(),
+        ))
+    }
+
+    /// Remove all expired entries.
+    pub async fn sweep_expired(&self) {
+        let now = Instant::now();
+        self.entries
+            .write()
+            .await
+            .retain(|_, entry| entry.expires_at > now);
+    }
+
+    /// Spawn a background task that periodically sweeps expired entries.
+    pub fn spawn_cleanup_task(&self) {
+        let registry = self.clone();
+        tokio::spawn(async move {
+            let mut interval =
+                tokio::time::interval(std::time::Duration::from_secs(CLEANUP_INTERVAL_SECS));
+            loop {
+                interval.tick().await;
+                let count_before = registry.entries.read().await.len();
+                registry.sweep_expired().await;
+                let count_after = registry.entries.read().await.len();
+                let removed = count_before - count_after;
+                if removed > 0 {
+                    tracing::debug!(removed, remaining = count_after, "swept expired file entries");
+                }
+            }
+        });
+    }
+}
+
+impl Default for FileRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Axum handler to serve a registered file by ID.
+pub async fn serve_file(
+    axum::extract::Path(id): axum::extract::Path<String>,
+    axum::extract::State(registry): axum::extract::State<FileRegistry>,
+) -> axum::response::Response {
+    use axum::http::{header, HeaderValue, StatusCode};
+    use axum::response::IntoResponse;
+
+    let Some((path, mime_type, filename)) = registry.get(&id).await else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+
+    let Ok(bytes) = tokio::fs::read(&path).await else {
+        tracing::warn!(file_id = %id, path = %path.display(), "registered file not readable");
+        return StatusCode::NOT_FOUND.into_response();
+    };
+
+    let disposition = format!("inline; filename=\"{filename}\"");
+    let mut response = bytes.into_response();
+    let headers = response.headers_mut();
+    if let Ok(v) = HeaderValue::from_str(&mime_type) {
+        headers.insert(header::CONTENT_TYPE, v);
+    }
+    if let Ok(v) = HeaderValue::from_str(&disposition) {
+        headers.insert(header::CONTENT_DISPOSITION, v);
+    }
+    response
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test code uses unwrap for clarity")]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn register_and_lookup() {
+        let registry = FileRegistry::new();
+        let id = registry
+            .register(
+                PathBuf::from("/tmp/test.pdf"),
+                "application/pdf".to_string(),
+                "test.pdf".to_string(),
+            )
+            .await;
+
+        let entry = registry.get(&id).await;
+        assert!(entry.is_some(), "registered file should be found");
+        let (path, mime, filename) = entry.unwrap();
+        assert_eq!(path, PathBuf::from("/tmp/test.pdf"));
+        assert_eq!(mime, "application/pdf");
+        assert_eq!(filename, "test.pdf");
+    }
+
+    #[tokio::test]
+    async fn lookup_unknown_id_returns_none() {
+        let registry = FileRegistry::new();
+        assert!(registry.get("nonexistent").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn sweep_removes_expired() {
+        let registry = FileRegistry::new();
+        // Insert with already-expired time
+        {
+            let mut entries = registry.entries.write().await;
+            entries.insert(
+                "expired-id".to_string(),
+                FileEntry {
+                    path: PathBuf::from("/tmp/old.pdf"),
+                    mime_type: "application/pdf".to_string(),
+                    filename: "old.pdf".to_string(),
+                    expires_at: Instant::now() - std::time::Duration::from_secs(1),
+                },
+            );
+        }
+        registry.sweep_expired().await;
+        assert!(registry.get("expired-id").await.is_none());
+    }
+}

--- a/src/gateway/file_server.rs
+++ b/src/gateway/file_server.rs
@@ -118,7 +118,8 @@ pub async fn serve_file(
         return StatusCode::NOT_FOUND.into_response();
     };
 
-    let disposition = format!("inline; filename=\"{filename}\"");
+    let safe_filename = filename.replace('"', "").replace('\\', "");
+    let disposition = format!("inline; filename=\"{safe_filename}\"");
     let mut response = bytes.into_response();
     let headers = response.headers_mut();
     if let Ok(v) = HeaderValue::from_str(&mime_type) {

--- a/src/gateway/file_server.rs
+++ b/src/gateway/file_server.rs
@@ -118,7 +118,7 @@ pub async fn serve_file(
         return StatusCode::NOT_FOUND.into_response();
     };
 
-    let safe_filename = filename.replace('"', "").replace('\\', "");
+    let safe_filename: String = filename.chars().filter(|c| *c != '"' && *c != '\\').collect();
     let disposition = format!("inline; filename=\"{safe_filename}\"");
     let mut response = bytes.into_response();
     let headers = response.headers_mut();

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -2,7 +2,7 @@
 
 mod actions;
 pub(crate) mod event_loop;
-pub(crate) mod file_server;
+pub mod file_server;
 mod helpers;
 mod idle;
 mod memory;

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -2,6 +2,7 @@
 
 mod actions;
 pub(crate) mod event_loop;
+pub(crate) mod file_server;
 mod helpers;
 mod idle;
 mod memory;

--- a/src/gateway/protocol.rs
+++ b/src/gateway/protocol.rs
@@ -80,6 +80,22 @@ pub enum ServerMessage {
         /// The response content.
         content: String,
     },
+    /// A file attachment from the agent.
+    FileAttachment {
+        /// Correlation ID of the original message.
+        reply_to: String,
+        /// Original filename.
+        filename: String,
+        /// MIME type of the file.
+        mime_type: String,
+        /// File size in bytes.
+        size: u64,
+        /// URL to fetch the file (e.g. "/api/files/{id}").
+        url: String,
+        /// Optional caption text.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        caption: Option<String>,
+    },
     /// Intermediate text the agent emitted alongside tool calls.
     BroadcastResponse {
         /// The intermediate content.
@@ -352,5 +368,35 @@ mod tests {
             ),
             "should survive serialization round-trip with images"
         );
+    }
+
+    #[test]
+    fn server_message_serialize_file_attachment() {
+        let msg = ServerMessage::FileAttachment {
+            reply_to: "id-1".to_string(),
+            filename: "report.pdf".to_string(),
+            mime_type: "application/pdf".to_string(),
+            size: 1024,
+            url: "/api/files/abc-123".to_string(),
+            caption: Some("Here's the report".to_string()),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains("\"type\":\"file_attachment\""), "should have type tag");
+        assert!(json.contains("\"filename\":\"report.pdf\""), "should have filename");
+        assert!(json.contains("\"url\":\"/api/files/abc-123\""), "should have url");
+    }
+
+    #[test]
+    fn server_message_serialize_file_attachment_no_caption() {
+        let msg = ServerMessage::FileAttachment {
+            reply_to: "id-2".to_string(),
+            filename: "voice.mp3".to_string(),
+            mime_type: "audio/mpeg".to_string(),
+            size: 2048,
+            url: "/api/files/def-456".to_string(),
+            caption: None,
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(!json.contains("\"caption\""), "caption should be skipped when None");
     }
 }

--- a/src/gateway/protocol.rs
+++ b/src/gateway/protocol.rs
@@ -89,6 +89,7 @@ pub enum ServerMessage {
         /// MIME type of the file.
         mime_type: String,
         /// File size in bytes.
+        #[ts(type = "number")]
         size: u64,
         /// URL to fetch the file (e.g. "/api/files/{id}").
         url: String,
@@ -381,9 +382,18 @@ mod tests {
             caption: Some("Here's the report".to_string()),
         };
         let json = serde_json::to_string(&msg).unwrap();
-        assert!(json.contains("\"type\":\"file_attachment\""), "should have type tag");
-        assert!(json.contains("\"filename\":\"report.pdf\""), "should have filename");
-        assert!(json.contains("\"url\":\"/api/files/abc-123\""), "should have url");
+        assert!(
+            json.contains("\"type\":\"file_attachment\""),
+            "should have type tag"
+        );
+        assert!(
+            json.contains("\"filename\":\"report.pdf\""),
+            "should have filename"
+        );
+        assert!(
+            json.contains("\"url\":\"/api/files/abc-123\""),
+            "should have url"
+        );
     }
 
     #[test]
@@ -397,6 +407,9 @@ mod tests {
             caption: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
-        assert!(!json.contains("\"caption\""), "caption should be skipped when None");
+        assert!(
+            !json.contains("\"caption\""),
+            "caption should be skipped when None"
+        );
     }
 }

--- a/src/gateway/reload.rs
+++ b/src/gateway/reload.rs
@@ -391,6 +391,7 @@ async fn reload_gateway(rt: &mut GatewayRuntime, new_cfg: &Config) {
                 tunnel_status_rx: rt.tunnel_status_rx.clone(),
                 publisher: rt.publisher.clone(),
                 bus_handle: rt.bus_handle.clone(),
+                file_registry: rt.file_registry.clone(),
             };
             let config_api_state = crate::gateway::web::ConfigApiState {
                 config_dir: rt.config_dir.clone(),

--- a/src/gateway/types.rs
+++ b/src/gateway/types.rs
@@ -109,6 +109,7 @@ pub(crate) struct GatewayState {
     pub tunnel_status_rx: tokio::sync::watch::Receiver<TunnelStatus>,
     pub publisher: Publisher,
     pub bus_handle: BusHandle,
+    pub file_registry: crate::gateway::file_server::FileRegistry,
 }
 
 /// All state needed by the main event loop.
@@ -179,6 +180,8 @@ pub(crate) struct GatewayRuntime {
     /// Cloned core senders for rebuilding adapters on reload.
     pub reload_tx: tokio::sync::watch::Sender<ReloadSignal>,
     pub command_tx: mpsc::Sender<ServerCommand>,
+    /// File registry for serving attachments to WebSocket clients.
+    pub file_registry: crate::gateway::file_server::FileRegistry,
     /// Shared path policy for updating blocked paths on reload.
     pub path_policy: crate::tools::SharedPathPolicy,
     /// Shared tracing service for observability API.

--- a/src/gateway/ws.rs
+++ b/src/gateway/ws.rs
@@ -39,7 +39,7 @@ async fn handle_connection(socket: WebSocket, state: GatewayState) {
     let (mut ws_tx, mut ws_rx) = socket.split();
 
     // Subscribe to typed bus topics for this connection
-    let mut subs = match WsSubscribers::new(&state.bus_handle, EndpointName::from("ws")).await {
+    let mut subs = match WsSubscribers::new(&state.bus_handle, EndpointName::from("ws"), state.file_registry.clone()).await {
         Ok(s) => s,
         Err(e) => {
             tracing::warn!(error = %e, "failed to subscribe to bus topics for ws connection");

--- a/src/gateway/ws.rs
+++ b/src/gateway/ws.rs
@@ -39,7 +39,13 @@ async fn handle_connection(socket: WebSocket, state: GatewayState) {
     let (mut ws_tx, mut ws_rx) = socket.split();
 
     // Subscribe to typed bus topics for this connection
-    let mut subs = match WsSubscribers::new(&state.bus_handle, EndpointName::from("ws"), state.file_registry.clone()).await {
+    let mut subs = match WsSubscribers::new(
+        &state.bus_handle,
+        EndpointName::from("ws"),
+        state.file_registry.clone(),
+    )
+    .await
+    {
         Ok(s) => s,
         Err(e) => {
             tracing::warn!(error = %e, "failed to subscribe to bus topics for ws connection");

--- a/src/interfaces/attachment.rs
+++ b/src/interfaces/attachment.rs
@@ -61,8 +61,7 @@ impl FileAttachment {
 
         let filename = path
             .file_name()
-            .map(|n| n.to_string_lossy().to_string())
-            .unwrap_or_else(|| "unnamed".to_string());
+            .map_or_else(|| "unnamed".to_string(), |n| n.to_string_lossy().to_string());
 
         let mime_type = detect_mime_type(path);
         let size = metadata.len();

--- a/src/interfaces/attachment.rs
+++ b/src/interfaces/attachment.rs
@@ -59,9 +59,10 @@ impl FileAttachment {
             }
         })?;
 
-        let filename = path
-            .file_name()
-            .map_or_else(|| "unnamed".to_string(), |n| n.to_string_lossy().to_string());
+        let filename = path.file_name().map_or_else(
+            || "unnamed".to_string(),
+            |n| n.to_string_lossy().to_string(),
+        );
 
         let mime_type = detect_mime_type(path);
         let size = metadata.len();
@@ -378,7 +379,9 @@ mod tests {
     async fn file_attachment_from_path_success() {
         let dir = tempfile::tempdir().unwrap();
         let file_path = dir.path().join("report.pdf");
-        tokio::fs::write(&file_path, b"fake pdf content").await.unwrap();
+        tokio::fs::write(&file_path, b"fake pdf content")
+            .await
+            .unwrap();
 
         let attachment = FileAttachment::from_path(&file_path).await.unwrap();
         assert_eq!(attachment.filename, "report.pdf");
@@ -389,10 +392,14 @@ mod tests {
 
     #[tokio::test]
     async fn file_attachment_from_path_not_found() {
-        let result = FileAttachment::from_path(Path::new("/tmp/nonexistent_residuum_test.pdf")).await;
+        let result =
+            FileAttachment::from_path(Path::new("/tmp/nonexistent_residuum_test.pdf")).await;
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert!(err.contains("file not found"), "error should mention not found: {err}");
+        assert!(
+            err.contains("file not found"),
+            "error should mention not found: {err}"
+        );
     }
 
     #[test]

--- a/src/interfaces/attachment.rs
+++ b/src/interfaces/attachment.rs
@@ -7,6 +7,7 @@
 use std::path::{Path, PathBuf};
 
 use base64::Engine;
+use mime_guess;
 
 use crate::models::ImageData;
 
@@ -18,6 +19,62 @@ pub const MAX_IMAGE_INLINE_SIZE: u32 = 20 * 1024 * 1024;
 
 /// MIME types that can be sent inline to the model as images.
 const SUPPORTED_IMAGE_TYPES: &[&str] = &["image/jpeg", "image/png", "image/gif", "image/webp"];
+
+/// Detect MIME type from a file's extension.
+///
+/// Uses `mime_guess` for known extensions, falls back to `application/octet-stream`.
+#[must_use]
+pub fn detect_mime_type(path: &Path) -> String {
+    mime_guess::from_path(path)
+        .first_raw()
+        .unwrap_or("application/octet-stream")
+        .to_string()
+}
+
+/// Metadata for an outbound file attachment.
+#[derive(Debug, Clone)]
+pub struct FileAttachment {
+    /// Absolute path to the file on disk.
+    pub path: PathBuf,
+    /// Original filename (from the path).
+    pub filename: String,
+    /// Detected MIME type.
+    pub mime_type: String,
+    /// File size in bytes.
+    pub size: u64,
+}
+
+impl FileAttachment {
+    /// Create a `FileAttachment` by validating and inspecting a file path.
+    ///
+    /// # Errors
+    ///
+    /// Returns a descriptive error string if the file does not exist or is not readable.
+    pub async fn from_path(path: &Path) -> Result<Self, String> {
+        let metadata = tokio::fs::metadata(path).await.map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                format!("file not found: {}", path.display())
+            } else {
+                format!("file not readable: {}", path.display())
+            }
+        })?;
+
+        let filename = path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| "unnamed".to_string());
+
+        let mime_type = detect_mime_type(path);
+        let size = metadata.len();
+
+        Ok(Self {
+            path: path.to_path_buf(),
+            filename,
+            mime_type,
+            size,
+        })
+    }
+}
 
 /// Check if a content type is a supported image format for inline encoding.
 #[must_use]
@@ -285,6 +342,58 @@ mod tests {
             err.contains("exceeds 25 MB"),
             "error should mention size limit: {err}"
         );
+    }
+
+    #[test]
+    fn detect_mime_known_types() {
+        assert_eq!(detect_mime_type(Path::new("photo.jpg")), "image/jpeg");
+        assert_eq!(detect_mime_type(Path::new("photo.jpeg")), "image/jpeg");
+        assert_eq!(detect_mime_type(Path::new("image.png")), "image/png");
+        assert_eq!(detect_mime_type(Path::new("anim.gif")), "image/gif");
+        assert_eq!(detect_mime_type(Path::new("pic.webp")), "image/webp");
+        assert_eq!(detect_mime_type(Path::new("song.mp3")), "audio/mpeg");
+        assert_eq!(detect_mime_type(Path::new("voice.ogg")), "audio/ogg");
+        assert_eq!(detect_mime_type(Path::new("clip.wav")), "audio/wav");
+        assert_eq!(detect_mime_type(Path::new("note.m4a")), "audio/m4a");
+        assert_eq!(detect_mime_type(Path::new("doc.pdf")), "application/pdf");
+    }
+
+    #[test]
+    fn detect_mime_unknown_extension() {
+        // mime_guess doesn't know .zzz — falls back to application/octet-stream
+        assert_eq!(
+            detect_mime_type(Path::new("data.zzz")),
+            "application/octet-stream"
+        );
+    }
+
+    #[test]
+    fn detect_mime_no_extension() {
+        assert_eq!(
+            detect_mime_type(Path::new("README")),
+            "application/octet-stream"
+        );
+    }
+
+    #[tokio::test]
+    async fn file_attachment_from_path_success() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("report.pdf");
+        tokio::fs::write(&file_path, b"fake pdf content").await.unwrap();
+
+        let attachment = FileAttachment::from_path(&file_path).await.unwrap();
+        assert_eq!(attachment.filename, "report.pdf");
+        assert_eq!(attachment.mime_type, "application/pdf");
+        assert_eq!(attachment.size, 16); // b"fake pdf content".len()
+        assert_eq!(attachment.path, file_path);
+    }
+
+    #[tokio::test]
+    async fn file_attachment_from_path_not_found() {
+        let result = FileAttachment::from_path(Path::new("/tmp/nonexistent_residuum_test.pdf")).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("file not found"), "error should mention not found: {err}");
     }
 
     #[test]

--- a/src/interfaces/cli/mod.rs
+++ b/src/interfaces/cli/mod.rs
@@ -151,6 +151,18 @@ impl CliClient {
                 self.indicator.finish();
                 println!("\n{}\n", self.theme.format_notice(message));
             }
+            ServerMessage::FileAttachment {
+                filename, url, caption, ..
+            } => {
+                self.indicator.finish();
+                let caption_text = caption.as_deref().unwrap_or("");
+                let line = if caption_text.is_empty() {
+                    format!("[file: {filename}] {url}")
+                } else {
+                    format!("[file: {filename}] {url} — {caption_text}")
+                };
+                println!("{}", self.theme.format_tool(&line));
+            }
             // Reloading is intercepted in run_connect before display() is called
             ServerMessage::Pong | ServerMessage::Reloading => {}
         }

--- a/src/interfaces/cli/mod.rs
+++ b/src/interfaces/cli/mod.rs
@@ -152,7 +152,10 @@ impl CliClient {
                 println!("\n{}\n", self.theme.format_notice(message));
             }
             ServerMessage::FileAttachment {
-                filename, url, caption, ..
+                filename,
+                url,
+                caption,
+                ..
             } => {
                 self.indicator.finish();
                 let caption_text = caption.as_deref().unwrap_or("");

--- a/src/interfaces/discord/subscriber.rs
+++ b/src/interfaces/discord/subscriber.rs
@@ -63,7 +63,13 @@ pub(crate) async fn run_discord_subscriber(
             }
             event = subs.response.recv() => {
                 match event {
-                    Ok(Some(resp)) => send_chunks(&http, cid, &resp.content).await,
+                    Ok(Some(resp)) => {
+                        if let Some(ref att) = resp.attachment {
+                            send_file_attachment(&http, cid, att, &resp.content).await;
+                        } else if !resp.content.is_empty() {
+                            send_chunks(&http, cid, &resp.content).await;
+                        }
+                    }
                     Ok(None) => break,
                     Err(_) => { clean_exit = false; break; }
                 }
@@ -109,6 +115,51 @@ async fn send_chunks(http: &serenity::http::Http, channel_id: ChannelId, content
     for chunk in chunks {
         if let Err(e) = channel_id.say(http, &chunk).await {
             tracing::warn!(channel_id = %channel_id, error = %e, "failed to send discord message");
+        }
+    }
+}
+
+async fn send_file_attachment(
+    http: &serenity::http::Http,
+    channel_id: ChannelId,
+    attachment: &crate::interfaces::attachment::FileAttachment,
+    caption: &str,
+) {
+    use serenity::builder::{CreateAttachment, CreateMessage};
+
+    let file_attachment = match CreateAttachment::path(&attachment.path).await {
+        Ok(a) => a,
+        Err(e) => {
+            tracing::warn!(
+                filename = %attachment.filename,
+                endpoint = "discord",
+                error = %e,
+                "failed to read file for discord attachment"
+            );
+            return;
+        }
+    };
+
+    let mut message = CreateMessage::new().add_file(file_attachment);
+    if !caption.is_empty() {
+        message = message.content(caption);
+    }
+
+    match channel_id.send_message(http, message).await {
+        Ok(_) => {
+            tracing::debug!(
+                filename = %attachment.filename,
+                endpoint = "discord",
+                "file delivered"
+            );
+        }
+        Err(e) => {
+            tracing::warn!(
+                filename = %attachment.filename,
+                endpoint = "discord",
+                error = %e,
+                "file delivery failed"
+            );
         }
     }
 }

--- a/src/interfaces/telegram/subscriber.rs
+++ b/src/interfaces/telegram/subscriber.rs
@@ -57,7 +57,13 @@ pub(crate) async fn run_telegram_subscriber(
             }
             event = subs.response.recv() => {
                 match event {
-                    Ok(Some(resp)) => send_chunks(&bot, chat_id, &resp.content).await,
+                    Ok(Some(resp)) => {
+                        if let Some(ref att) = resp.attachment {
+                            send_file(&bot, chat_id, att, &resp.content).await;
+                        } else if !resp.content.is_empty() {
+                            send_chunks(&bot, chat_id, &resp.content).await;
+                        }
+                    }
                     Ok(None) => break,
                     Err(_) => { clean_exit = false; break; }
                 }
@@ -104,5 +110,68 @@ async fn send_chunks(bot: &Bot, chat_id: ChatId, content: &str) {
         if let Err(e) = bot.send_message(chat_id, &chunk).await {
             tracing::warn!(chat_id = %chat_id, error = %e, "failed to send telegram message");
         }
+    }
+}
+
+async fn send_file(
+    bot: &Bot,
+    chat_id: ChatId,
+    attachment: &crate::interfaces::attachment::FileAttachment,
+    caption: &str,
+) {
+    use teloxide::payloads::{SendAudioSetters, SendDocumentSetters, SendPhotoSetters};
+    use teloxide::types::InputFile;
+
+    let file = InputFile::file(&attachment.path);
+    let cap = if caption.is_empty() {
+        None
+    } else if caption.len() > 1024 {
+        // Telegram caption limit is 1024 chars; send full text separately
+        Some(caption.chars().take(1024).collect::<String>())
+    } else {
+        Some(caption.to_string())
+    };
+
+    let result = if attachment.mime_type.starts_with("image/") {
+        let mut req = bot.send_photo(chat_id, file);
+        if let Some(ref c) = cap {
+            req = req.caption(c);
+        }
+        req.await.map(|_| ())
+    } else if attachment.mime_type.starts_with("audio/") {
+        let mut req = bot.send_audio(chat_id, file);
+        if let Some(ref c) = cap {
+            req = req.caption(c);
+        }
+        req.await.map(|_| ())
+    } else {
+        let mut req = bot.send_document(chat_id, file);
+        if let Some(ref c) = cap {
+            req = req.caption(c);
+        }
+        req.await.map(|_| ())
+    };
+
+    match result {
+        Ok(()) => {
+            tracing::debug!(
+                filename = %attachment.filename,
+                endpoint = "telegram",
+                "file delivered"
+            );
+        }
+        Err(e) => {
+            tracing::warn!(
+                filename = %attachment.filename,
+                endpoint = "telegram",
+                error = %e,
+                "file delivery failed"
+            );
+        }
+    }
+
+    // If caption was truncated, send the full text separately
+    if caption.len() > 1024 {
+        send_chunks(bot, chat_id, caption).await;
     }
 }

--- a/src/interfaces/websocket/subscriber.rs
+++ b/src/interfaces/websocket/subscriber.rs
@@ -146,6 +146,7 @@ mod tests {
                 correlation_id: "c1".into(),
                 content: "hello".into(),
                 timestamp: ts(),
+                attachment: None,
             },
         )
         .await

--- a/src/interfaces/websocket/subscriber.rs
+++ b/src/interfaces/websocket/subscriber.rs
@@ -164,7 +164,13 @@ mod tests {
         let handle = crate::bus::spawn_broker();
         let pub_ = handle.publisher();
         let ep = EndpointName::from("ws");
-        let mut subs = WsSubscribers::new(&handle, ep.clone(), crate::gateway::file_server::FileRegistry::new()).await.unwrap();
+        let mut subs = WsSubscribers::new(
+            &handle,
+            ep.clone(),
+            crate::gateway::file_server::FileRegistry::new(),
+        )
+        .await
+        .unwrap();
 
         pub_.publish(
             topics::Endpoint(ep),
@@ -191,7 +197,13 @@ mod tests {
         let handle = crate::bus::spawn_broker();
         let pub_ = handle.publisher();
         let ep = EndpointName::from("ws");
-        let mut subs = WsSubscribers::new(&handle, ep.clone(), crate::gateway::file_server::FileRegistry::new()).await.unwrap();
+        let mut subs = WsSubscribers::new(
+            &handle,
+            ep.clone(),
+            crate::gateway::file_server::FileRegistry::new(),
+        )
+        .await
+        .unwrap();
 
         pub_.publish(
             topics::Endpoint(ep),
@@ -218,7 +230,13 @@ mod tests {
         let handle = crate::bus::spawn_broker();
         let pub_ = handle.publisher();
         let ep = EndpointName::from("ws");
-        let mut subs = WsSubscribers::new(&handle, ep.clone(), crate::gateway::file_server::FileRegistry::new()).await.unwrap();
+        let mut subs = WsSubscribers::new(
+            &handle,
+            ep.clone(),
+            crate::gateway::file_server::FileRegistry::new(),
+        )
+        .await
+        .unwrap();
 
         pub_.publish(
             topics::Endpoint(ep),
@@ -246,7 +264,13 @@ mod tests {
         let handle = crate::bus::spawn_broker();
         let pub_ = handle.publisher();
         let ep = EndpointName::from("ws");
-        let mut subs = WsSubscribers::new(&handle, ep.clone(), crate::gateway::file_server::FileRegistry::new()).await.unwrap();
+        let mut subs = WsSubscribers::new(
+            &handle,
+            ep.clone(),
+            crate::gateway::file_server::FileRegistry::new(),
+        )
+        .await
+        .unwrap();
 
         pub_.publish(
             topics::Endpoint(ep),
@@ -271,7 +295,13 @@ mod tests {
         let handle = crate::bus::spawn_broker();
         let pub_ = handle.publisher();
         let ep = EndpointName::from("ws");
-        let mut subs = WsSubscribers::new(&handle, ep, crate::gateway::file_server::FileRegistry::new()).await.unwrap();
+        let mut subs = WsSubscribers::new(
+            &handle,
+            ep,
+            crate::gateway::file_server::FileRegistry::new(),
+        )
+        .await
+        .unwrap();
 
         pub_.publish(
             topics::Notification(NotifyName::from(crate::bus::SYSTEM_CHANNEL)),
@@ -295,7 +325,13 @@ mod tests {
         let handle = crate::bus::spawn_broker();
         let pub_ = handle.publisher();
         let ep = EndpointName::from("ws");
-        let mut subs = WsSubscribers::new(&handle, ep.clone(), crate::gateway::file_server::FileRegistry::new()).await.unwrap();
+        let mut subs = WsSubscribers::new(
+            &handle,
+            ep.clone(),
+            crate::gateway::file_server::FileRegistry::new(),
+        )
+        .await
+        .unwrap();
 
         pub_.publish(
             topics::Endpoint(ep),
@@ -319,7 +355,13 @@ mod tests {
         let handle = crate::bus::spawn_broker();
         let pub_ = handle.publisher();
         let ep = EndpointName::from("ws");
-        let mut subs = WsSubscribers::new(&handle, ep.clone(), crate::gateway::file_server::FileRegistry::new()).await.unwrap();
+        let mut subs = WsSubscribers::new(
+            &handle,
+            ep.clone(),
+            crate::gateway::file_server::FileRegistry::new(),
+        )
+        .await
+        .unwrap();
 
         pub_.publish(
             topics::Endpoint(ep.clone()),
@@ -351,7 +393,13 @@ mod tests {
         let handle = crate::bus::spawn_broker();
         let pub_ = handle.publisher();
         let ep = EndpointName::from("ws");
-        let mut subs = WsSubscribers::new(&handle, ep, crate::gateway::file_server::FileRegistry::new()).await.unwrap();
+        let mut subs = WsSubscribers::new(
+            &handle,
+            ep,
+            crate::gateway::file_server::FileRegistry::new(),
+        )
+        .await
+        .unwrap();
 
         pub_.publish(
             topics::Notification(NotifyName::from(crate::bus::SYSTEM_CHANNEL)),

--- a/src/interfaces/websocket/subscriber.rs
+++ b/src/interfaces/websocket/subscriber.rs
@@ -14,6 +14,7 @@ pub struct WsSubscribers {
     pub intermediate: Subscriber<IntermediateEvent>,
     pub notice: Subscriber<NoticeEvent>,
     pub error: Subscriber<ErrorEvent>,
+    pub file_registry: crate::gateway::file_server::FileRegistry,
 }
 
 impl WsSubscribers {
@@ -25,6 +26,7 @@ impl WsSubscribers {
     pub async fn new(
         bus_handle: &crate::bus::BusHandle,
         ep: EndpointName,
+        file_registry: crate::gateway::file_server::FileRegistry,
     ) -> Result<Self, crate::bus::BusError> {
         let system_topic = || topics::Notification(NotifyName::from(crate::bus::SYSTEM_CHANNEL));
         Ok(Self {
@@ -34,6 +36,7 @@ impl WsSubscribers {
             intermediate: bus_handle.subscribe(topics::Endpoint(ep)).await?,
             notice: bus_handle.subscribe(system_topic()).await?,
             error: bus_handle.subscribe(system_topic()).await?,
+            file_registry,
         })
     }
 
@@ -45,10 +48,33 @@ impl WsSubscribers {
             let msg = tokio::select! {
                 event = self.response.recv() => {
                     match event {
-                        Ok(Some(resp)) => Some(ServerMessage::Response {
-                            reply_to: resp.correlation_id,
-                            content: resp.content,
-                        }),
+                        Ok(Some(resp)) => {
+                            if let Some(ref att) = resp.attachment {
+                                let id = self.file_registry.register(
+                                    att.path.clone(),
+                                    att.mime_type.clone(),
+                                    att.filename.clone(),
+                                ).await;
+                                let caption = if resp.content.is_empty() {
+                                    None
+                                } else {
+                                    Some(resp.content.clone())
+                                };
+                                Some(ServerMessage::FileAttachment {
+                                    reply_to: resp.correlation_id.clone(),
+                                    filename: att.filename.clone(),
+                                    mime_type: att.mime_type.clone(),
+                                    size: att.size,
+                                    url: format!("/api/files/{id}"),
+                                    caption,
+                                })
+                            } else {
+                                Some(ServerMessage::Response {
+                                    reply_to: resp.correlation_id,
+                                    content: resp.content,
+                                })
+                            }
+                        }
                         _ => return None,
                     }
                 }
@@ -138,7 +164,7 @@ mod tests {
         let handle = crate::bus::spawn_broker();
         let pub_ = handle.publisher();
         let ep = EndpointName::from("ws");
-        let mut subs = WsSubscribers::new(&handle, ep.clone()).await.unwrap();
+        let mut subs = WsSubscribers::new(&handle, ep.clone(), crate::gateway::file_server::FileRegistry::new()).await.unwrap();
 
         pub_.publish(
             topics::Endpoint(ep),
@@ -165,7 +191,7 @@ mod tests {
         let handle = crate::bus::spawn_broker();
         let pub_ = handle.publisher();
         let ep = EndpointName::from("ws");
-        let mut subs = WsSubscribers::new(&handle, ep.clone()).await.unwrap();
+        let mut subs = WsSubscribers::new(&handle, ep.clone(), crate::gateway::file_server::FileRegistry::new()).await.unwrap();
 
         pub_.publish(
             topics::Endpoint(ep),
@@ -192,7 +218,7 @@ mod tests {
         let handle = crate::bus::spawn_broker();
         let pub_ = handle.publisher();
         let ep = EndpointName::from("ws");
-        let mut subs = WsSubscribers::new(&handle, ep.clone()).await.unwrap();
+        let mut subs = WsSubscribers::new(&handle, ep.clone(), crate::gateway::file_server::FileRegistry::new()).await.unwrap();
 
         pub_.publish(
             topics::Endpoint(ep),
@@ -220,7 +246,7 @@ mod tests {
         let handle = crate::bus::spawn_broker();
         let pub_ = handle.publisher();
         let ep = EndpointName::from("ws");
-        let mut subs = WsSubscribers::new(&handle, ep.clone()).await.unwrap();
+        let mut subs = WsSubscribers::new(&handle, ep.clone(), crate::gateway::file_server::FileRegistry::new()).await.unwrap();
 
         pub_.publish(
             topics::Endpoint(ep),
@@ -245,7 +271,7 @@ mod tests {
         let handle = crate::bus::spawn_broker();
         let pub_ = handle.publisher();
         let ep = EndpointName::from("ws");
-        let mut subs = WsSubscribers::new(&handle, ep).await.unwrap();
+        let mut subs = WsSubscribers::new(&handle, ep, crate::gateway::file_server::FileRegistry::new()).await.unwrap();
 
         pub_.publish(
             topics::Notification(NotifyName::from(crate::bus::SYSTEM_CHANNEL)),
@@ -269,7 +295,7 @@ mod tests {
         let handle = crate::bus::spawn_broker();
         let pub_ = handle.publisher();
         let ep = EndpointName::from("ws");
-        let mut subs = WsSubscribers::new(&handle, ep.clone()).await.unwrap();
+        let mut subs = WsSubscribers::new(&handle, ep.clone(), crate::gateway::file_server::FileRegistry::new()).await.unwrap();
 
         pub_.publish(
             topics::Endpoint(ep),
@@ -293,7 +319,7 @@ mod tests {
         let handle = crate::bus::spawn_broker();
         let pub_ = handle.publisher();
         let ep = EndpointName::from("ws");
-        let mut subs = WsSubscribers::new(&handle, ep.clone()).await.unwrap();
+        let mut subs = WsSubscribers::new(&handle, ep.clone(), crate::gateway::file_server::FileRegistry::new()).await.unwrap();
 
         pub_.publish(
             topics::Endpoint(ep.clone()),
@@ -325,7 +351,7 @@ mod tests {
         let handle = crate::bus::spawn_broker();
         let pub_ = handle.publisher();
         let ep = EndpointName::from("ws");
-        let mut subs = WsSubscribers::new(&handle, ep).await.unwrap();
+        let mut subs = WsSubscribers::new(&handle, ep, crate::gateway::file_server::FileRegistry::new()).await.unwrap();
 
         pub_.publish(
             topics::Notification(NotifyName::from(crate::bus::SYSTEM_CHANNEL)),

--- a/src/tools/TOOLS.md
+++ b/src/tools/TOOLS.md
@@ -526,29 +526,40 @@ On total failure: error with failure details.
 **Source:** `send_message.rs` · `SendMessageTool`
 
 **Description sent to LLM:**
-> Send a one-off message to a notification or interactive endpoint. Use list_endpoints to see available targets.
+> Send a message and/or file attachment to a notification or interactive endpoint. Use list_endpoints to see available targets.
 
 ### Input
 
-| Parameter  | Type   | Required | Description                                                                    |
-|------------|--------|----------|--------------------------------------------------------------------------------|
-| `endpoint` | string | yes      | Target endpoint name (any interactive or notification endpoint)               |
-| `message`  | string | yes      | The message body to send                                                       |
-| `title`    | string | no       | Optional title for notifications (defaults to first 60 chars of message)      |
+| Parameter   | Type   | Required        | Description                                                                    |
+|-------------|--------|-----------------|--------------------------------------------------------------------------------|
+| `endpoint`  | string | yes             | Target endpoint name (any interactive or notification endpoint)               |
+| `message`   | string | no†             | Message body or caption text                                                   |
+| `file_path` | string | no†             | Absolute path to a file to attach (interactive endpoints only)                |
+| `title`     | string | no              | Optional title for notifications (defaults to first 60 chars of message)      |
+
+† At least one of `message` or `file_path` must be provided.
 
 ### Output
 
-On success: `"Message published to endpoint '{name}'"`
+On success:
+- Text only: `"Message published to endpoint '{name}'"`
+- File only: `"File '{filename}' published to endpoint '{name}'"`
+- Text + file: `"Message and file '{filename}' published to endpoint '{name}'"`
 
 On error:
+- Neither message nor file → `"at least one of 'message' or 'file_path' is required"`
 - Unknown endpoint → `"unknown endpoint '{name}'; available: {list}"`
 - Endpoint does not accept messages (e.g. inbox) → `"endpoint '{name}' does not accept messages; available: {list}"`
+- File with notify endpoint → `"endpoint '{name}' does not support file attachments"`
+- File not found → `"file not found: {path}"`
+- File exceeds size limit → `"file '{name}' is {N}MB, exceeds {limit}MB limit for {endpoint}"`
 - Bus publish failure → execution error with details
 
 **Side effects:**
 - Notify endpoints: publishes `NotificationEvent` to the endpoint's topic
-- Interactive endpoints: publishes `ResponseEvent` to the endpoint's topic
+- Interactive endpoints: publishes `ResponseEvent` to the endpoint's topic (with optional `FileAttachment`)
 - **Cannot send to inbox** — the agent has no write path to inbox
+- **File attachments require interactive endpoints** — Telegram allows up to 50MB, others 25MB
 
 ---
 

--- a/src/tools/TOOLS.md
+++ b/src/tools/TOOLS.md
@@ -526,7 +526,7 @@ On total failure: error with failure details.
 **Source:** `send_message.rs` · `SendMessageTool`
 
 **Description sent to LLM:**
-> Send a message and/or file attachment to a notification or interactive endpoint. Use list_endpoints to see available targets.
+> Send a message and/or file attachment to an endpoint. When sharing a file with the user, always use the file_path parameter — the file will be delivered natively (inline image, audio player, or download link) rather than as a text path. Use list_endpoints to see available targets.
 
 ### Input
 
@@ -534,7 +534,7 @@ On total failure: error with failure details.
 |-------------|--------|-----------------|--------------------------------------------------------------------------------|
 | `endpoint`  | string | yes             | Target endpoint name (any interactive or notification endpoint)               |
 | `message`   | string | no†             | Message body or caption text                                                   |
-| `file_path` | string | no†             | Absolute path to a file to attach (interactive endpoints only)                |
+| `file_path` | string | no†             | Absolute path to a file to send. Images render inline, audio gets a player, other files appear as downloads. Always use this instead of pasting file paths as text. |
 | `title`     | string | no              | Optional title for notifications (defaults to first 60 chars of message)      |
 
 † At least one of `message` or `file_path` must be provided.

--- a/src/tools/send_message.rs
+++ b/src/tools/send_message.rs
@@ -41,6 +41,58 @@ impl SendMessageTool {
     }
 }
 
+async fn validate_file_attachment(
+    fp: &str,
+    endpoint_name: &str,
+) -> Result<crate::interfaces::attachment::FileAttachment, String> {
+    let path = std::path::Path::new(fp);
+    let att = crate::interfaces::attachment::FileAttachment::from_path(path).await?;
+
+    // Size limit: 50MB for Telegram, 25MB for others
+    let limit: u64 = if endpoint_name.contains("telegram") {
+        50 * 1024 * 1024
+    } else {
+        25 * 1024 * 1024
+    };
+    if att.size > limit {
+        let size_mb = att.size / (1024 * 1024);
+        let limit_mb = limit / (1024 * 1024);
+        return Err(format!(
+            "file '{}' is {}MB, exceeds {}MB limit for {endpoint_name}",
+            att.filename, size_mb, limit_mb,
+        ));
+    }
+
+    tracing::info!(
+        filename = %att.filename,
+        mime_type = %att.mime_type,
+        size = att.size,
+        endpoint = %endpoint_name,
+        "file attachment published"
+    );
+
+    Ok(att)
+}
+
+fn build_success_message(
+    endpoint_name: &str,
+    file_path_str: Option<&str>,
+    message: Option<&str>,
+) -> String {
+    if let Some(fp) = file_path_str {
+        let filename = std::path::Path::new(fp)
+            .file_name()
+            .map_or_else(|| fp.to_string(), |n| n.to_string_lossy().to_string());
+        if message.is_some() {
+            format!("Message and file '{filename}' published to endpoint '{endpoint_name}'")
+        } else {
+            format!("File '{filename}' published to endpoint '{endpoint_name}'")
+        }
+    } else {
+        format!("Message published to endpoint '{endpoint_name}'")
+    }
+}
+
 #[async_trait]
 impl Tool for SendMessageTool {
     fn name(&self) -> &'static str {
@@ -130,36 +182,10 @@ impl Tool for SendMessageTool {
                     "endpoint '{endpoint_name}' does not support file attachments"
                 )));
             }
-            let path = std::path::Path::new(fp);
-            let att = match crate::interfaces::attachment::FileAttachment::from_path(path).await {
-                Ok(a) => a,
+            match validate_file_attachment(fp, endpoint_name).await {
+                Ok(att) => Some(att),
                 Err(e) => return Ok(ToolResult::error(e)),
-            };
-
-            // Size limit: 50MB for Telegram, 25MB for others
-            let limit: u64 = if endpoint_name.contains("telegram") {
-                50 * 1024 * 1024
-            } else {
-                25 * 1024 * 1024
-            };
-            if att.size > limit {
-                let size_mb = att.size / (1024 * 1024);
-                let limit_mb = limit / (1024 * 1024);
-                return Ok(ToolResult::error(format!(
-                    "file '{}' is {}MB, exceeds {}MB limit for {endpoint_name}",
-                    att.filename, size_mb, limit_mb,
-                )));
             }
-
-            tracing::info!(
-                filename = %att.filename,
-                mime_type = %att.mime_type,
-                size = att.size,
-                endpoint = %endpoint_name,
-                "file attachment published"
-            );
-
-            Some(att)
         } else {
             None
         };
@@ -204,19 +230,7 @@ impl Tool for SendMessageTool {
         }
 
         // Build success message
-        let success_msg = if let Some(fp) = file_path_str {
-            let filename = std::path::Path::new(fp)
-                .file_name()
-                .map(|n| n.to_string_lossy().to_string())
-                .unwrap_or_else(|| fp.to_string());
-            if message.is_some() {
-                format!("Message and file '{filename}' published to endpoint '{endpoint_name}'")
-            } else {
-                format!("File '{filename}' published to endpoint '{endpoint_name}'")
-            }
-        } else {
-            format!("Message published to endpoint '{endpoint_name}'")
-        };
+        let success_msg = build_success_message(endpoint_name, file_path_str, message);
 
         Ok(ToolResult::success(success_msg))
     }

--- a/src/tools/send_message.rs
+++ b/src/tools/send_message.rs
@@ -139,6 +139,7 @@ impl Tool for SendMessageTool {
                 correlation_id: String::new(),
                 content: message.to_string(),
                 timestamp: now,
+                attachment: None,
             };
             let topic = topics::Endpoint(EndpointName::from(endpoint_name));
             self.publisher.publish(topic, response).await.map_err(|e| {

--- a/src/tools/send_message.rs
+++ b/src/tools/send_message.rs
@@ -102,8 +102,10 @@ impl Tool for SendMessageTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: self.name().to_string(),
-            description: "Send a message and/or file attachment to a notification or interactive \
-                endpoint. Use list_endpoints to see available targets."
+            description: "Send a message and/or file attachment to an endpoint. When sharing \
+                a file with the user, always use the file_path parameter — the file will be \
+                delivered natively (inline image, audio player, or download link) rather than \
+                as a text path. Use list_endpoints to see available targets."
                 .to_string(),
             parameters: serde_json::json!({
                 "type": "object",
@@ -118,7 +120,7 @@ impl Tool for SendMessageTool {
                     },
                     "file_path": {
                         "type": "string",
-                        "description": "Absolute path to a file to attach (optional if message is provided)"
+                        "description": "Absolute path to a file to send. Images render inline, audio gets a player, other files appear as downloads. Always use this instead of pasting file paths as text."
                     },
                     "title": {
                         "type": "string",

--- a/src/tools/send_message.rs
+++ b/src/tools/send_message.rs
@@ -50,8 +50,8 @@ impl Tool for SendMessageTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: self.name().to_string(),
-            description: "Send a one-off message to a notification or interactive endpoint. \
-                Use list_endpoints to see available targets."
+            description: "Send a message and/or file attachment to a notification or interactive \
+                endpoint. Use list_endpoints to see available targets."
                 .to_string(),
             parameters: serde_json::json!({
                 "type": "object",
@@ -62,23 +62,34 @@ impl Tool for SendMessageTool {
                     },
                     "message": {
                         "type": "string",
-                        "description": "The message body to send"
+                        "description": "Message body or caption text (optional if file_path is provided)"
+                    },
+                    "file_path": {
+                        "type": "string",
+                        "description": "Absolute path to a file to attach (optional if message is provided)"
                     },
                     "title": {
                         "type": "string",
                         "description": "Optional title for notifications (defaults to first 60 chars of message)"
                     }
                 },
-                "required": ["endpoint", "message"]
+                "required": ["endpoint"]
             }),
         }
     }
 
     async fn execute(&self, arguments: Value) -> Result<ToolResult, ToolError> {
         let endpoint_name = super::require_str(&arguments, "endpoint")?;
-        let message = super::require_str(&arguments, "message")?;
-
+        let message = arguments.get("message").and_then(Value::as_str);
+        let file_path_str = arguments.get("file_path").and_then(Value::as_str);
         let title = arguments.get("title").and_then(Value::as_str);
+
+        // Must have at least one of message or file_path
+        if message.is_none() && file_path_str.is_none() {
+            return Ok(ToolResult::error(
+                "at least one of 'message' or 'file_path' is required".to_string(),
+            ));
+        }
 
         let endpoint_id = EndpointId::from(endpoint_name);
         let Some(entry) = self.registry.get(&endpoint_id) else {
@@ -112,15 +123,57 @@ impl Tool for SendMessageTool {
             )));
         }
 
+        // File attachments only supported on interactive endpoints
+        let attachment = if let Some(fp) = file_path_str {
+            if !is_interactive {
+                return Ok(ToolResult::error(format!(
+                    "endpoint '{endpoint_name}' does not support file attachments"
+                )));
+            }
+            let path = std::path::Path::new(fp);
+            let att = match crate::interfaces::attachment::FileAttachment::from_path(path).await {
+                Ok(a) => a,
+                Err(e) => return Ok(ToolResult::error(e)),
+            };
+
+            // Size limit: 50MB for Telegram, 25MB for others
+            let limit: u64 = if endpoint_name.contains("telegram") {
+                50 * 1024 * 1024
+            } else {
+                25 * 1024 * 1024
+            };
+            if att.size > limit {
+                let size_mb = att.size / (1024 * 1024);
+                let limit_mb = limit / (1024 * 1024);
+                return Ok(ToolResult::error(format!(
+                    "file '{}' is {}MB, exceeds {}MB limit for {endpoint_name}",
+                    att.filename, size_mb, limit_mb,
+                )));
+            }
+
+            tracing::info!(
+                filename = %att.filename,
+                mime_type = %att.mime_type,
+                size = att.size,
+                endpoint = %endpoint_name,
+                "file attachment published"
+            );
+
+            Some(att)
+        } else {
+            None
+        };
+
         let now = chrono::Utc::now().naive_utc();
+        let content = message.unwrap_or("").to_string();
 
         if is_notify {
             let notification = NotificationEvent {
                 title: title.map_or_else(
-                    || message.chars().take(60).collect::<String>(),
+                    || content.chars().take(60).collect::<String>(),
                     str::to_string,
                 ),
-                content: message.to_string(),
+                content: content.clone(),
                 source: EventTrigger::Agent,
                 timestamp: now,
             };
@@ -137,9 +190,9 @@ impl Tool for SendMessageTool {
         } else {
             let response = ResponseEvent {
                 correlation_id: String::new(),
-                content: message.to_string(),
+                content,
                 timestamp: now,
-                attachment: None,
+                attachment,
             };
             let topic = topics::Endpoint(EndpointName::from(endpoint_name));
             self.publisher.publish(topic, response).await.map_err(|e| {
@@ -150,9 +203,22 @@ impl Tool for SendMessageTool {
             })?;
         }
 
-        Ok(ToolResult::success(format!(
-            "Message published to endpoint '{endpoint_name}'"
-        )))
+        // Build success message
+        let success_msg = if let Some(fp) = file_path_str {
+            let filename = std::path::Path::new(fp)
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_else(|| fp.to_string());
+            if message.is_some() {
+                format!("Message and file '{filename}' published to endpoint '{endpoint_name}'")
+            } else {
+                format!("File '{filename}' published to endpoint '{endpoint_name}'")
+            }
+        } else {
+            format!("Message published to endpoint '{endpoint_name}'")
+        };
+
+        Ok(ToolResult::success(success_msg))
     }
 }
 
@@ -300,5 +366,138 @@ mod tests {
 
         let result = tool.execute(serde_json::json!({"message": "test"})).await;
         assert!(result.is_err(), "should error on missing endpoint");
+    }
+
+    #[tokio::test]
+    async fn send_file_to_interactive_endpoint_publishes() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("test.pdf");
+        tokio::fs::write(&file_path, b"fake pdf").await.unwrap();
+
+        let registry = make_registry();
+        let bus_handle = crate::bus::spawn_broker();
+        let publisher = bus_handle.publisher();
+        let mut subscriber = bus_handle
+            .subscribe(topics::Endpoint(EndpointName::from("ws")))
+            .await
+            .unwrap();
+        let tool = SendMessageTool::new(registry, publisher);
+
+        let result = tool
+            .execute(serde_json::json!({
+                "endpoint": "ws",
+                "file_path": file_path.to_str().unwrap()
+            }))
+            .await
+            .unwrap();
+
+        assert!(!result.is_error, "should succeed: {}", result.output);
+        assert!(result.output.contains("test.pdf"), "should mention filename: {}", result.output);
+
+        let event: crate::bus::ResponseEvent = subscriber.recv().await.unwrap().unwrap();
+        assert!(event.attachment.is_some(), "should have attachment");
+        let att = event.attachment.unwrap();
+        assert_eq!(att.filename, "test.pdf");
+        assert_eq!(att.mime_type, "application/pdf");
+    }
+
+    #[tokio::test]
+    async fn send_file_with_caption() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("photo.jpg");
+        tokio::fs::write(&file_path, b"fake image").await.unwrap();
+
+        let registry = make_registry();
+        let bus_handle = crate::bus::spawn_broker();
+        let publisher = bus_handle.publisher();
+        let mut subscriber = bus_handle
+            .subscribe(topics::Endpoint(EndpointName::from("ws")))
+            .await
+            .unwrap();
+        let tool = SendMessageTool::new(registry, publisher);
+
+        let result = tool
+            .execute(serde_json::json!({
+                "endpoint": "ws",
+                "message": "Check out this photo",
+                "file_path": file_path.to_str().unwrap()
+            }))
+            .await
+            .unwrap();
+
+        assert!(!result.is_error, "should succeed: {}", result.output);
+
+        let event: crate::bus::ResponseEvent = subscriber.recv().await.unwrap().unwrap();
+        assert_eq!(event.content, "Check out this photo");
+        assert!(event.attachment.is_some());
+    }
+
+    #[tokio::test]
+    async fn send_no_message_no_file_returns_error() {
+        let registry = make_registry();
+        let publisher = make_publisher();
+        let tool = SendMessageTool::new(registry, publisher);
+
+        let result = tool
+            .execute(serde_json::json!({
+                "endpoint": "ws"
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.is_error, "should error with no message or file");
+        assert!(
+            result.output.contains("at least one of"),
+            "should explain: {}",
+            result.output
+        );
+    }
+
+    #[tokio::test]
+    async fn send_file_not_found_returns_error() {
+        let registry = make_registry();
+        let publisher = make_publisher();
+        let tool = SendMessageTool::new(registry, publisher);
+
+        let result = tool
+            .execute(serde_json::json!({
+                "endpoint": "ws",
+                "file_path": "/tmp/nonexistent_residuum_test_file.pdf"
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.is_error, "should error for missing file");
+        assert!(
+            result.output.contains("file not found"),
+            "should mention not found: {}",
+            result.output
+        );
+    }
+
+    #[tokio::test]
+    async fn send_file_to_notify_endpoint_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("doc.pdf");
+        tokio::fs::write(&file_path, b"content").await.unwrap();
+
+        let registry = make_registry();
+        let publisher = make_publisher();
+        let tool = SendMessageTool::new(registry, publisher);
+
+        let result = tool
+            .execute(serde_json::json!({
+                "endpoint": "my-ntfy",
+                "file_path": file_path.to_str().unwrap()
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.is_error, "should error for notify endpoint with file");
+        assert!(
+            result.output.contains("does not support file attachments"),
+            "should explain: {}",
+            result.output
+        );
     }
 }

--- a/src/tools/send_message.rs
+++ b/src/tools/send_message.rs
@@ -408,7 +408,11 @@ mod tests {
             .unwrap();
 
         assert!(!result.is_error, "should succeed: {}", result.output);
-        assert!(result.output.contains("test.pdf"), "should mention filename: {}", result.output);
+        assert!(
+            result.output.contains("test.pdf"),
+            "should mention filename: {}",
+            result.output
+        );
 
         let event: crate::bus::ResponseEvent = subscriber.recv().await.unwrap().unwrap();
         assert!(event.attachment.is_some(), "should have attachment");
@@ -509,7 +513,10 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(result.is_error, "should error for notify endpoint with file");
+        assert!(
+            result.is_error,
+            "should error for notify endpoint with file"
+        );
         assert!(
             result.output.contains("does not support file attachments"),
             "should explain: {}",

--- a/src/workspace/channel_builder.rs
+++ b/src/workspace/channel_builder.rs
@@ -67,7 +67,7 @@ async fn build_macos_channel(
     kind: &ExternalChannelKind,
 ) -> Option<Box<dyn NotificationChannel>> {
     use crate::notify::macos::MacosChannelConfig;
-    use crate::notify::macos::categories::{parse_category, parse_priority};
+    use crate::notify::macos::categories::{MacosCategory, MacosInterruptionLevel};
 
     let ExternalChannelKind::Macos {
         default_category,
@@ -84,7 +84,7 @@ async fn build_macos_channel(
     let mut config = MacosChannelConfig::default();
 
     if let Some(cat) = default_category {
-        match parse_category(cat) {
+        match cat.parse::<MacosCategory>() {
             Ok(c) => config.default_category = c,
             Err(e) => {
                 tracing::warn!(channel = %name, error = %e, "invalid macOS channel config, skipping");
@@ -94,7 +94,7 @@ async fn build_macos_channel(
     }
 
     if let Some(pri) = default_priority {
-        match parse_priority(pri) {
+        match pri.parse::<MacosInterruptionLevel>() {
             Ok(p) => config.default_priority = p,
             Err(e) => {
                 tracing::warn!(channel = %name, error = %e, "invalid macOS channel config, skipping");

--- a/tests/file_attachment_integration.rs
+++ b/tests/file_attachment_integration.rs
@@ -1,18 +1,30 @@
-//! Integration test: file attachment through send_message → bus → subscriber.
+//! Integration test: file attachment through `send_message` → bus → subscriber.
 //!
-//! Tests the full backend flow: send_message tool with file_path →
-//! ResponseEvent with FileAttachment → WebSocket subscriber maps to
-//! ServerMessage::FileAttachment with a valid URL.
+//! Tests the full backend flow: `send_message` tool with `file_path` →
+//! `ResponseEvent` with `FileAttachment` → WebSocket subscriber maps to
+//! `ServerMessage::FileAttachment` with a valid URL.
 
 #[expect(clippy::unwrap_used, reason = "test code uses unwrap for clarity")]
+#[expect(clippy::expect_used, reason = "test code uses expect for clarity")]
+#[expect(
+    clippy::panic,
+    reason = "test assertions use panic on unexpected variants"
+)]
+#[expect(
+    clippy::wildcard_enum_match_arm,
+    reason = "test assertions use wildcard for non-matching variants"
+)]
 #[cfg(test)]
 mod tests {
-    use residuum::bus::{EndpointCapabilities, EndpointEntry, EndpointId, EndpointName, EndpointRegistry, Publisher, ResponseEvent, TopicId, topics};
+    use residuum::bus::{
+        EndpointCapabilities, EndpointEntry, EndpointId, EndpointName, EndpointRegistry,
+        ResponseEvent, TopicId, topics,
+    };
     use residuum::gateway::file_server::FileRegistry;
     use residuum::gateway::protocol::ServerMessage;
     use residuum::interfaces::websocket::subscriber::WsSubscribers;
-    use residuum::tools::send_message::SendMessageTool;
     use residuum::tools::Tool;
+    use residuum::tools::send_message::SendMessageTool;
 
     fn make_registry() -> EndpointRegistry {
         let registry = EndpointRegistry::new();
@@ -29,10 +41,12 @@ mod tests {
     async fn send_message_file_publishes_response_event_with_attachment() {
         let dir = tempfile::tempdir().unwrap();
         let file_path = dir.path().join("report.pdf");
-        tokio::fs::write(&file_path, b"fake pdf content").await.unwrap();
+        tokio::fs::write(&file_path, b"fake pdf content")
+            .await
+            .unwrap();
 
         let bus = residuum::bus::spawn_broker();
-        let publisher: Publisher = bus.publisher();
+        let publisher = bus.publisher();
         let mut subscriber = bus
             .subscribe(topics::Endpoint(EndpointName::from("ws")))
             .await
@@ -57,7 +71,9 @@ mod tests {
         );
 
         let event: ResponseEvent = subscriber.recv().await.unwrap().unwrap();
-        let att = event.attachment.expect("ResponseEvent should have attachment");
+        let att = event
+            .attachment
+            .expect("ResponseEvent should have attachment");
         assert_eq!(att.filename, "report.pdf");
         assert_eq!(att.mime_type, "application/pdf");
         assert_eq!(att.size, 16); // b"fake pdf content".len()
@@ -67,13 +83,17 @@ mod tests {
     async fn ws_subscriber_maps_response_event_to_file_attachment_message() {
         let dir = tempfile::tempdir().unwrap();
         let file_path = dir.path().join("photo.jpg");
-        tokio::fs::write(&file_path, b"fake image bytes").await.unwrap();
+        tokio::fs::write(&file_path, b"fake image bytes")
+            .await
+            .unwrap();
 
         let bus = residuum::bus::spawn_broker();
-        let publisher: Publisher = bus.publisher();
+        let publisher = bus.publisher();
         let ep = EndpointName::from("ws");
         let file_registry = FileRegistry::new();
-        let mut subs = WsSubscribers::new(&bus, ep.clone(), file_registry).await.unwrap();
+        let mut subs = WsSubscribers::new(&bus, ep.clone(), file_registry)
+            .await
+            .unwrap();
 
         let att = residuum::interfaces::attachment::FileAttachment {
             path: file_path.clone(),
@@ -109,7 +129,10 @@ mod tests {
                 assert_eq!(filename, "photo.jpg");
                 assert_eq!(mime_type, "image/jpeg");
                 assert_eq!(size, 16);
-                assert!(url.starts_with("/api/files/"), "url should be a file API path: {url}");
+                assert!(
+                    url.starts_with("/api/files/"),
+                    "url should be a file API path: {url}"
+                );
                 assert_eq!(caption, Some("Here's your photo".to_string()));
             }
             other => panic!("expected FileAttachment, got: {other:?}"),
@@ -119,7 +142,7 @@ mod tests {
     #[tokio::test]
     async fn send_message_text_only_still_works() {
         let bus = residuum::bus::spawn_broker();
-        let publisher: Publisher = bus.publisher();
+        let publisher = bus.publisher();
         let mut subscriber = bus
             .subscribe(topics::Endpoint(EndpointName::from("ws")))
             .await
@@ -136,10 +159,17 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(!result.is_error, "text-only should succeed: {}", result.output);
+        assert!(
+            !result.is_error,
+            "text-only should succeed: {}",
+            result.output
+        );
 
         let event: ResponseEvent = subscriber.recv().await.unwrap().unwrap();
         assert_eq!(event.content, "hello from agent");
-        assert!(event.attachment.is_none(), "text-only should have no attachment");
+        assert!(
+            event.attachment.is_none(),
+            "text-only should have no attachment"
+        );
     }
 }

--- a/tests/file_attachment_integration.rs
+++ b/tests/file_attachment_integration.rs
@@ -1,0 +1,145 @@
+//! Integration test: file attachment through send_message → bus → subscriber.
+//!
+//! Tests the full backend flow: send_message tool with file_path →
+//! ResponseEvent with FileAttachment → WebSocket subscriber maps to
+//! ServerMessage::FileAttachment with a valid URL.
+
+#[expect(clippy::unwrap_used, reason = "test code uses unwrap for clarity")]
+#[cfg(test)]
+mod tests {
+    use residuum::bus::{EndpointCapabilities, EndpointEntry, EndpointId, EndpointName, EndpointRegistry, Publisher, ResponseEvent, TopicId, topics};
+    use residuum::gateway::file_server::FileRegistry;
+    use residuum::gateway::protocol::ServerMessage;
+    use residuum::interfaces::websocket::subscriber::WsSubscribers;
+    use residuum::tools::send_message::SendMessageTool;
+    use residuum::tools::Tool;
+
+    fn make_registry() -> EndpointRegistry {
+        let registry = EndpointRegistry::new();
+        registry.register(EndpointEntry {
+            id: EndpointId::from("ws"),
+            topic: TopicId::Endpoint(EndpointName::from("ws")),
+            capabilities: EndpointCapabilities::INTERACTIVE,
+            display_name: "WebSocket".to_string(),
+        });
+        registry
+    }
+
+    #[tokio::test]
+    async fn send_message_file_publishes_response_event_with_attachment() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("report.pdf");
+        tokio::fs::write(&file_path, b"fake pdf content").await.unwrap();
+
+        let bus = residuum::bus::spawn_broker();
+        let publisher: Publisher = bus.publisher();
+        let mut subscriber = bus
+            .subscribe(topics::Endpoint(EndpointName::from("ws")))
+            .await
+            .unwrap();
+
+        let registry = make_registry();
+        let tool = SendMessageTool::new(registry, publisher);
+
+        let result = tool
+            .execute(serde_json::json!({
+                "endpoint": "ws",
+                "file_path": file_path.to_str().unwrap()
+            }))
+            .await
+            .unwrap();
+
+        assert!(!result.is_error, "tool should succeed: {}", result.output);
+        assert!(
+            result.output.contains("report.pdf"),
+            "success message should contain filename: {}",
+            result.output
+        );
+
+        let event: ResponseEvent = subscriber.recv().await.unwrap().unwrap();
+        let att = event.attachment.expect("ResponseEvent should have attachment");
+        assert_eq!(att.filename, "report.pdf");
+        assert_eq!(att.mime_type, "application/pdf");
+        assert_eq!(att.size, 16); // b"fake pdf content".len()
+    }
+
+    #[tokio::test]
+    async fn ws_subscriber_maps_response_event_to_file_attachment_message() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("photo.jpg");
+        tokio::fs::write(&file_path, b"fake image bytes").await.unwrap();
+
+        let bus = residuum::bus::spawn_broker();
+        let publisher: Publisher = bus.publisher();
+        let ep = EndpointName::from("ws");
+        let file_registry = FileRegistry::new();
+        let mut subs = WsSubscribers::new(&bus, ep.clone(), file_registry).await.unwrap();
+
+        let att = residuum::interfaces::attachment::FileAttachment {
+            path: file_path.clone(),
+            filename: "photo.jpg".to_string(),
+            mime_type: "image/jpeg".to_string(),
+            size: 16,
+        };
+
+        publisher
+            .publish(
+                topics::Endpoint(ep),
+                ResponseEvent {
+                    correlation_id: "req-1".into(),
+                    content: "Here's your photo".into(),
+                    timestamp: chrono::Utc::now().naive_utc(),
+                    attachment: Some(att),
+                },
+            )
+            .await
+            .unwrap();
+
+        let msg = subs.recv().await.unwrap();
+        match msg {
+            ServerMessage::FileAttachment {
+                reply_to,
+                filename,
+                mime_type,
+                size,
+                url,
+                caption,
+            } => {
+                assert_eq!(reply_to, "req-1");
+                assert_eq!(filename, "photo.jpg");
+                assert_eq!(mime_type, "image/jpeg");
+                assert_eq!(size, 16);
+                assert!(url.starts_with("/api/files/"), "url should be a file API path: {url}");
+                assert_eq!(caption, Some("Here's your photo".to_string()));
+            }
+            other => panic!("expected FileAttachment, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn send_message_text_only_still_works() {
+        let bus = residuum::bus::spawn_broker();
+        let publisher: Publisher = bus.publisher();
+        let mut subscriber = bus
+            .subscribe(topics::Endpoint(EndpointName::from("ws")))
+            .await
+            .unwrap();
+
+        let registry = make_registry();
+        let tool = SendMessageTool::new(registry, publisher);
+
+        let result = tool
+            .execute(serde_json::json!({
+                "endpoint": "ws",
+                "message": "hello from agent"
+            }))
+            .await
+            .unwrap();
+
+        assert!(!result.is_error, "text-only should succeed: {}", result.output);
+
+        let event: ResponseEvent = subscriber.recv().await.unwrap().unwrap();
+        assert_eq!(event.content, "hello from agent");
+        assert!(event.attachment.is_none(), "text-only should have no attachment");
+    }
+}

--- a/tests/gateway_integration.rs
+++ b/tests/gateway_integration.rs
@@ -114,10 +114,13 @@ mod gateway_integration {
         let ep = EndpointName::from("ws");
 
         let file_registry = residuum::gateway::file_server::FileRegistry::new();
-        let mut subs =
-            residuum::interfaces::websocket::subscriber::WsSubscribers::new(&bus, ep.clone(), file_registry)
-                .await
-                .unwrap();
+        let mut subs = residuum::interfaces::websocket::subscriber::WsSubscribers::new(
+            &bus,
+            ep.clone(),
+            file_registry,
+        )
+        .await
+        .unwrap();
         let sub_broadcast = broadcast_tx.clone();
         tokio::spawn(async move {
             while let Some(msg) = subs.recv().await {

--- a/tests/gateway_integration.rs
+++ b/tests/gateway_integration.rs
@@ -113,8 +113,9 @@ mod gateway_integration {
         let publisher = bus.publisher();
         let ep = EndpointName::from("ws");
 
+        let file_registry = residuum::gateway::file_server::FileRegistry::new();
         let mut subs =
-            residuum::interfaces::websocket::subscriber::WsSubscribers::new(&bus, ep.clone())
+            residuum::interfaces::websocket::subscriber::WsSubscribers::new(&bus, ep.clone(), file_registry)
                 .await
                 .unwrap();
         let sub_broadcast = broadcast_tx.clone();

--- a/tests/gateway_integration.rs
+++ b/tests/gateway_integration.rs
@@ -187,6 +187,7 @@ mod gateway_integration {
                                             correlation_id: reply_id.clone(),
                                             content: text.clone(),
                                             timestamp: chrono::NaiveDateTime::default(),
+                                            attachment: None,
                                         },
                                     )
                                     .await,

--- a/web/src/components/ChatFeed.svelte
+++ b/web/src/components/ChatFeed.svelte
@@ -9,6 +9,7 @@
   import MessageDivider from "./MessageDivider.svelte";
   import ToolGroup from "./ToolGroup.svelte";
   import ThinkingIndicator from "./ThinkingIndicator.svelte";
+  import FileAttachment from "./FileAttachment.svelte";
 
   let {
     items,
@@ -56,6 +57,8 @@
         <ToolGroup calls={item.calls} {verbose} />
       {:else if item.kind === "command-output"}
         <MessageNotice content={item.content} />
+      {:else if item.kind === "file-attachment"}
+        <FileAttachment {item} />
       {/if}
     {/each}
     {#if isProcessing}

--- a/web/src/components/FileAttachment.svelte
+++ b/web/src/components/FileAttachment.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import type { FileAttachmentFeedItem } from "../lib/types";
+
+  let { item }: { item: FileAttachmentFeedItem } = $props();
+
+  function formatSize(bytes: number): string {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+
+  const isImage = $derived(item.mimeType.startsWith("image/"));
+  const isAudio = $derived(item.mimeType.startsWith("audio/"));
+</script>
+
+<div class="msg msg-assistant file-attachment">
+  {#if item.caption}
+    <p class="file-attachment-caption">{item.caption}</p>
+  {/if}
+
+  {#if isImage}
+    <img src={item.url} alt={item.filename} class="file-attachment-image" />
+  {:else if isAudio}
+    <audio controls src={item.url} class="file-attachment-audio">
+      <track kind="captions" />
+    </audio>
+  {:else}
+    <a href={item.url} download={item.filename} class="file-attachment-download">
+      {item.filename} ({formatSize(item.size)})
+    </a>
+  {/if}
+</div>

--- a/web/src/lib/feed.svelte.ts
+++ b/web/src/lib/feed.svelte.ts
@@ -9,6 +9,7 @@ import type {
   ToolGroupFeedItem,
   ToolCallState,
   ImageAttachment,
+  FileAttachmentFeedItem,
 } from "./types";
 
 /** Manages the chat feed state and processes incoming server messages. */
@@ -78,6 +79,21 @@ export class FeedStore {
           content: "Gateway is reloading...",
         });
         break;
+
+      case "file_attachment": {
+        const item: FileAttachmentFeedItem = {
+          id: nextFeedId(),
+          kind: "file-attachment",
+          filename: msg.filename,
+          mimeType: msg.mime_type,
+          size: msg.size,
+          url: msg.url,
+          caption: msg.caption,
+        };
+        this.feed.push(item);
+        this.isProcessing = false;
+        break;
+      }
 
       case "pong":
         break;

--- a/web/src/lib/generated/ServerMessage.ts
+++ b/web/src/lib/generated/ServerMessage.ts
@@ -4,7 +4,7 @@ import type { JsonValue } from "./serde_json/JsonValue";
 /**
  * Messages sent from the server to WebSocket clients.
  */
-export type ServerMessage = { "type": "turn_started", 
+export type ServerMessage = { "type": "file_attachment", reply_to: string, filename: string, mime_type: string, size: number, url: string, caption: string | null, } | { "type": "turn_started",
 /**
  * Correlation ID of the message being processed.
  */

--- a/web/src/lib/generated/ServerMessage.ts
+++ b/web/src/lib/generated/ServerMessage.ts
@@ -4,7 +4,7 @@ import type { JsonValue } from "./serde_json/JsonValue";
 /**
  * Messages sent from the server to WebSocket clients.
  */
-export type ServerMessage = { "type": "file_attachment", reply_to: string, filename: string, mime_type: string, size: number, url: string, caption: string | null, } | { "type": "turn_started",
+export type ServerMessage = { "type": "turn_started", 
 /**
  * Correlation ID of the message being processed.
  */
@@ -44,7 +44,31 @@ reply_to: string,
 /**
  * The response content.
  */
-content: string, } | { "type": "broadcast_response", 
+content: string, } | { "type": "file_attachment", 
+/**
+ * Correlation ID of the original message.
+ */
+reply_to: string, 
+/**
+ * Original filename.
+ */
+filename: string, 
+/**
+ * MIME type of the file.
+ */
+mime_type: string, 
+/**
+ * File size in bytes.
+ */
+size: number, 
+/**
+ * URL to fetch the file (e.g. "/api/files/{id}").
+ */
+url: string, 
+/**
+ * Optional caption text.
+ */
+caption: string | null, } | { "type": "broadcast_response", 
 /**
  * The intermediate content.
  */

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -252,6 +252,15 @@ export interface CommandOutputFeedItem extends FeedItemBase {
   content: string;
 }
 
+export interface FileAttachmentFeedItem extends FeedItemBase {
+  kind: "file-attachment";
+  filename: string;
+  mimeType: string;
+  size: number;
+  url: string;
+  caption: string | null;
+}
+
 export type FeedItem =
   | UserFeedItem
   | AssistantFeedItem
@@ -260,4 +269,5 @@ export type FeedItem =
   | NoticeFeedItem
   | DividerFeedItem
   | ToolGroupFeedItem
-  | CommandOutputFeedItem;
+  | CommandOutputFeedItem
+  | FileAttachmentFeedItem;


### PR DESCRIPTION
## Summary

- Extends `send_message` tool with optional `file_path` parameter for delivering file attachments (images, audio, documents) to interactive endpoints
- Adds `FileAttachment` struct, MIME detection, `FileRegistry` with TTL-based serving via `/api/files/{id}`
- **Telegram**: MIME-dispatched delivery (photo/audio/document) with caption handling
- **Discord**: file attachment via serenity `CreateAttachment`
- **Web UI**: inline image, `<audio>` player, or download link based on MIME type
- **macOS app**: `AsyncImage` for images, `AVPlayer` for audio, `NSSavePanel` for downloads
- Security: Content-Disposition header sanitization, UUID file IDs, 1-hour TTL cleanup

## Test plan

- [x] Unit tests: FileAttachment struct, MIME detection, FileRegistry, send_message parameter validation
- [x] Integration test: end-to-end bus flow from tool invocation to WebSocket subscriber
- [x] Security review: Content-Disposition injection, file path handling, OWASP concerns
- [x] User tested: Web UI (images, audio, docs), macOS app (images, audio, docs), Telegram (images)
- [ ] Discord endpoint (not tested — no active Discord connection during development)

🤖 Generated with [Claude Code](https://claude.com/claude-code)