### PR TITLE
Garden: continuous unattended tending

### DIFF
--- a/src/config/resolve/mod.rs
+++ b/src/config/resolve/mod.rs
@@ -635,7 +635,16 @@ fn resolve_search_config(section: Option<&SearchConfigFile>) -> SearchConfig {
             cfg.min_score = v;
         }
         if let Some(v) = s.candidate_multiplier {
-            cfg.candidate_multiplier = v;
+            if v == 0 {
+                tracing::warn!(
+                    section = "memory.search",
+                    value = v,
+                    default = cfg.candidate_multiplier,
+                    "candidate_multiplier must be positive; using default"
+                );
+            } else {
+                cfg.candidate_multiplier = v;
+            }
         }
         if let Some(v) = s.temporal_decay {
             cfg.temporal_decay = v;

--- a/src/memory/search.rs
+++ b/src/memory/search.rs
@@ -16,7 +16,7 @@ use anyhow::Context;
 
 use crate::config::SearchConfig;
 use crate::memory::chunk_extractor::read_idx_jsonl;
-use crate::memory::types::{IndexChunk, IndexManifest, ManifestFileEntry, Observation};
+use crate::memory::types::{DocSource, IndexChunk, IndexManifest, ManifestFileEntry, Observation};
 use crate::memory::vector_store::{VectorSearchFilters, VectorStore};
 use crate::models::EmbeddingProvider;
 
@@ -28,8 +28,8 @@ const WRITER_MEMORY_BUDGET_BYTES: usize = 50_000_000;
 pub struct SearchResult {
     /// Document identifier (obs or chunk ID).
     pub id: String,
-    /// Source type stored in the index: `"observation"` or `"chunk"` (internal values).
-    pub source_type: String,
+    /// Which kind of document this result came from.
+    pub source_type: DocSource,
     /// Parent episode identifier.
     pub episode_id: String,
     /// Date string (YYYY-MM-DD).
@@ -49,9 +49,9 @@ pub struct SearchResult {
 /// Filters for narrowing search results.
 #[derive(Debug, Clone, Default)]
 pub struct SearchFilters {
-    /// Filter by internal source type value: `"observation"` or `"chunk"`.
+    /// Filter to a single document source. `None` searches both.
     /// The tool layer translates user-facing names before setting this.
-    pub source: Option<String>,
+    pub source: Option<DocSource>,
     /// Filter results on or after this date (YYYY-MM-DD, inclusive).
     pub date_from: Option<String>,
     /// Filter results on or before this date (YYYY-MM-DD, inclusive).
@@ -291,8 +291,8 @@ impl MemoryIndex {
         let (text_query, _errors) = query_parser.parse_query_lenient(query_str);
 
         // Apply source_type filter as a BooleanQuery for early reduction
-        let query: Box<dyn tantivy::query::Query> = if let Some(ref source) = filters.source {
-            let source_term = Term::from_field_text(self.source_type_field, source);
+        let query: Box<dyn tantivy::query::Query> = if let Some(source) = filters.source {
+            let source_term = Term::from_field_text(self.source_type_field, source.as_str());
             let source_query = tantivy::query::TermQuery::new(
                 source_term,
                 tantivy::schema::IndexRecordOption::Basic,
@@ -357,8 +357,16 @@ impl MemoryIndex {
             }
 
             let snippet = get_snippet(&doc, self.content_field);
-            let source_type = get_text(&doc, self.source_type_field);
             let id = get_text(&doc, self.id_field);
+            let source_type_raw = get_text(&doc, self.source_type_field);
+            let Some(source_type) = DocSource::from_index_value(&source_type_raw) else {
+                tracing::error!(
+                    source_type = %source_type_raw,
+                    id = %id,
+                    "memory index document has unrecognized source_type, skipping"
+                );
+                continue;
+            };
             let line_start = parse_line_num(&doc, self.line_start_field);
             let line_end = parse_line_num(&doc, self.line_end_field);
 
@@ -573,7 +581,7 @@ impl MemoryIndex {
     ) -> anyhow::Result<()> {
         let mut doc = TantivyDocument::default();
         doc.add_text(self.id_field, doc_id);
-        doc.add_text(self.source_type_field, "observation");
+        doc.add_text(self.source_type_field, DocSource::Observation.as_str());
         doc.add_text(self.episode_id_field, episode_id);
         doc.add_text(self.date_field, date);
         doc.add_text(self.ctx_field, ctx);
@@ -594,7 +602,7 @@ impl MemoryIndex {
     ) -> anyhow::Result<()> {
         let mut doc = TantivyDocument::default();
         doc.add_text(self.id_field, &chunk.chunk_id);
-        doc.add_text(self.source_type_field, "chunk");
+        doc.add_text(self.source_type_field, DocSource::Chunk.as_str());
         doc.add_text(self.episode_id_field, &chunk.episode_id);
         doc.add_text(self.date_field, &chunk.date);
         doc.add_text(self.ctx_field, &chunk.context);
@@ -962,7 +970,7 @@ fn merge_hybrid_results(
             let snippet = crate::memory::truncate_at_char_boundary(&vec_r.content, 200);
             SearchResult {
                 id: vec_r.id.clone(),
-                source_type: vec_r.source_type.clone(),
+                source_type: vec_r.source_type,
                 episode_id: vec_r.episode_id.clone(),
                 date: vec_r.date.clone(),
                 context: vec_r.context.clone(),
@@ -1077,7 +1085,7 @@ mod tests {
 
         let results = index.search("tantivy BM25", 5, &no_filters()).unwrap();
         assert!(!results.is_empty(), "should find matching observation");
-        assert_eq!(results[0].source_type, "observation");
+        assert_eq!(results[0].source_type, DocSource::Observation);
         assert_eq!(results[0].episode_id, "ep-001");
     }
 
@@ -1102,7 +1110,7 @@ mod tests {
 
         let results = index.search("observer token", 5, &no_filters()).unwrap();
         assert!(!results.is_empty(), "should find matching chunk");
-        assert_eq!(results[0].source_type, "chunk");
+        assert_eq!(results[0].source_type, DocSource::Chunk);
         assert_eq!(results[0].line_start, Some(2));
         assert_eq!(results[0].line_end, Some(3));
     }
@@ -1138,12 +1146,16 @@ mod tests {
                 "rust memory",
                 10,
                 &SearchFilters {
-                    source: Some("observation".to_string()),
+                    source: Some(DocSource::Observation),
                     ..Default::default()
                 },
             )
             .unwrap();
-        assert!(obs_only.iter().all(|r| r.source_type == "observation"));
+        assert!(
+            obs_only
+                .iter()
+                .all(|r| r.source_type == DocSource::Observation)
+        );
 
         // Chunks only
         let chunk_only = index
@@ -1151,12 +1163,12 @@ mod tests {
                 "rust memory",
                 10,
                 &SearchFilters {
-                    source: Some("chunk".to_string()),
+                    source: Some(DocSource::Chunk),
                     ..Default::default()
                 },
             )
             .unwrap();
-        assert!(chunk_only.iter().all(|r| r.source_type == "chunk"));
+        assert!(chunk_only.iter().all(|r| r.source_type == DocSource::Chunk));
     }
 
     #[test]
@@ -1526,7 +1538,7 @@ mod tests {
                 "line ranges",
                 10,
                 &SearchFilters {
-                    source: Some("observation".to_string()),
+                    source: Some(DocSource::Observation),
                     ..Default::default()
                 },
             )
@@ -1543,7 +1555,7 @@ mod tests {
                 "line ranges",
                 10,
                 &SearchFilters {
-                    source: Some("chunk".to_string()),
+                    source: Some(DocSource::Chunk),
                     ..Default::default()
                 },
             )
@@ -1677,7 +1689,7 @@ mod tests {
     fn make_bm25_result(id: &str, score: f32) -> SearchResult {
         SearchResult {
             id: id.to_string(),
-            source_type: "observation".to_string(),
+            source_type: DocSource::Observation,
             episode_id: "ep-001".to_string(),
             date: "2026-02-19".to_string(),
             context: "residuum".to_string(),
@@ -1691,7 +1703,7 @@ mod tests {
     fn make_vec_result(id: &str, distance: f64) -> crate::memory::vector_store::VectorSearchResult {
         crate::memory::vector_store::VectorSearchResult {
             id: id.to_string(),
-            source_type: "observation".to_string(),
+            source_type: DocSource::Observation,
             episode_id: "ep-001".to_string(),
             date: "2026-02-19".to_string(),
             context: "residuum".to_string(),
@@ -1803,7 +1815,7 @@ mod tests {
             .block_on(searcher.search("rust ownership", 5, &no_filters()))
             .unwrap();
         assert!(!results.is_empty(), "BM25 fallback should find results");
-        assert_eq!(results[0].source_type, "observation");
+        assert_eq!(results[0].source_type, DocSource::Observation);
     }
 
     // ── Temporal decay tests ─────────────────────────────────────────────
@@ -1811,7 +1823,7 @@ mod tests {
     fn make_result(id: &str, date: &str, score: f32) -> SearchResult {
         SearchResult {
             id: id.to_string(),
-            source_type: "observation".to_string(),
+            source_type: DocSource::Observation,
             episode_id: "ep-001".to_string(),
             date: date.to_string(),
             context: "test".to_string(),

--- a/src/memory/types.rs
+++ b/src/memory/types.rs
@@ -39,6 +39,52 @@ pub enum Visibility {
     Background,
 }
 
+/// Which kind of document a memory search result came from.
+///
+/// The memory index holds two kinds of documents: distilled [`Observation`]s
+/// and raw interaction-pair [`IndexChunk`]s. `DocSource` is the single internal
+/// vocabulary for that distinction — it is the value stored in the index's
+/// `source_type` field, the value filtered on, and the value shown in results.
+/// The `memory_search` tool maps its user-facing names (`"observations"`/
+/// `"episodes"`) onto these variants at its boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DocSource {
+    /// A distilled observation document.
+    Observation,
+    /// A raw interaction-pair chunk document.
+    Chunk,
+}
+
+impl DocSource {
+    /// The stable string stored in the index and shown in search results.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Observation => "observation",
+            Self::Chunk => "chunk",
+        }
+    }
+
+    /// Parse the value stored in the index's `source_type` field.
+    ///
+    /// Returns `None` for any value the index should never contain — a signal
+    /// of index corruption rather than a normal input.
+    #[must_use]
+    pub fn from_index_value(value: &str) -> Option<Self> {
+        match value {
+            "observation" => Some(Self::Observation),
+            "chunk" => Some(Self::Chunk),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for DocSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// A single extracted observation with full metadata.
 ///
 /// Each observation is self-describing: it carries when it was created,
@@ -260,6 +306,36 @@ mod tests {
             !json.contains("source_episodes"),
             "empty source_episodes should be skipped in serialization"
         );
+    }
+
+    #[test]
+    fn doc_source_as_str_round_trips_through_index_value() {
+        for source in [DocSource::Observation, DocSource::Chunk] {
+            assert_eq!(
+                DocSource::from_index_value(source.as_str()),
+                Some(source),
+                "as_str should round-trip through from_index_value"
+            );
+        }
+    }
+
+    #[test]
+    fn doc_source_index_values_are_stable() {
+        assert_eq!(DocSource::Observation.as_str(), "observation");
+        assert_eq!(DocSource::Chunk.as_str(), "chunk");
+    }
+
+    #[test]
+    fn doc_source_display_matches_index_value() {
+        assert_eq!(DocSource::Observation.to_string(), "observation");
+        assert_eq!(DocSource::Chunk.to_string(), "chunk");
+    }
+
+    #[test]
+    fn doc_source_rejects_unknown_index_value() {
+        assert_eq!(DocSource::from_index_value("episodes"), None);
+        assert_eq!(DocSource::from_index_value(""), None);
+        assert_eq!(DocSource::from_index_value("Observation"), None);
     }
 
     #[test]

--- a/src/memory/vector_store.rs
+++ b/src/memory/vector_store.rs
@@ -11,15 +11,15 @@ use zerocopy::IntoBytes;
 
 use anyhow::Context;
 
-use crate::memory::types::{IndexChunk, Observation};
+use crate::memory::types::{DocSource, IndexChunk, Observation};
 
 /// A vector search result from either the observation or chunk table.
 #[derive(Debug, Clone)]
 pub struct VectorSearchResult {
     /// Document identifier (obs or chunk ID).
     pub id: String,
-    /// Source type: `"observation"` or `"chunk"`.
-    pub source_type: String,
+    /// Which kind of document this result came from.
+    pub source_type: DocSource,
     /// Parent episode identifier.
     pub episode_id: String,
     /// Date string (YYYY-MM-DD).
@@ -465,7 +465,7 @@ fn search_obs_table(
         .query_map(param_refs.as_slice(), |row| {
             Ok(VectorSearchResult {
                 id: row.get(0)?,
-                source_type: "observation".to_string(),
+                source_type: DocSource::Observation,
                 episode_id: row.get(1)?,
                 date: row.get(2)?,
                 context: row.get(3)?,
@@ -522,7 +522,7 @@ fn search_chunk_table(
             let line_end: Option<i64> = row.get(6)?;
             Ok(VectorSearchResult {
                 id: row.get(0)?,
-                source_type: "chunk".to_string(),
+                source_type: DocSource::Chunk,
                 episode_id: row.get(1)?,
                 date: row.get(2)?,
                 context: row.get(3)?,
@@ -631,7 +631,7 @@ mod tests {
             .search(&query, 5, &VectorSearchFilters::default())
             .unwrap();
         assert!(!results.is_empty(), "should find results");
-        assert_eq!(results[0].source_type, "observation");
+        assert_eq!(results[0].source_type, DocSource::Observation);
         assert_eq!(results[0].episode_id, "ep-001");
     }
 
@@ -659,7 +659,7 @@ mod tests {
             .search(&query, 5, &VectorSearchFilters::default())
             .unwrap();
         assert!(!results.is_empty(), "should find chunk");
-        assert_eq!(results[0].source_type, "chunk");
+        assert_eq!(results[0].source_type, DocSource::Chunk);
         assert_eq!(results[0].line_start, Some(2));
         assert_eq!(results[0].line_end, Some(3));
     }

--- a/src/tools/CLAUDE.md
+++ b/src/tools/CLAUDE.md
@@ -15,3 +15,17 @@
 **Update `TOOLS.md` in the same commit** as the Rust change. Never let them drift.
 
 The file lives at `src/tools/TOOLS.md`.
+
+## Mechanical checklist: adding a new tool
+
+- Declare the module in `src/tools/mod.rs` (`mod foo;` or `pub mod foo;`).
+- Add a `register_*` method for it in `src/tools/registry.rs`, then wire that
+  call into whichever registry-building surface(s) should carry it. There are
+  **two separate registration surfaces** and a new tool is not on both by default:
+  - the main agent's registry, built in `src/gateway/startup/tools.rs`
+  - the sub-agent registry, built by `ToolRegistry::build_subagent_registry`
+    in `src/tools/registry.rs`
+  Decide on purpose whether the new tool belongs in one or both — do not assume
+  parity between them. (Past gap: `ollama_web_search` is registered for the main
+  agent in `gateway/startup/tools.rs` but has no corresponding call in
+  `build_subagent_registry`, with no record of whether that's intentional.)

--- a/src/tools/TOOLS.md
+++ b/src/tools/TOOLS.md
@@ -528,6 +528,30 @@ On total failure: error with failure details.
 
 ---
 
+## `user_inbox_add`
+
+**Source:** `inbox.rs` · `UserInboxAddTool`
+
+**Description sent to LLM:**
+> Add a new item to the user's inbox. Use this to explicitly send notes, reminders, or items for the human user to review later.
+
+### Input
+
+| Parameter | Type   | Required | Description                          |
+|-----------|--------|----------|---------------------------------------|
+| `title`   | string | yes      | A short summary of the item          |
+| `body`    | string | yes      | The detailed content of the item     |
+
+### Output
+
+On success: `"Added item to user inbox with ID: {id}"`
+
+On error: failure to write the item message.
+
+**Side effect:** Writes a new `.json` item to the user's inbox directory via `inbox::quick_add`, tagged with source `"agent"`.
+
+---
+
 ## `send_message`
 
 **Source:** `send_message.rs` · `SendMessageTool`
@@ -796,6 +820,8 @@ On execution error:
 - Response parse failure: `"failed to parse ollama web search response: {details}"`
 
 **No side effects.** Read-only tool with a 30-second timeout.
+
+**Not available to sub-agents:** `build_subagent_registry()` never calls `register_ollama_web_search_tool`.
 
 ---
 

--- a/src/tools/memory_search.rs
+++ b/src/tools/memory_search.rs
@@ -101,15 +101,18 @@ impl Tool for MemorySearchTool {
         };
 
         // Map the tool-facing source names onto the internal DocSource vocabulary.
-        // Omitted → None (search both).
-        let source_filter = arguments
-            .get("source")
-            .and_then(Value::as_str)
-            .and_then(|s| match s {
-                "observations" => Some(DocSource::Observation),
-                "episodes" => Some(DocSource::Chunk),
-                _ => None,
-            });
+        // Omitted → None (search both); an unrecognized value is rejected rather
+        // than silently falling back to searching both.
+        let source_filter = match arguments.get("source").and_then(Value::as_str) {
+            Some("observations") => Some(DocSource::Observation),
+            Some("episodes") => Some(DocSource::Chunk),
+            None => None,
+            Some(other) => {
+                return Err(ToolError::InvalidArguments(format!(
+                    "unknown source '{other}': expected 'observations' or 'episodes'"
+                )));
+            }
+        };
 
         let filters = SearchFilters {
             source: source_filter,
@@ -281,6 +284,28 @@ mod tests {
         assert!(
             result.output.contains("[observation]"),
             "should return observations"
+        );
+    }
+
+    #[tokio::test]
+    async fn search_tool_rejects_unknown_source() {
+        let (_dir, tool) = create_test_tool();
+        // An unrecognized source value is a caller mistake — reject it clearly
+        // instead of silently searching both sources.
+        let result = tool
+            .execute(serde_json::json!({
+                "query": "rust memory",
+                "source": "observation"
+            }))
+            .await;
+
+        assert!(
+            matches!(
+                &result,
+                Err(ToolError::InvalidArguments(msg))
+                    if msg.contains("observation") && msg.contains("expected")
+            ),
+            "unknown source should be rejected with a clear InvalidArguments error naming the bad value, got {result:?}"
         );
     }
 

--- a/src/tools/memory_search.rs
+++ b/src/tools/memory_search.rs
@@ -7,6 +7,7 @@ use serde_json::Value;
 
 use super::{Tool, ToolError, ToolResult};
 use crate::memory::search::{HybridSearcher, SearchFilters};
+use crate::memory::types::DocSource;
 use crate::models::ToolDefinition;
 
 /// Tool that searches the memory index using hybrid BM25 + vector search.
@@ -99,14 +100,14 @@ impl Tool for MemorySearchTool {
             None => 5,
         };
 
-        // Map tool-facing values to internal index values:
-        // "observations" → "observation", "episodes" → "chunk", "both"/omitted → None
+        // Map the tool-facing source names onto the internal DocSource vocabulary.
+        // Omitted → None (search both).
         let source_filter = arguments
             .get("source")
             .and_then(Value::as_str)
             .and_then(|s| match s {
-                "observations" => Some("observation".to_string()),
-                "episodes" => Some("chunk".to_string()),
+                "observations" => Some(DocSource::Observation),
+                "episodes" => Some(DocSource::Chunk),
                 _ => None,
             });
 

--- a/tests/memory_integration.rs
+++ b/tests/memory_integration.rs
@@ -25,7 +25,7 @@ mod memory_integration {
     };
     use residuum::memory::reflector::{Reflector, ReflectorConfig};
     use residuum::memory::search::{MemoryIndex, SearchFilters};
-    use residuum::memory::types::{IndexManifest, Visibility};
+    use residuum::memory::types::{DocSource, IndexManifest, Visibility};
     use residuum::models::{
         CompletionOptions, Message, ModelError, ModelProvider, ModelResponse, ToolDefinition,
     };
@@ -290,7 +290,7 @@ mod memory_integration {
                 "workspace layout",
                 5,
                 &SearchFilters {
-                    source: Some("observation".to_string()),
+                    source: Some(DocSource::Observation),
                     ..Default::default()
                 },
             )
@@ -300,7 +300,9 @@ mod memory_integration {
             "should find observation results for workspace layout"
         );
         assert!(
-            obs_results.iter().all(|r| r.source_type == "observation"),
+            obs_results
+                .iter()
+                .all(|r| r.source_type == DocSource::Observation),
             "all should be observations"
         );
 
@@ -310,7 +312,7 @@ mod memory_integration {
                 "workspace layout",
                 5,
                 &SearchFilters {
-                    source: Some("chunk".to_string()),
+                    source: Some(DocSource::Chunk),
                     ..Default::default()
                 },
             )
@@ -320,7 +322,9 @@ mod memory_integration {
             "should find chunk results for workspace layout"
         );
         assert!(
-            chunk_results.iter().all(|r| r.source_type == "chunk"),
+            chunk_results
+                .iter()
+                .all(|r| r.source_type == DocSource::Chunk),
             "all should be chunks"
         );
 
@@ -453,7 +457,7 @@ mod memory_integration {
         );
         assert_eq!(
             results.first().unwrap().source_type,
-            "observation",
+            DocSource::Observation,
             "should be an observation"
         );
     }
@@ -786,13 +790,15 @@ mod memory_integration {
                 "search",
                 10,
                 &SearchFilters {
-                    source: Some("observation".to_string()),
+                    source: Some(DocSource::Observation),
                     ..Default::default()
                 },
             )
             .unwrap();
         assert!(
-            obs_only.iter().all(|r| r.source_type == "observation"),
+            obs_only
+                .iter()
+                .all(|r| r.source_type == DocSource::Observation),
             "should only return observations"
         );
 

--- a/web/src/Setup.svelte
+++ b/web/src/Setup.svelte
@@ -17,41 +17,122 @@
 
   const TOTAL_STEPS = 6;
   const stepIndices = Array.from({ length: TOTAL_STEPS }, (_, i) => i);
-  let step = $state(0);
+
+  // ── Draft persistence ────────────────────────────────────────────────
+  // Setup is the highest-stakes form in the app (hand-typed API keys across
+  // up to 6 steps) with no undo — a refresh or crashed tab must not throw
+  // away everything the user just entered. We keep a draft in localStorage
+  // and restore it on mount, but never persist raw provider API keys or
+  // integration tokens (matching the convention in Review.svelte, which
+  // only ever sends those to the backend via storeSecret(), never stores
+  // them client-side as plain text).
+  const STORAGE_KEY = "residuum-setup-draft";
+
+  interface PersistedWizard {
+    step: number;
+    wizardState: SetupWizardState;
+  }
+
+  function defaultWizardState(): SetupWizardState {
+    return {
+      userName: "",
+      timezone: "",
+      selectedProviders: ["anthropic"] as ProviderKey[],
+      providerConfigs: {
+        anthropic: { apiKey: "", model: "", url: "" },
+        openai: { apiKey: "", model: "", url: "" },
+        gemini: { apiKey: "", model: "", url: "" },
+        ollama: { apiKey: "", model: "", url: "" },
+      },
+      mainProvider: "anthropic",
+      roles: {
+        observer: { provider: "", url: "", model: "" },
+        reflector: { provider: "", url: "", model: "" },
+        pulse: { provider: "", url: "", model: "" },
+      },
+      embeddingModel: { provider: "", model: "" },
+      backgroundModels: {
+        small: { provider: "", model: "" },
+        medium: { provider: "", model: "" },
+        large: { provider: "", model: "" },
+      },
+      mcpServers: [],
+      integrations: { discordToken: "", telegramToken: "" },
+      secretRefs: {},
+    };
+  }
+
+  function loadPersisted(): PersistedWizard | null {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw) as Partial<PersistedWizard>;
+      if (typeof parsed.step !== "number" || typeof parsed.wizardState !== "object") {
+        return null;
+      }
+      return { step: parsed.step, wizardState: parsed.wizardState as SetupWizardState };
+    } catch (err: unknown) {
+      console.warn("discarding unreadable setup draft", err);
+      localStorage.removeItem(STORAGE_KEY);
+      return null;
+    }
+  }
+
+  // Strip fields that should never be written to localStorage in the
+  // clear, even transiently. These are exactly the fields Review.svelte
+  // exchanges for a secret reference before setup completes.
+  function sanitizeForStorage(state: SetupWizardState): SetupWizardState {
+    const clone = structuredClone(state);
+    for (const key of Object.keys(clone.providerConfigs) as ProviderKey[]) {
+      clone.providerConfigs[key] = { ...clone.providerConfigs[key], apiKey: "" };
+    }
+    clone.integrations = { discordToken: "", telegramToken: "" };
+    return clone;
+  }
+
+  const persisted = loadPersisted();
+
+  let step = $state(Math.min(Math.max(persisted?.step ?? 0, 0), TOTAL_STEPS - 1));
   let catalog = $state<McpCatalogEntry[]>([]);
 
-  let wizardState = $state<SetupWizardState>({
-    userName: "",
-    timezone: "",
-    selectedProviders: ["anthropic"] as ProviderKey[],
-    providerConfigs: {
-      anthropic: { apiKey: "", model: "", url: "" },
-      openai: { apiKey: "", model: "", url: "" },
-      gemini: { apiKey: "", model: "", url: "" },
-      ollama: { apiKey: "", model: "", url: "" },
-    },
-    mainProvider: "anthropic",
-    roles: {
-      observer: { provider: "", url: "", model: "" },
-      reflector: { provider: "", url: "", model: "" },
-      pulse: { provider: "", url: "", model: "" },
-    },
-    embeddingModel: { provider: "", model: "" },
-    backgroundModels: {
-      small: { provider: "", model: "" },
-      medium: { provider: "", model: "" },
-      large: { provider: "", model: "" },
-    },
-    mcpServers: [],
-    integrations: { discordToken: "", telegramToken: "" },
-    secretRefs: {},
-  });
+  let wizardState = $state<SetupWizardState>(persisted?.wizardState ?? defaultWizardState());
 
   onMount(async () => {
     const [tz, cat] = await Promise.all([fetchTimezone(), fetchMcpCatalog()]);
-    wizardState.timezone = tz;
+    // Don't clobber a timezone the user already resolved in a prior session.
+    if (!wizardState.timezone) wizardState.timezone = tz;
     catalog = cat;
   });
+
+  let persistTimer: ReturnType<typeof setTimeout> | undefined;
+
+  function schedulePersist() {
+    if (persistTimer) clearTimeout(persistTimer);
+    persistTimer = setTimeout(() => {
+      try {
+        const sanitized = sanitizeForStorage($state.snapshot(wizardState));
+        localStorage.setItem(STORAGE_KEY, JSON.stringify({ step, wizardState: sanitized }));
+      } catch (err: unknown) {
+        console.warn("failed to persist setup draft", err);
+      }
+    }, 500);
+  }
+
+  $effect(() => {
+    $state.snapshot(wizardState);
+    step;
+    schedulePersist();
+  });
+
+  function clearPersisted() {
+    if (persistTimer) clearTimeout(persistTimer);
+    localStorage.removeItem(STORAGE_KEY);
+  }
+
+  function handleComplete() {
+    clearPersisted();
+    onComplete();
+  }
 
   function next() {
     if (step < TOTAL_STEPS - 1) step++;
@@ -82,7 +163,7 @@
       {:else if step === 4}
         <Integrations {wizardState} onNext={next} onBack={back} />
       {:else if step === 5}
-        <Review {wizardState} onBack={back} {onComplete} />
+        <Review {wizardState} onBack={back} onComplete={handleComplete} />
       {/if}
     </div>
   </div>

--- a/web/src/components/ChatFeed.svelte
+++ b/web/src/components/ChatFeed.svelte
@@ -240,6 +240,15 @@
     >
       <span class="feed-loading-older">loading earlier messages…</span>
     </div>
+    {#if items.length === 0}
+      <div class="feed-empty">
+        <p class="feed-empty-text">No messages yet.</p>
+        <p class="feed-empty-hint">
+          Type <span class="feed-empty-key">/help</span> to see available commands, or press
+          <span class="feed-empty-key">?</span> anytime for the shortcuts overlay.
+        </p>
+      </div>
+    {/if}
     {#each items as item (item.id)}
       {#if item.kind === "user"}
         <MessageUser content={item.content} images={item.images} />

--- a/web/src/components/ChatInput.svelte
+++ b/web/src/components/ChatInput.svelte
@@ -269,7 +269,7 @@
           bind:this={textarea}
           bind:value
           class="chat-input"
-          placeholder="Send a message..."
+          placeholder={disabled ? "Reconnecting…" : "Send a message..."}
           rows="1"
           {disabled}
           onkeydown={handleKeydown}

--- a/web/src/components/Workspace.svelte
+++ b/web/src/components/Workspace.svelte
@@ -6,6 +6,7 @@
   import { toast } from "../lib/toast.svelte";
   import { Icon } from "../lib/icons";
   import FileTree from "./FileTree.svelte";
+  import Modal from "./Modal.svelte";
 
   let { onClose }: { onClose: () => void } = $props();
 
@@ -19,6 +20,8 @@
   let expandedDirs = new SvelteSet<string>();
   let treeCache = $state<Record<string, WorkspaceEntry[]>>({});
   let mobileEditorOpen = $state(false);
+  let switchConfirmOpen = $state(false);
+  let pendingFilePath = $state("");
 
   // Derived
   let dirty = $derived(editContent !== fileContent);
@@ -71,6 +74,27 @@
   }
 
   async function handleSelectFile(path: string) {
+    if (dirty) {
+      pendingFilePath = path;
+      switchConfirmOpen = true;
+      return;
+    }
+    await loadFile(path);
+  }
+
+  function cancelSwitchFile() {
+    switchConfirmOpen = false;
+    pendingFilePath = "";
+  }
+
+  async function confirmSwitchFile() {
+    switchConfirmOpen = false;
+    const path = pendingFilePath;
+    pendingFilePath = "";
+    await loadFile(path);
+  }
+
+  async function loadFile(path: string) {
     selectedFile = path;
     loading = true;
     error = "";
@@ -175,3 +199,12 @@
     {/if}
   </div>
 </div>
+
+<Modal open={switchConfirmOpen} title="Discard unsaved changes?" onClose={cancelSwitchFile}>
+  Switching files will discard your unsaved edits to {fileName(selectedFile)}.
+
+  {#snippet actions()}
+    <button class="btn btn-secondary" onclick={cancelSwitchFile}>Cancel</button>
+    <button class="btn btn-danger" onclick={confirmSwitchFile}>Discard and switch</button>
+  {/snippet}
+</Modal>

--- a/web/src/components/settings/Providers.svelte
+++ b/web/src/components/settings/Providers.svelte
@@ -63,6 +63,7 @@
   // Model lists and loading state per role
   let modelLists = $state<Record<string, ModelEntry[]>>({});
   let modelLoading = $state<Record<string, boolean>>({});
+  let modelErrors = $state<Record<string, string | null>>({});
   let otherActive = $state<Record<string, boolean>>({});
   let otherValues = $state<Record<string, string>>({});
 
@@ -119,6 +120,7 @@
     if (role === "embedding") {
       const list = EMBEDDING_MODEL_LISTS[entry.type] ?? [];
       modelLists[role] = list;
+      modelErrors[role] = null;
       const current = getModel(role);
       if (!current && list.length > 0) {
         const def = DEFAULT_EMBEDDING_MODELS[entry.type] ?? "";
@@ -135,6 +137,7 @@
     const result = await fetchModels(entry.type, apiKey, url);
     modelLists[role] = result.models;
     modelLoading[role] = false;
+    modelErrors[role] = result.error;
 
     const current = getModel(role);
     if (!current && result.models.length > 0) {
@@ -333,6 +336,15 @@
               </div>
             </div>
           </div>
+          {#if modelErrors[role]}
+            <div class="provider-warning">
+              <span class="provider-warning-icon">&#9888;</span>
+              <span
+                >Couldn't load live models ({modelErrors[role]}) — showing a fallback list, not
+                the provider's real models. Check the API key or URL and try again.</span
+              >
+            </div>
+          {/if}
           <div class="role-overrides">
             <div class="settings-field override-field">
               <label for="srole-{role}-temp">Temperature</label>
@@ -439,6 +451,15 @@
               </div>
             </div>
           </div>
+          {#if modelErrors[role]}
+            <div class="provider-warning">
+              <span class="provider-warning-icon">&#9888;</span>
+              <span
+                >Couldn't load live models ({modelErrors[role]}) — showing a fallback list, not
+                the provider's real models. Check the API key or URL and try again.</span
+              >
+            </div>
+          {/if}
           <div class="role-overrides">
             <div class="settings-field override-field">
               <label for="srole-{role}-temp">Temperature</label>
@@ -604,6 +625,15 @@
               </div>
             </div>
           </div>
+          {#if modelErrors[role]}
+            <div class="provider-warning">
+              <span class="provider-warning-icon">&#9888;</span>
+              <span
+                >Couldn't load live models ({modelErrors[role]}) — showing a fallback list, not
+                the provider's real models. Check the API key or URL and try again.</span
+              >
+            </div>
+          {/if}
           <div class="role-overrides">
             <div class="settings-field override-field">
               <label for="srole-{role}-temp">Temperature</label>

--- a/web/src/components/setup/Roles.svelte
+++ b/web/src/components/setup/Roles.svelte
@@ -43,6 +43,7 @@
   // Track model lists per role
   let modelLists = $state<Record<string, ModelEntry[]>>({});
   let modelLoading = $state<Record<string, boolean>>({});
+  let modelErrors = $state<Record<string, string | null>>({});
   let otherActive = $state<Record<string, boolean>>({});
   let otherValues = $state<Record<string, string>>({});
 
@@ -150,6 +151,7 @@
     if (role === "embedding") {
       const models = EMBEDDING_MODEL_LISTS[prov] ?? [];
       modelLists[role] = models;
+      modelErrors[role] = null;
       const current = getRoleModel(role);
       if (!current && models.length > 0) {
         const defaultModel = DEFAULT_EMBEDDING_MODELS[prov] ?? "";
@@ -167,6 +169,7 @@
     const result = await fetchModels(prov, apiKey, url);
     modelLists[role] = result.models;
     modelLoading[role] = false;
+    modelErrors[role] = result.error;
 
     // Auto-select default if no model set
     const current = getRoleModel(role);
@@ -272,6 +275,15 @@
         </div>
       </div>
     </div>
+    {#if modelErrors["main"]}
+      <div class="provider-warning">
+        <span class="provider-warning-icon">&#9888;</span>
+        <span
+          >Couldn't load live models ({modelErrors["main"]}) — showing a fallback list, not the
+          provider's real models. Check the API key or URL and try again.</span
+        >
+      </div>
+    {/if}
   </div>
 </div>
 
@@ -334,6 +346,15 @@
           </div>
         </div>
       </div>
+      {#if modelErrors[role]}
+        <div class="provider-warning">
+          <span class="provider-warning-icon">&#9888;</span>
+          <span
+            >Couldn't load live models ({modelErrors[role]}) — showing a fallback list, not the
+            provider's real models. Check the API key or URL and try again.</span
+          >
+        </div>
+      {/if}
     </div>
   {/each}
 </div>
@@ -460,6 +481,15 @@
           </div>
         </div>
       </div>
+      {#if modelErrors[role]}
+        <div class="provider-warning">
+          <span class="provider-warning-icon">&#9888;</span>
+          <span
+            >Couldn't load live models ({modelErrors[role]}) — showing a fallback list, not the
+            provider's real models. Check the API key or URL and try again.</span
+          >
+        </div>
+      {/if}
     </div>
   {/each}
 </div>

--- a/web/src/styles/chat.css
+++ b/web/src/styles/chat.css
@@ -329,6 +329,41 @@
   transform: translateX(-50%) translateY(0);
 }
 
+/* ── Empty feed ────────────────────────────────────────────────────────── */
+
+.feed-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--s-2);
+  min-height: 200px;
+  text-align: center;
+  padding: var(--s-5);
+}
+
+.feed-empty-text {
+  font-family: var(--font-body);
+  font-weight: 300;
+  font-style: italic;
+  font-size: var(--fs-md);
+  color: var(--text-dim);
+  margin: 0;
+}
+
+.feed-empty-hint {
+  font-family: var(--font-body);
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.feed-empty-key {
+  font-family: var(--font-mono);
+  color: var(--vein-bright);
+  padding: 0 var(--s-1);
+}
+
 /* ── Lazy-load sentinel + dust indicator ────────────────────────────────── */
 
 .feed-top-sentinel {


### PR DESCRIPTION
This PR is the running log for an unattended "Garden" tending loop (see the `tending` skill's `references/garden.md` in grizzly-plugins), firing hourly. Each cycle scouts a few areas with a fresh lens, dispatches small findings to fixer agents and large findings to a dedicated agent, verifies centrally (`cargo fmt`/`clippy`/`test`, plus the web build/lint/typecheck via the pre-commit hooks), and commits per unit of care. Since each hourly firing is a fresh session, this description (and its comments) is the durable memory across cycles — later cycles should read it before assuming anything is "already looked at."

## Cycle 1 — 2026-07-21

**Scouted:** `src/tools` (fresh-agent walk, code.md + agents.md), `web/src` (first-time-user walk, code.md + interfaces.md), `src/memory` (3am-debugger walk, code.md).

**Tended (8 small findings, committed):**
- `feat(web)`: empty state for the chat feed — the one stateful list in the app missing one
- `fix(web)`: confirm before discarding unsaved workspace edits (dirty flag existed but wasn't wired to the destructive path)
- `fix(web)`: persist the setup wizard's draft across refresh (API keys/tokens stripped before write)
- `fix(web)`: surface model-fetch failures instead of silently showing a fallback list as if it were live
- `fix(web)`: explain why chat input is disabled while reconnecting
- `fix`: validate `candidate_multiplier` so `0` can't silently empty every search result
- `docs(tools)` ×2: document the missing `user_inbox_add` tool and `ollama_web_search`'s undocumented sub-agent exclusion; add the mechanical tool-registration checklist `CLAUDE.md` was missing

**In flight:** a large Sweep replacing the stringly-typed `source_type`/`source` concept in memory search (three independent string vocabularies across `memory_search.rs`, `search.rs`, `vector_store.rs`) with a real `enum DocSource`, running in an isolated worktree. Will be reviewed and merged in a follow-up commit once it reports back.

**Named for a future cycle, not yet dispatched (deliberately — each needs judgment a scout/fixer pair shouldn't make unsupervised):**
- `src/tools`: `docs/systems-usage/projects.md` documents a per-project "scoped tool allowlist" as live, but the underlying mechanism (`ToolFilter.gated`) is never populated on any construction path — every tool is available in every project regardless of its `tools:` list. This is a safety-relevant docs/behavior mismatch (a user could believe destructive tools are scoped away when they aren't). Needs a human-adjacent decision: implement real enforcement, or correct the docs to match reality — not something to resolve silently.
- `src/memory`: no locking around the read-modify-write append cycle for `recent_messages.json`/`observations.json` (`src/util/fs.rs`'s `atomic_write` prevents corrupt partial writes but not lost updates from concurrent callers). Currently only latent (the gateway loop appears to serialize calls today, but nothing enforces it) — needs a design decision about who owns single-writer discipline for the memory persistence layer.
- `src/memory`: date filters (`date_from`/`date_to`) are compared as raw strings rather than parsed at the boundary, so a non-zero-padded date silently sorts wrong. Deferred this cycle only because it shares files with the in-flight `source_type` sweep; safe to pick up once that merges.
- `src/memory`: the vector-search-degraded log line is `trace`-level, invisible at this project's default `debug` log level. Same file-overlap reason for deferring.

Verification: `cargo fmt --check`, `cargo clippy --all-targets`, `cargo test --quiet` (1568+ tests), and `npm run build` all green on the 8 committed changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AcR4PKcLm9prHz8eir2h4j)_