### PR TITLE
fix: ship ca-certificates and git in the container image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,6 +36,13 @@ WORKDIR /app
 
 ENV RESIDUUM_GATEWAY_BIND=0.0.0.0
 
+# ca-certificates: rustls-platform-verifier reads the system trust store, so
+# HTTPS to model providers fails without it. git: the agent shells out and
+# needs a real runtime present in the image (the [tools] PATH only covers
+# single-file static binaries).
+# Kept ahead of the COPY so this layer stays cached across releases.
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates git && rm -rf /var/lib/apt/lists/*
+
 COPY --from=builder /app/target/release/residuum /app/residuum
 
 RUN chmod +x residuum

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -6,6 +6,13 @@ WORKDIR /app
 
 ENV RESIDUUM_GATEWAY_BIND=0.0.0.0
 
+# ca-certificates: rustls-platform-verifier reads the system trust store, so
+# HTTPS to model providers fails without it. git: the agent shells out and
+# needs a real runtime present in the image (the [tools] PATH only covers
+# single-file static binaries).
+# Kept ahead of the COPY so this layer stays cached across releases.
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates git && rm -rf /var/lib/apt/lists/*
+
 COPY residuum-${TARGETARCH} /app/residuum
 
 RUN chmod +x residuum && useradd -m residuum

--- a/docs/systems-usage/tools.md
+++ b/docs/systems-usage/tools.md
@@ -73,7 +73,21 @@ tool `PATH` is applied first and the server's explicit `env` overrides it.
 
 - **Single-file static binaries only.** `gh`, `kubectl`, `flux`, `bao`, `uv`,
   and most Go/Rust CLIs work perfectly this way.
-- **Interpreter/runtime tools are out of scope.** `git`, `node`, and `python`
-  aren't single files and still need their runtime present in the base image
-  (or route around them — e.g. `gh api` instead of `git`, `uv` for
-  Python-based MCP servers).
+- **Interpreter/runtime tools are out of scope.** `node` and `python` aren't
+  single files and still need their runtime present in the base image (or route
+  around them — e.g. `uv`, itself a single static binary, for Python-based MCP
+  servers). `git` is the exception: the published image ships it (see below).
+
+## What the container image already ships
+
+The published image installs two things beyond the binary itself, because
+neither can be supplied through the tool `PATH`:
+
+- **`git`** — the common agent workflow (clone → edit → commit → push) needs a
+  real `git`, not a dropped-in static binary.
+- **`ca-certificates`** — the HTTP client verifies TLS against the *system*
+  trust store, so every HTTPS model provider is unreachable without a CA
+  bundle in the image.
+
+Everything else is expected to arrive via `~/.residuum/bin` or a mounted
+`[tools].path` dir.


### PR DESCRIPTION
Closes #112.

The published runtime image is a bare `debian:trixie-slim` + the binary. It ships **no CA trust store** and **no git**.

## CA certificates — a real bug for every self-hoster

`reqwest` resolves to rustls + `rustls-platform-verifier` (no OpenSSL/native-tls in the graph). On Linux that verifier loads the *system* trust store and, if the store is empty, **hard-fails**:

```rust
if root_store.is_empty() {
    return Err(rustls::Error::General(
        "No CA certificates were loaded from the system".to_owned(),
    ));
}
```

The `webpki_root_certs` fallback sitting right below it is gated `#[cfg(target_arch = "wasm32")]` — WASM only — so despite `webpki-root-certs` being a dependency there is **no bundled-roots path on Linux**. Confirmed empirically against `:latest`: `/etc/ssl/certs` doesn't even exist and `ca-certificates` is not installed.

Net effect: every HTTPS model provider (Anthropic, OpenAI, Gemini, Ollama Cloud) fails TLS. This was easy to miss because the **relay keeps working** — `tokio-tungstenite` uses `rustls-tls-webpki-roots`, which genuinely bundles roots — so an instance connects to Cloud fine and only model calls break.

## git

`git` isn't a single-file static binary, so the `[tools]` PATH mechanism from #111 can't supply it. Since residuum's model is an agent that shells out (`exec` + MCP stdio), shipping git makes the common clone → edit → commit → push → PR workflow work out of the box. `docs/systems-usage/tools.md` already described interpreter runtimes as a base-image concern; this makes that true rather than aspirational.

## Changes

- `docker/Dockerfile.release` and the runtime stage of `docker/Dockerfile`: install `ca-certificates` + `git`. Placed **ahead of the binary `COPY`** so the apt layer stays cached across releases instead of rebuilding on every version bump.
- `docs/systems-usage/tools.md`: document what the image ships, and correct the now-stale advice to route around git via `gh api` (node/python remain out of scope; `uv` is still the suggested route for Python MCP servers).

## Verification

Built `Dockerfile.release` with `--build-arg TARGETARCH=amd64`:

- `/etc/ssl/certs/ca-certificates.crt` present — 301 certs
- `git version 2.47.3`
- default user still unprivileged: `uid=1000(residuum)`

Builder stage untouched; no version bumps; no CI changes.
