### PR TITLE
fix(web): chat history blank after refresh (closes #115)

### DIFF
--- a/web/src/lib/feed.svelte.ts
+++ b/web/src/lib/feed.svelte.ts
@@ -15,6 +15,34 @@ import type {
   EpisodeHistorySegment,
 } from "./types";
 
+/**
+ * Coerce tool-call arguments to an object, whatever shape they arrived in.
+ *
+ * Tool arguments reach the UI two ways and they do NOT agree: the history
+ * endpoint serializes a Rust `serde_json::Value` (an **object**), while the
+ * live socket has carried a JSON **string**. Every reader must go through
+ * here — a bare `JSON.parse()` throws `SyntaxError` on the object form
+ * (`JSON.parse` stringifies its argument first, yielding "[object Object]"),
+ * and because feed building is a single pass, one throw blanks the entire
+ * conversation rather than one message.
+ *
+ * Malformed input degrades to `{}` so a single bad record can't take the
+ * feed down with it.
+ */
+export function normalizeToolArgs(value: unknown): Record<string, unknown> {
+  if (typeof value === "string") {
+    try {
+      const parsed: unknown = JSON.parse(value);
+      return typeof parsed === "object" && parsed !== null
+        ? (parsed as Record<string, unknown>)
+        : {};
+    } catch {
+      return {};
+    }
+  }
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
+}
+
 const DAY_DIVIDER_FORMATTER = new Intl.DateTimeFormat(undefined, {
   month: "long",
   day: "numeric",
@@ -219,7 +247,7 @@ export class FeedStore {
           }
           if (msg.tool_calls?.length) {
             const calls: ToolCallState[] = msg.tool_calls.map((tc) => {
-              const args = JSON.parse(tc.arguments) as Record<string, unknown>;
+              const args = normalizeToolArgs(tc.arguments);
               const call: ToolCallState = {
                 id: tc.id,
                 name: tc.name,
@@ -268,10 +296,7 @@ export class FeedStore {
   }
 
   private handleToolCall(msg: Extract<ServerMessage, { type: "tool_call" }>): void {
-    const args =
-      typeof msg.arguments === "string"
-        ? (JSON.parse(msg.arguments) as Record<string, unknown>)
-        : ((msg.arguments as Record<string, unknown>) ?? {});
+    const args = normalizeToolArgs(msg.arguments);
 
     const call: ToolCallState = {
       id: msg.id,

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -11,7 +11,18 @@ type ImageAttachment = _ImageAttachment;
 export interface ToolCallRecord {
   id: string;
   name: string;
-  arguments: string;
+  /**
+   * Deliberately `unknown`: the wire shape depends on the source. History
+   * (`/api/chat/history`) serializes this from a Rust `serde_json::Value`, so
+   * it arrives as an **object**; other paths have carried it as a JSON
+   * **string**. Typing it as `string` previously invited a bare
+   * `JSON.parse(...)`, which throws `SyntaxError` on an object and took out
+   * the whole feed render.
+   *
+   * Keep this `unknown` so the compiler forces every reader through
+   * `normalizeToolArgs()` instead of assuming a shape.
+   */
+  arguments: unknown;
 }
 
 export interface RecentMessage {


### PR DESCRIPTION
## Symptom

Chat history is not displayed after a browser refresh. Live chat works normally; reload and the conversation is blank. The server is fine — `GET /api/chat/history` returns `200` with the full payload (verified: 11.5 KB, `{"kind":"recent","messages":[…]}`). Nothing is logged: zero `WARN`/`ERROR` lines. The failure is entirely client-side.

## Root cause

`web/src/lib/feed.svelte.ts` parsed tool-call arguments **unconditionally** on the history path:

```ts
const args = JSON.parse(tc.arguments) as Record<string, unknown>;
```

But history serializes `tool_calls[].arguments` from a Rust `serde_json::Value` (`src/models/mod.rs` — `pub arguments: serde_json::Value`), so it arrives as an **object**:

```json
"tool_calls": [{ "id": "call_0", "name": "skill_activate",
                 "arguments": { "name": "residuum-getting-started" } }]
```

`JSON.parse` stringifies its argument first, so an object becomes `"[object Object]"` and it throws `SyntaxError`. Feed building is a **single pass over all messages**, so one throw discards the *entire* conversation — hence "blank", not "one broken message".

Live chat was unaffected because `handleToolCall` already normalized both shapes:

```ts
typeof msg.arguments === "string" ? JSON.parse(msg.arguments) : (msg.arguments ?? {})
```

That asymmetry is the whole bug: **two readers of the same field, only one defensive.**

## This is a recurrence, which shapes the fix

The same string-vs-object ambiguity was handled once before — `6bca7fa` had:

```ts
const argsText = typeof msg.arguments === "string" ? msg.arguments : JSON.stringify(msg.arguments, null, 2);
```

Then `5d4aafb` ("per-tool formatted display for tool call arguments") changed `arguments` from a display string to a parsed object. It preserved the defensiveness on the live path but introduced a bare `JSON.parse` on the history path, and the later lazy-load history work (`0e0286d`) carried it forward.

So this is not a one-off typo — it's a class that reappears whenever a new reader of `arguments` is written. `ToolCallRecord.arguments` was typed `string`, which actively invited it: the type asserted a shape the server never sends, so the compiler endorsed the bug.

## Fix

Rather than re-patch the instance:

1. **One normalizer.** `normalizeToolArgs(value: unknown): Record<string, unknown>` in `feed.svelte.ts`, handling object, JSON-string, and malformed input (degrading to `{}` so one bad record can't blank the feed). Both readers now call it.
2. **A type that makes the bug uncompilable.** `ToolCallRecord.arguments: string` → `unknown`. A bare `JSON.parse(tc.arguments)` is now a compile error:
   ```
   ERROR src/lib/feed.svelte.ts 250:39 "Argument of type 'unknown' is not assignable to parameter of type 'string'."
   ```
   Verified by reintroducing the old line and re-running `npm run check`. Since `check` runs in release CI, a future reader cannot reintroduce this silently — which a unit test alone would not guarantee (and the web package currently has no test framework, so the type system is the available guard).

## Verification

- `svelte-check`: 305 files, 0 errors, 0 warnings.
- `eslint` + css lint: clean.
- `vite build`: succeeds.
- Guard confirmed to reject the old code (above).

Found while deploying Residuum as a platform assistant against Ollama Cloud (`glm-5.2:cloud`).
