### PR TITLE
Improve observability, durability, and collision detection across systems

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,9 @@
 - [Notification Routing](./docs/notification-routing-design.md)
 - [Systems Usage](./docs/systems-usage/) (authoritative reference for how systems are intended to work)
 
-**Web interface:** The Residuum web UI lives in `residuum/web/` (Svelte 5 SPA). See `web/CLAUDE.md` for details. **Do not confuse with `relay/web/`**, which is only a marketing landing page.
+The design docs above are historical records and may not reflect current behavior — `docs/systems-usage/` is the authoritative reference for how systems work today.
+
+**Web interface:** The Residuum web UI lives in `residuum/web/` (Svelte 5 SPA). See `web/CLAUDE.md` for details. **Do not confuse with `relay/web/`**, the marketing landing page — it lives in a separate repository, not this one.
 
 ## Build & Quality Gates
 

--- a/assets/bundled-skills/residuum-system/SKILL.md
+++ b/assets/bundled-skills/residuum-system/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: residuum-system
-description: Reference documentation for all Residuum workspace systems — memory, projects, heartbeats, inbox, actions, skills, notifications, and background tasks.
+description: Reference documentation for all Residuum workspace systems — memory, projects, heartbeats, inbox, actions, skills, MCP, notifications, background tasks, and subconscious.
 ---
 
 # Residuum System Reference
@@ -18,8 +18,10 @@ This skill provides reference documentation for every major workspace system. Ac
 | Scheduled Actions | `schedule_action`, `list_actions`, `cancel_action` | `scheduled_actions.json` | [scheduled-actions](references/scheduled-actions.md) |
 | Skills | `skill_activate`, `skill_deactivate` | per-skill `SKILL.md` | [skills](references/skills.md) |
 | Tool PATH | `exec` (uses it) | `[tools]` in config.toml, `~/.residuum/bin` | [tools](references/tools.md) |
+| MCP | *(none — surfaced as regular tools)* | `config/mcp.json`, per-project `mcp_servers` | [mcp](references/mcp.md) |
 | Notifications | `list_endpoints`, `switch_endpoint`, `send_message` | `ALERTS.md`, `config/channels.toml` | [notifications](references/notifications.md) |
 | Background Tasks | `subagent_spawn`, `list_agents`, `stop_agent` | `[background]` in config.toml | [background-tasks](references/background-tasks.md) |
+| Subconscious | *(none — automatic)* | `SUBCONSCIOUS.md`, `[subconscious]` in config.toml | [subconscious](references/subconscious.md) |
 
 ## Workspace Directory Layout
 

--- a/assets/bundled-skills/residuum-system/references/mcp.md
+++ b/assets/bundled-skills/residuum-system/references/mcp.md
@@ -1,0 +1,50 @@
+# MCP (Model Context Protocol)
+
+Residuum extends the agent's tool set with external MCP servers — spawned
+stdio children or remote HTTP endpoints — reconciled against desired state
+and exposed alongside the agent's built-in tools.
+
+## Config: `config/mcp.json`
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/data"]
+    },
+    "hosted-search": {
+      "type": "http",
+      "url": "https://example.com/mcp",
+      "headers": { "Authorization": "Bearer ${API_TOKEN}" }
+    }
+  }
+}
+```
+
+Same `mcpServers` map format used by Claude Code/Desktop. `${VAR}` /
+`${VAR:-default}` expansion applies to HTTP header values only, not stdio
+`env`. A bad entry (missing `command`/`url`, unrecognized transport) drops
+just that server — never a hard failure.
+
+## Projects
+
+Project frontmatter references servers by name rather than embedding them:
+
+```yaml
+mcp_servers:
+  - filesystem
+  - git
+```
+
+Names resolve against a project-local `mcp.json` first, then the workspace
+one. Servers are reference-counted across sub-agents sharing a project, so
+multiple agents with the same project active reuse one running server
+instead of starting duplicates.
+
+## Tools
+
+No dedicated tools — once a server is running, its tools are merged directly
+into the agent's available tool set.
+
+See the authoritative reference: `docs/systems-usage/mcp.md`.

--- a/assets/bundled-skills/residuum-system/references/subconscious.md
+++ b/assets/bundled-skills/residuum-system/references/subconscious.md
@@ -1,0 +1,43 @@
+# Subconscious
+
+A small-model classifier that watches the main agent's conversation and
+steers it when it drifts from its instructions — e.g. acknowledging a user
+preference but not persisting it to `MEMORY.md`, or acting against a rule in
+`SOUL.md`/`AGENTS.md`. Opt-in, disabled by default.
+
+## When it runs
+
+Only for user-visible (foreground) turns — background, wake, system, and
+sub-agent turns are never watched, which bounds the feedback loop.
+
+- **Mid-turn watch**: every `every_n_iterations` tool-loop iterations, a
+  detached classifier may inject a live course correction for an urgent
+  (`act`) finding.
+- **End-of-turn triage**: after the turn completes, evaluates the whole turn
+  plus anything the mid-turn watch queued. The first `act` finding becomes a
+  correction turn; `note` findings surface as passive `[Subconscious note]`
+  context on the next turn.
+
+## SUBCONSCIOUS.md
+
+User-editable policy file (in the workspace) controlling *what* the
+classifier checks for — read fresh from disk on every evaluation. The output
+schema and "stay quiet unless certain" guidance are fixed by code, not
+editable via the file.
+
+## Learning
+
+End-of-turn triage can also emit a `learn` signal (`preference` or
+`recovery`), which spawns the `learner` sub-agent preset, subject to a
+cooldown. Opt-in via `[subconscious] learning = true`. A separate
+`[learning] nudge_after_turns` fallback exists for users who keep the
+subconscious itself off.
+
+## Config
+
+`[subconscious]` in `config.toml`: `enabled` (default `false`), `mid_turn`,
+`every_n_iterations`, `max_interventions_per_turn`, `max_transcript_tokens`,
+`learning`, `learning_cooldown_minutes`. Model assigned via the
+`subconscious` role in `providers.toml`.
+
+See the authoritative reference: `docs/systems-usage/subconscious.md`.

--- a/docs/systems-usage/README.md
+++ b/docs/systems-usage/README.md
@@ -59,6 +59,7 @@ These are drawn from [design-philosophy.md](../design-philosophy.md) and inform 
 | [Tool PATH](tools.md) | Runtime-extensible PATH for spawned CLIs (exec + MCP stdio) | *(automatic — no tools)* | `[tools]` in `config.toml`, `~/.residuum/bin` |
 | [MCP](mcp.md) | External tool servers (stdio + HTTP), reconciled against desired state | *(automatic — surfaced as regular tools)* | `config/mcp.json`, per-project `mcp_servers` |
 | [Notifications](notifications.md) | Result routing from background tasks | `list_endpoints`, `switch_endpoint`, `send_message` | `ALERTS.md`, `config/channels.toml` |
+| [Idle](idle.md) | Deactivates project/skills, switches notification channel, and injects a continuity message after user inactivity | *(automatic — no tools)* | `[idle]` in `config.toml` |
 | [Background Tasks](background-tasks.md) | Sub-agents and scripts | `subagent_spawn`, `list_agents`, `stop_agent` | `[background]` in `config.toml`, `subagents/` presets |
 | [Subconscious](subconscious.md) | Instruction-drift classifier that steers the agent | *(automatic — no tools)* | `[subconscious]` in `config.toml`, `SUBCONSCIOUS.md` |
 

--- a/docs/systems-usage/README.md
+++ b/docs/systems-usage/README.md
@@ -57,6 +57,7 @@ These are drawn from [design-philosophy.md](../design-philosophy.md) and inform 
 | [Scheduled Actions](scheduled-actions.md) | One-off future tasks | `schedule_action`, `list_actions`, `cancel_action` | `scheduled_actions.json` |
 | [Skills](skills.md) | Loadable instruction modules | `skill_activate`, `skill_deactivate` | per-skill `SKILL.md` |
 | [Tool PATH](tools.md) | Runtime-extensible PATH for spawned CLIs (exec + MCP stdio) | *(automatic — no tools)* | `[tools]` in `config.toml`, `~/.residuum/bin` |
+| [MCP](mcp.md) | External tool servers (stdio + HTTP), reconciled against desired state | *(automatic — surfaced as regular tools)* | `config/mcp.json`, per-project `mcp_servers` |
 | [Notifications](notifications.md) | Result routing from background tasks | `list_endpoints`, `switch_endpoint`, `send_message` | `ALERTS.md`, `config/channels.toml` |
 | [Background Tasks](background-tasks.md) | Sub-agents and scripts | `subagent_spawn`, `list_agents`, `stop_agent` | `[background]` in `config.toml`, `subagents/` presets |
 | [Subconscious](subconscious.md) | Instruction-drift classifier that steers the agent | *(automatic — no tools)* | `[subconscious]` in `config.toml`, `SUBCONSCIOUS.md` |

--- a/docs/systems-usage/idle.md
+++ b/docs/systems-usage/idle.md
@@ -1,0 +1,60 @@
+# Idle
+
+After a configurable period of user inactivity, the gateway runs an idle transition: it deactivates the active project and any explicitly-activated skills, fires the observer and clears the in-memory message buffer, optionally switches where subsequent output is routed, and injects a continuity message into the agent's history. There is no polling — a single deadline in the event loop's `select!` loop (`idle_deadline`, alongside `observe_deadline`) fires once and is cleared.
+
+## Trigger
+
+Only inbound user messages reset the idle deadline (`handle_inbound_message` in `src/gateway/event_loop/turns.rs`) — background-origin turns (`origin.endpoint == "background"`) do not. On a qualifying message, `idle_deadline` is set to `now + rt.cfg.idle.timeout`, provided the timeout isn't zero. When the deadline expires, `idle::execute_idle_transition` (`src/gateway/idle.rs`) runs and `idle_deadline` is cleared back to `None` (`src/gateway/event_loop/run_loop.rs`). Nothing resets the deadline besides a new user message — tool calls, background task results, and pulses are not activity.
+
+`timeout_minutes = 0` disables the system entirely: the deadline is never set.
+
+## Transition sequence
+
+`execute_idle_transition` runs these steps in order:
+
+1. **Deactivate the active project, if any** (`deactivate_project_if_active`). Generates an LLM session log, calls `ProjectState::deactivate` with it, clears the path policy's active project, clears the agent's tool filter, deactivates the project's MCP server refs (`McpRegistry::deactivate_project`), and rescans skills to drop any that were project-scoped. Counts skills removed by the rescan for the summary message. No-op if no project is active.
+2. **Deactivate remaining explicitly-activated skills** (`deactivate_remaining_skills`) — whatever wasn't already removed by the project rescan in step 1.
+3. **Fire the observer, then clear the in-memory message buffer.** Runs the normal `execute_observation` path so the episode gets a proper summary, then calls `rt.agent.clear_messages()` so the agent doesn't see stale mid-conversation context on the next turn. Also clears `observe_deadline`.
+4. **Switch the notification interface**, if `idle.idle_channel` is configured (see below).
+5. **Inject a continuity system message** built by `format_idle_summary`, e.g. `[Idle] Transitioned to idle after 30m of inactivity. Deactivated project "aerohive-setup" and 2 skills. Session log written.`
+
+### Session log generation
+
+`generate_deactivation_log` builds a one-shot prompt (project name + description, recent messages from `recent_messages.json`) and sends it to the `small` background model tier — no tool access, no multi-turn loop. On success, the log is `"[idle] {llm summary}"`. On any failure (provider build error, completion error, or an empty response), `build_fallback_log` writes the raw recent-message slice to `notes/log/YYYY-MM/idle-raw-DD-HHMMSS.json` and uses a structured fallback string naming that path, so the context isn't lost even when the LLM call fails.
+
+## Switching the notification interface
+
+`switch_idle_interface` looks up `idle.idle_channel` in `rt.endpoint_registry`. If the endpoint exists and has `EndpointCapabilities::INTERACTIVE`, `rt.last_output_endpoint` is set to it — the same field that already governs where background-turn responses (e.g. `agent_wake` results) get routed, so this reuses existing routing plumbing rather than a separate mechanism. If the endpoint is missing or not interactive, the switch is skipped with a `warn` log and the current output topic is left unchanged; this is a soft fallback, not a hard failure.
+
+## Configuration
+
+`config.toml`:
+
+```toml
+[idle]
+timeout_minutes = 30       # 0 disables the idle system entirely
+idle_channel = "telegram"  # optional; interface to route output to when idle
+```
+
+Resolved into `IdleConfig { timeout: Duration, idle_channel: Option<String> }` (`src/config/types.rs`) by `resolve_idle_config` (`src/config/resolve/mod.rs`). `idle_channel`, if set, is validated at config load time against the interfaces actually configured: `"telegram"` and `"discord"` require the corresponding `[telegram]`/`[discord]` section to be present, `"websocket"` is always valid, and any other name is rejected outright. An invalid value fails config load with a `FatalError::Config` — it is not a silent runtime fallback like the endpoint-registry check in `switch_idle_interface` above.
+
+### Hot reload
+
+A config reload that changes `[idle]` is detected via `ConfigDiff::idle_changed` (`src/gateway/reload.rs`) and translated into an `IdleAction`:
+
+- `Disable` — timeout became zero; clears `idle_deadline` immediately.
+- `Recalculate { new_timeout }` — timeout changed; the deadline is recomputed from `last_user_message_instant` plus the new timeout. If that recalculated deadline has already passed, the idle transition runs immediately instead of waiting for the next tick.
+- `None` — no idle-relevant change.
+
+## Reactivation
+
+There is none, automatic or otherwise. The next user message is processed normally, the idle deadline resets, and the agent sees the injected `[Idle]` system message in its history — whether it reactivates the previous project or skills is left entirely to its own judgment based on the conversation that follows.
+
+## Interaction with Other Systems
+
+- **Projects**: deactivation goes through the standard `ProjectState::deactivate` contract with a non-empty log, same as an agent-initiated `project_deactivate`. See [projects.md](projects.md).
+- **Skills**: project-scoped skills are removed via the rescan in step 1; any skills activated outside a project are swept in step 2. See [skills.md](skills.md).
+- **MCP**: project MCP server refs are released via `McpRegistry::deactivate_project`, the same ref-counted path used by explicit `project_deactivate` calls. See [mcp.md](mcp.md).
+- **Memory**: the observer fires before the message buffer is cleared, so the idle boundary is captured in the episode record rather than lost. See [memory.md](memory.md).
+- **Notifications**: switching `last_output_endpoint` affects where background-task results (`agent_wake`, etc.) surface after the user goes idle. See [notifications.md](notifications.md).
+- **Background Tasks**: unaffected by idle — background tasks, pulses, and scheduled actions keep running regardless of user activity; only user messages drive the idle timer. See [background-tasks.md](background-tasks.md).

--- a/docs/systems-usage/mcp.md
+++ b/docs/systems-usage/mcp.md
@@ -69,7 +69,7 @@ Project names are lowercased for the ref-count key, so activation/deactivation i
 
 ## Consumption
 
-- **`tool_definitions()`** returns the flat union of `ToolDefinition`s from every `Running` server — this is what gets merged into the agent's available tool set.
+- **`tool_definitions()`** returns the flat union of `ToolDefinition`s from every `Running` server — this is what gets merged into the agent's available tool set. Names aren't guaranteed unique across servers or against built-ins, so a deterministic collision policy applies before this union is built: a built-in tool always wins, and among MCP servers the first-registered running one wins; the losing tool is shadowed (excluded from the union, never dispatched) and the collision is logged once at `warn`. See [`src/mcp/CLAUDE.md`](../../src/mcp/CLAUDE.md) for the implementation.
 - **`call_tool(name, args)`** finds the first `Running` server whose tool list contains `name` and routes the call to its `McpClient`. Unknown tool names return `ToolError::NotFound`; a found-but-broken client (an internal-consistency bug, not a user error) returns `ToolError::Execution` and is logged at `error`. Each call has a one-minute timeout (`TOOL_CALL_TIMEOUT`); a timeout is reported as an execution error naming the tool, server, and elapsed seconds.
 - Tool results only preserve text content blocks (`extract_text_content` joins them with newlines); non-text blocks (e.g. images) are silently dropped from the MCP path today.
 

--- a/docs/systems-usage/mcp.md
+++ b/docs/systems-usage/mcp.md
@@ -1,0 +1,80 @@
+# MCP (Model Context Protocol)
+
+MCP servers extend the agent's tool set with external tools served by a separate process, either a spawned stdio child or a remote HTTP endpoint. Residuum maintains a registry of running servers, reconciles it against desired state, and exposes each server's tools alongside the agent's built-in tools.
+
+## Configuration: `config/mcp.json`
+
+Server definitions live in `config/mcp.json` (workspace-level, via `WorkspaceLayout::mcp_json()`), in the same `mcpServers` map format used by Claude Code/Desktop:
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/data"],
+      "env": { "SOME_TOKEN": "${MY_TOKEN:-}" }
+    },
+    "hosted-search": {
+      "type": "http",
+      "url": "https://example.com/mcp",
+      "headers": { "Authorization": "Bearer ${API_TOKEN}" }
+    }
+  }
+}
+```
+
+The loader (`crate::workspace::config::load_mcp_servers_map`, in `src/workspace/config.rs`) accepts either the Residuum-native `transport` field (`"stdio"` | `"http"`) or the Claude Code/Desktop `type` field (`"stdio"` | `"streamable-http"` | `"http"` | `"sse"`); `type` takes priority when both are present. `"sse"` is recognized but skipped with a warning (deprecated by the MCP spec), as is any unrecognized transport value. For HTTP servers, `url` is preferred over `command` as the address; a server missing both is skipped with a warning. A stdio server missing `command` is likewise skipped. None of these are hard failures — a bad entry drops that one server, not the whole file.
+
+Project frontmatter references servers by name rather than embedding them (see [projects.md](projects.md)):
+
+```yaml
+mcp_servers:
+  - filesystem
+  - git
+```
+
+`resolve_mcp_references` (same file) resolves each name against a project-local `mcp.json` (`<project_root>/mcp.json`) first, then the global workspace `mcp.json`, so a project can shadow a global server definition by reusing its name. An unresolvable reference is an error for the whole activation — surfaced to the agent as a warning rather than aborting activation (see `ProjectActivateTool` in `src/tools/projects.rs`).
+
+## Transports
+
+`McpServerEntry::transport` (`src/projects/types.rs`) selects the connection strategy in `McpClient::connect` (`src/mcp/client.rs`):
+
+- **Stdio** (default): spawns `entry.command` with `entry.args` as a child process and speaks MCP over stdin/stdout (`TokioChildProcess`). The tool-PATH handle (see [tools.md](tools.md)) is applied to the child's `PATH` first, then the entry's own `env` — so an explicit `PATH` in the entry still wins.
+- **Http**: connects to `entry.command` (the URL) via Streamable HTTP (`StreamableHttpClientTransport`). If `headers` is non-empty, header values are expanded for env interpolation and attached as custom headers.
+
+Both paths perform the MCP handshake via `rmcp`'s `ServiceExt::serve`; a spawn/dial failure or a handshake failure both surface as connection errors, and the caller (the registry) marks the server `Failed` with that reason.
+
+## `${VAR}` / `${VAR:-default}` expansion
+
+`expand_env_vars` (`src/mcp/client.rs`) expands `${VAR}` and `${VAR:-default}` patterns against the process's own environment. It is currently applied only to HTTP server **header values** at connect time (`expand_header_env_vars`) — a missing variable with no default resolves to an empty string; an empty (but set) variable does **not** trigger the default, which diverges from POSIX shell semantics. Stdio `env` entries are passed through to the child process as literal strings without this expansion.
+
+## Registry and reconciliation
+
+`McpRegistry` (`src/mcp/registry.rs`) tracks servers as a flat list of `TrackedServer { name, command, args, status, client, tools }`. Status is one of `Pending`, `Running`, or `Failed(reason)`.
+
+- **`reconcile(desired)`** — pure diff, no I/O. Servers in `desired` that aren't already `Running`/`Pending` go into `to_start` (and are immediately re-tracked as `Pending`, replacing any stale entry). Tracked servers not in `desired` and currently `Running`/`Pending` go into `to_stop`. A `Failed` server whose name is still in `desired` is treated as absent and restarted.
+- **`reconcile_and_connect(desired)`** — runs `reconcile`, then connects everything in `to_start` and disconnects everything in `to_stop`, returning an `McpReconcileReport` (`started`, `stopped`, `failures: Vec<(name, error)>`). This is the workspace-level reconciliation path: it runs at startup against `config/mcp.json` and again on a live config reload (`handle_workspace_reload` in `src/gateway/event_loop/run_loop.rs`) — a config edit that removes a server tears it down, one that adds a server starts it, without a restart.
+- **`connect_servers(entries)`** — purely additive; never stops or removes existing servers. Used for one-off attachments outside the desired-state model, e.g. the standalone web-search MCP servers (Brave/Tavily, wired in `connect_web_search_mcp` in `src/gateway/startup/mod.rs`) that aren't declared in `mcp.json` at all.
+- **`connect(entry)`** — the low-level step: builds an `McpClient`, lists its tools, and marks the server `Running` with the discovered `ToolDefinition`s cached. On any failure it marks the tracked entry `Failed` with the error text (visible via `servers()`).
+
+## Per-project reference counting
+
+Multiple sub-agents can have the same project active at once, so MCP servers declared in project frontmatter are shared rather than started per-agent. `McpRegistry` keeps a separate map, `project_refs: HashMap<lowercased-name, ProjectMcpState>`, alongside the flat server list:
+
+- **`activate_project(name, servers)`** — first activation (ref count 0→1) reconciles and connects `servers`, then records the count and the resolved entries. Subsequent activations (count N→N+1) just increment and return an empty report — servers already running are reused, not restarted.
+- **`deactivate_project(name)`** — decrements the count; only at 0 does it disconnect the project's servers and return their names. `project_activate`/`project_deactivate` tool calls and the idle-timeout project deactivation (`src/gateway/idle.rs`) both go through this path.
+- **`force_deactivate_project(name)`** — ignores the ref count entirely: removes the tracking entry and disconnects immediately. This is the crash-recovery path — a sub-agent whose turn loop ends without calling `project_deactivate` (crash, cancellation, or exhausted retry) leaves its project active, so `background/subagent.rs`'s `force_deactivate_project` helper calls this to tear the MCP servers down alongside clearing the path policy and tool filter, regardless of how many other agents still think the project is active.
+
+Project names are lowercased for the ref-count key, so activation/deactivation is case-insensitive with respect to matching.
+
+## Consumption
+
+- **`tool_definitions()`** returns the flat union of `ToolDefinition`s from every `Running` server — this is what gets merged into the agent's available tool set.
+- **`call_tool(name, args)`** finds the first `Running` server whose tool list contains `name` and routes the call to its `McpClient`. Unknown tool names return `ToolError::NotFound`; a found-but-broken client (an internal-consistency bug, not a user error) returns `ToolError::Execution` and is logged at `error`. Each call has a one-minute timeout (`TOOL_CALL_TIMEOUT`); a timeout is reported as an execution error naming the tool, server, and elapsed seconds.
+- Tool results only preserve text content blocks (`extract_text_content` joins them with newlines); non-text blocks (e.g. images) are silently dropped from the MCP path today.
+
+## Interaction with Other Systems
+
+- **Tool PATH**: stdio servers resolve their `command` against the effective tool `PATH` (configured dirs + `~/.residuum/bin` + inherited `PATH`), injected into the registry via `McpRegistry::new_shared_with_tools_path`. See [tools.md](tools.md).
+- **Projects**: project frontmatter's `mcp_servers` list is names, not inline definitions; resolution and reference-counted lifecycle are described above. See [projects.md](projects.md).
+- **Background tasks**: sub-agents share the same `SharedMcpRegistry` as the main agent — there is no per-agent isolation. If a sub-agent's turn loop ends with a project still active, force-deactivation tears down that project's MCP servers even though other agents may still be relying on the ref count. See [background-tasks.md](background-tasks.md).

--- a/src/agent/context/assembly.rs
+++ b/src/agent/context/assembly.rs
@@ -351,36 +351,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn status_line_omits_zero_unread() {
-        let identity = IdentityFiles::default();
-        let mut recent = RecentMessages::new();
-        recent.push(Message::user("check inbox"));
-
-        let ctx = StatusLine {
-            now: dt(2026, 2, 22, 17, 0),
-            last_message_at: None,
-            message_source: None,
-        };
-
-        let messages = assemble_system_prompt(
-            &identity,
-            &recent,
-            &no_memory(),
-            &PromptContext::default(),
-            Some(&ctx),
-        );
-
-        let tag = messages
-            .iter()
-            .find(|m| m.content.contains("[Current Time:"))
-            .map(|m| m.content.as_str());
-        assert!(
-            tag.is_some_and(|t| !t.contains("[Unread Inbox:")),
-            "should not include unread inbox tag when count is 0, got: {tag:?}"
-        );
-    }
-
     // ── compute_context_breakdown tests ──────────────────────────────────────
 
     #[test]

--- a/src/agent/context/prompt.rs
+++ b/src/agent/context/prompt.rs
@@ -976,18 +976,4 @@ mod tests {
             "should have message source tag"
         );
     }
-
-    #[test]
-    fn build_status_line_source_only() {
-        let ctx = StatusLine {
-            now: dt(2024, 1, 1, 12, 0),
-            last_message_at: None,
-            message_source: Some("cli".to_string()),
-        };
-        let result = build_status_line(&ctx);
-        assert!(
-            !result.contains("[Unread Inbox:"),
-            "should not have unread inbox tag when count is 0"
-        );
-    }
 }

--- a/src/agent/turn.rs
+++ b/src/agent/turn.rs
@@ -58,7 +58,10 @@ pub(crate) struct TurnResources<'a> {
 /// executing any requested tools in between. Updates `recent_messages` in place.
 ///
 /// MCP tool definitions are merged into the built-in tool list, and tool calls
-/// fall back to MCP servers when no built-in tool matches.
+/// fall back to MCP servers when no built-in tool matches. Name collisions are
+/// resolved by the MCP registry before this merge: a built-in always wins and
+/// the colliding MCP tool is dropped from the union, so the model is never
+/// offered two definitions under one name. See `src/mcp/CLAUDE.md`.
 ///
 /// Returns a vec containing the final text-only response. Intermediate texts
 /// emitted alongside tool calls are sent via `reply` in real-time but not
@@ -92,7 +95,10 @@ pub(crate) async fn execute_turn(
         let filter = resources.tool_filter.read().await.clone();
         let mut tool_definitions = resources.tools.definitions(&filter);
 
-        // Merge MCP tool definitions from all connected servers
+        // Merge MCP tool definitions from all connected servers. The registry
+        // has already dropped any MCP tool whose name collides with a built-in
+        // or with an earlier server, so this union never carries a duplicate
+        // name (collision policy: src/mcp/CLAUDE.md).
         let mcp_guard = resources.mcp_registry.read().await;
         tool_definitions.extend(mcp_guard.tool_definitions());
         drop(mcp_guard);
@@ -237,7 +243,11 @@ async fn execute_tool(
         )
         .await;
 
-    // Try built-in tools first, fall back to MCP servers
+    // Try built-in tools first, fall back to MCP servers. This ordering is the
+    // dispatch half of the collision policy: a built-in always wins its name,
+    // and the registry has already hidden any shadowed MCP tool from the model
+    // (src/mcp/CLAUDE.md), so the fallback only ever reaches genuinely
+    // MCP-owned names.
     let mut used_mcp = false;
     let result = match resources
         .tools

--- a/src/background/spawn_context.rs
+++ b/src/background/spawn_context.rs
@@ -2,7 +2,6 @@
 //! for background tasks (pulse, actions, and on-demand sub-agents).
 
 use std::collections::HashSet;
-use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::Context as _;
@@ -19,6 +18,7 @@ use crate::models::retry::RetryConfig;
 use crate::models::{CompletionOptions, SharedHttpClient, build_provider_chain};
 use crate::projects::activation::SharedProjectState;
 use crate::skills::SharedSkillState;
+use crate::subagents::SubagentPresetIndex;
 use crate::subagents::types::SubagentPresetFrontmatter;
 use crate::workspace::identity::IdentityFiles;
 use crate::workspace::layout::WorkspaceLayout;
@@ -143,20 +143,22 @@ pub(crate) async fn build_spawn_resources(
     .await)
 }
 
-/// Load a sub-agent preset and resolve its model tier.
+/// Resolve a sub-agent preset's frontmatter, body, and effective model tier
+/// from an already-scanned preset index.
 ///
-/// Returns the resolved tier and the preset frontmatter+body.
-/// Used by pulse, scheduled actions, and on-demand spawning.
+/// Callers that need to look up more than one preset name against the same
+/// directory (e.g. a primary preset with a `general-purpose` fallback) should
+/// scan once via `SubagentPresetIndex::scan` and reuse that index across
+/// calls, rather than re-scanning per lookup.
 ///
 /// # Errors
-/// Returns an error if the preset index cannot be scanned or the preset cannot be loaded.
+/// Returns an error if the preset cannot be found or loaded from the index.
 #[tracing::instrument(skip_all, fields(preset = %preset_name))]
 pub(crate) async fn load_preset_for_spawn(
-    subagents_dir: &Path,
+    index: &SubagentPresetIndex,
     preset_name: &str,
     fallback_tier: BackgroundModelTier,
 ) -> Result<(BackgroundModelTier, SubagentPresetFrontmatter, String), anyhow::Error> {
-    let index = crate::subagents::SubagentPresetIndex::scan(subagents_dir).await?;
     let (fm, body) = index.load_preset(preset_name).await?;
 
     let tier: BackgroundModelTier = match fm.model_tier.as_deref() {

--- a/src/commands/connect.rs
+++ b/src/commands/connect.rs
@@ -183,6 +183,13 @@ fn handle_ws_frame(
         Ok(ref server_msg @ ServerMessage::Error { .. }) if *turn_active => {
             end_turn(client, server_msg, turn_active, gate_tx);
         }
+        // Closes turns that produced zero Response frames (e.g. interrupted
+        // or tool-only turns), which would otherwise leave the prompt gated
+        // forever. Turns that already ended via Response/Error above have
+        // turn_active == false by the time this arrives, so it's a no-op then.
+        Ok(ref server_msg @ ServerMessage::TurnEnded { .. }) if *turn_active => {
+            end_turn(client, server_msg, turn_active, gate_tx);
+        }
         Ok(server_msg) => client.display(&server_msg),
         Err(e) => tracing::warn!(error = %e, "failed to parse server message"),
     }
@@ -479,6 +486,60 @@ mod tests {
         assert!(
             gate_rx.try_recv().is_ok(),
             "gate should be signaled when Error ends turn"
+        );
+    }
+
+    #[test]
+    fn handle_ws_frame_turn_ended_active_ends_turn() {
+        let mut client = make_client();
+        let mut turn_active = true;
+        let (gate_tx, gate_rx) = make_gate();
+        let json = r#"{"type":"turn_ended","reply_to":"cli-1"}"#;
+        let result = handle_ws_frame(
+            Ok(TungsteniteMessage::text(json)),
+            &mut client,
+            &mut turn_active,
+            &gate_tx,
+        );
+        assert_eq!(
+            result,
+            std::ops::ControlFlow::Continue(()),
+            "TurnEnded should return Continue"
+        );
+        assert!(
+            !turn_active,
+            "turn_active should be false after TurnEnded ends turn"
+        );
+        assert!(
+            gate_rx.try_recv().is_ok(),
+            "gate should be signaled when TurnEnded ends turn"
+        );
+    }
+
+    #[test]
+    fn handle_ws_frame_turn_ended_inactive_is_noop() {
+        let mut client = make_client();
+        let mut turn_active = false;
+        let (gate_tx, gate_rx) = make_gate();
+        let json = r#"{"type":"turn_ended","reply_to":"cli-1"}"#;
+        let result = handle_ws_frame(
+            Ok(TungsteniteMessage::text(json)),
+            &mut client,
+            &mut turn_active,
+            &gate_tx,
+        );
+        assert_eq!(
+            result,
+            std::ops::ControlFlow::Continue(()),
+            "TurnEnded should return Continue"
+        );
+        assert!(
+            !turn_active,
+            "turn_active should remain false when already inactive"
+        );
+        assert!(
+            gate_rx.try_recv().is_err(),
+            "gate should not be signaled when TurnEnded arrives after the turn already ended"
         );
     }
 

--- a/src/gateway/event_loop/commands.rs
+++ b/src/gateway/event_loop/commands.rs
@@ -50,7 +50,7 @@ pub async fn handle_server_command(
                 bd.history_count,
             );
             if let Some(tx) = cmd.reply_tx {
-                tx.send(msg.clone()).ok();
+                tx.send(Ok(msg.clone())).ok();
             }
             if let Err(e) = rt
                 .publisher
@@ -65,13 +65,17 @@ pub async fn handle_server_command(
         }
         unknown => {
             tracing::debug!(command = %unknown, "received unknown server command");
-            if let Err(e) = rt
+            let reason = format!("unknown server command: {unknown}");
+            // Route the rejection back to whoever sent it, not to every
+            // connected client — an unknown command is specific to one
+            // sender's mistake, not system-wide news.
+            if let Some(tx) = cmd.reply_tx {
+                tx.send(Err(reason)).ok();
+            } else if let Err(e) = rt
                 .publisher
                 .publish(
                     topics::Notification(NotifyName::from(SYSTEM_CHANNEL)),
-                    NoticeEvent {
-                        message: format!("unknown server command: {unknown}"),
-                    },
+                    NoticeEvent { message: reason },
                 )
                 .await
             {

--- a/src/gateway/event_loop/run_loop.rs
+++ b/src/gateway/event_loop/run_loop.rs
@@ -74,6 +74,7 @@ struct SpawnedHandles {
     tracing_service: Arc<crate::tracing_service::TracingService>,
     sigterm: crate::gateway::types::TermSignal,
     file_registry: crate::gateway::file_server::FileRegistry,
+    watcher_handle: Option<tokio::task::JoinHandle<()>>,
 }
 
 /// Spawn the HTTP server, chat adapters, cloud tunnel, and workspace watcher.
@@ -138,11 +139,11 @@ async fn spawn_server_and_adapters(
     let (tunnel_handle, tunnel_shutdown_tx) = spawn_tunnel(cfg, Arc::clone(&tunnel_status_tx));
     let sigterm = crate::gateway::types::TermSignal::new()
         .map_err(|e| FatalError::Gateway(format!("failed to register termination handler: {e}")))?;
-    let _watcher_handle = watcher::spawn_workspace_watcher(
+    let watcher_handle = Some(watcher::spawn_workspace_watcher(
         parts.layout.mcp_json(),
         parts.layout.channels_toml(),
         core.reload_tx.clone(),
-    );
+    ));
 
     Ok(SpawnedHandles {
         server_handle,
@@ -154,6 +155,7 @@ async fn spawn_server_and_adapters(
         tracing_service,
         sigterm,
         file_registry,
+        watcher_handle,
     })
 }
 
@@ -310,6 +312,7 @@ async fn build_runtime(
         telegram_handle: spawned.adapters.telegram_handle,
         discord_shutdown_tx: spawned.adapters.discord_shutdown_tx,
         telegram_shutdown_tx: spawned.adapters.telegram_shutdown_tx,
+        watcher_handle: spawned.watcher_handle,
         reload_tx: core.reload_tx,
         command_tx: core.command_tx,
         file_registry: spawned.file_registry,
@@ -497,6 +500,9 @@ async fn graceful_shutdown(rt: &mut GatewayRuntime) {
     if let Some(tx) = rt.telegram_shutdown_tx.take() {
         tx.send(true).ok();
     }
+    if let Some(h) = rt.watcher_handle.take() {
+        h.abort();
+    }
     rt.http_shutdown_tx.send(true).ok();
     tracing::info!("graceful shutdown complete");
 }
@@ -552,6 +558,18 @@ async fn poll_handle(
             result
         }
         None => std::future::pending().await,
+    }
+}
+
+/// Logs an unexpected exit or failure of a background adapter task.
+///
+/// Shared by the `discord_handle`/`telegram_handle`/`watcher_handle` arms of
+/// `run_event_loop`, which only log on exit (unlike `tunnel_handle`, which
+/// also respawns).
+fn log_adapter_task_exit(task_name: &str, result: &Result<(), tokio::task::JoinError>) {
+    match result {
+        Ok(()) => tracing::error!("{task_name} task exited unexpectedly"),
+        Err(e) => tracing::error!(error = %e, "{task_name} task failed"),
     }
 }
 
@@ -697,17 +715,15 @@ async fn run_event_loop(mut rt: GatewayRuntime) -> GatewayExit {
             }
 
             result = poll_handle(&mut rt.discord_handle) => {
-                match &result {
-                    Ok(()) => tracing::error!("discord adapter task exited unexpectedly"),
-                    Err(e) => tracing::error!(error = %e, "discord adapter task failed"),
-                }
+                log_adapter_task_exit("discord adapter", &result);
             }
 
             result = poll_handle(&mut rt.telegram_handle) => {
-                match &result {
-                    Ok(()) => tracing::error!("telegram adapter task exited unexpectedly"),
-                    Err(e) => tracing::error!(error = %e, "telegram adapter task failed"),
-                }
+                log_adapter_task_exit("telegram adapter", &result);
+            }
+
+            result = poll_handle(&mut rt.watcher_handle) => {
+                log_adapter_task_exit("workspace watcher", &result);
             }
         }
     }

--- a/src/gateway/event_loop/turns.rs
+++ b/src/gateway/event_loop/turns.rs
@@ -276,11 +276,83 @@ async fn maybe_nudge_learner(rt: &mut GatewayRuntime) {
     }
 }
 
+/// Publish a `TurnLifecycleEvent::Ended` closing the turn on an endpoint.
+async fn publish_turn_ended(publisher: &Publisher, endpoint: &EndpointName, correlation_id: &str) {
+    if let Err(e) = publisher
+        .publish(
+            topics::Endpoint(endpoint.clone()),
+            TurnLifecycleEvent::Ended {
+                correlation_id: correlation_id.to_string(),
+            },
+        )
+        .await
+    {
+        tracing::warn!(error = %e, "failed to publish turn ended event");
+    }
+}
+
+/// Translate a completed turn's result into the bus events clients observe.
+///
+/// On success, emits one `ResponseEvent` per reply text to the output endpoint,
+/// then closes the turn with `TurnLifecycleEvent::Ended`. When there is no output
+/// endpoint (e.g. a background turn with no prior user endpoint), success publishes
+/// nothing.
+///
+/// On failure, logs the error, broadcasts an `ErrorEvent` on the system
+/// notification channel regardless of output endpoint, and — if there is an output
+/// endpoint — still closes the turn with `Ended`.
+async fn publish_turn_outcome(
+    turn_result: anyhow::Result<Vec<String>>,
+    publisher: &Publisher,
+    output_endpoint: Option<&EndpointName>,
+    correlation_id: &str,
+    tz: chrono_tz::Tz,
+) {
+    match turn_result {
+        Ok(texts) => {
+            let Some(ep) = output_endpoint else {
+                return;
+            };
+            for text in &texts {
+                if let Err(e) = publisher
+                    .publish(
+                        topics::Endpoint(ep.clone()),
+                        ResponseEvent {
+                            correlation_id: correlation_id.to_string(),
+                            content: text.clone(),
+                            timestamp: crate::time::now_local(tz),
+                            attachment: None,
+                        },
+                    )
+                    .await
+                {
+                    tracing::warn!(error = %e, "failed to publish response event");
+                }
+            }
+            publish_turn_ended(publisher, ep, correlation_id).await;
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "agent processing error");
+            if let Err(pub_err) = publisher
+                .publish(
+                    topics::Notification(NotifyName::from(SYSTEM_CHANNEL)),
+                    ErrorEvent {
+                        correlation_id: correlation_id.to_string(),
+                        message: e.to_string(),
+                    },
+                )
+                .await
+            {
+                tracing::warn!(error = %pub_err, "failed to publish agent error event");
+            }
+            if let Some(ep) = output_endpoint {
+                publish_turn_ended(publisher, ep, correlation_id).await;
+            }
+        }
+    }
+}
+
 /// Handle an inbound user message: run agent turn, persist, observe, and process leftovers.
-#[expect(
-    clippy::too_many_lines,
-    reason = "needs refactor — extract turn result publishing"
-)]
 #[tracing::instrument(skip_all, fields(correlation_id = %message.id, origin = %message.origin.endpoint))]
 pub async fn handle_inbound_message(
     message: InboundMessage,
@@ -349,70 +421,14 @@ pub async fn handle_inbound_message(
     )
     .await;
 
-    match turn_result {
-        Ok(texts) => {
-            if let Some(ref ep) = output_endpoint {
-                for text in &texts {
-                    if let Err(e) = rt
-                        .publisher
-                        .publish(
-                            topics::Endpoint(ep.clone()),
-                            ResponseEvent {
-                                correlation_id: reply_id.clone(),
-                                content: text.clone(),
-                                timestamp: crate::time::now_local(rt.tz),
-                                attachment: None,
-                            },
-                        )
-                        .await
-                    {
-                        tracing::warn!(error = %e, "failed to publish response event");
-                    }
-                }
-                if let Err(e) = rt
-                    .publisher
-                    .publish(
-                        topics::Endpoint(ep.clone()),
-                        TurnLifecycleEvent::Ended {
-                            correlation_id: reply_id.clone(),
-                        },
-                    )
-                    .await
-                {
-                    tracing::warn!(error = %e, "failed to publish turn ended event");
-                }
-            }
-        }
-        Err(e) => {
-            tracing::error!(error = %e, "agent processing error");
-            if let Err(pub_err) = rt
-                .publisher
-                .publish(
-                    topics::Notification(NotifyName::from(SYSTEM_CHANNEL)),
-                    ErrorEvent {
-                        correlation_id: reply_id.clone(),
-                        message: e.to_string(),
-                    },
-                )
-                .await
-            {
-                tracing::warn!(error = %pub_err, "failed to publish agent error event");
-            }
-            if let Some(ref ep) = output_endpoint
-                && let Err(end_err) = rt
-                    .publisher
-                    .publish(
-                        topics::Endpoint(ep.clone()),
-                        TurnLifecycleEvent::Ended {
-                            correlation_id: reply_id.clone(),
-                        },
-                    )
-                    .await
-            {
-                tracing::warn!(error = %end_err, "failed to publish turn ended event");
-            }
-        }
-    }
+    publish_turn_outcome(
+        turn_result,
+        &rt.publisher,
+        output_endpoint.as_ref(),
+        &reply_id,
+        rt.tz,
+    )
+    .await;
 
     let visibility = if is_background {
         Visibility::Background

--- a/src/gateway/event_loop/turns.rs
+++ b/src/gateway/event_loop/turns.rs
@@ -460,3 +460,172 @@ pub async fn handle_inbound_message(
         *idle_deadline = Some(now + rt.cfg.idle.timeout);
     }
 }
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "test code uses unwrap for clarity")]
+mod tests {
+    use super::*;
+    use crate::bus::Subscriber;
+    use std::time::Duration;
+
+    const TEST_TZ: chrono_tz::Tz = chrono_tz::Tz::UTC;
+
+    fn endpoint() -> EndpointName {
+        EndpointName::from("ws")
+    }
+
+    /// Assert a subscriber receives no event within a short window, proving the
+    /// unit published nothing on that topic/type.
+    async fn assert_no_event<E: Clone + Send + Sync + 'static>(sub: &mut Subscriber<E>) {
+        let recv = tokio::time::timeout(Duration::from_millis(50), sub.recv()).await;
+        assert!(recv.is_err(), "expected no event, but one was published");
+    }
+
+    #[tokio::test]
+    async fn ok_publishes_one_response_per_text_then_ends_turn() {
+        let handle = crate::bus::spawn_broker();
+        let publisher = handle.publisher();
+        let mut responses: Subscriber<ResponseEvent> = handle
+            .subscribe(topics::Endpoint(endpoint()))
+            .await
+            .unwrap();
+        let mut lifecycle: Subscriber<TurnLifecycleEvent> = handle
+            .subscribe(topics::Endpoint(endpoint()))
+            .await
+            .unwrap();
+
+        publish_turn_outcome(
+            Ok(vec!["first".into(), "second".into()]),
+            &publisher,
+            Some(&endpoint()),
+            "corr-1",
+            TEST_TZ,
+        )
+        .await;
+
+        let first = responses.recv().await.unwrap().unwrap();
+        assert_eq!(first.content, "first");
+        assert_eq!(first.correlation_id, "corr-1");
+        assert!(first.attachment.is_none());
+        let second = responses.recv().await.unwrap().unwrap();
+        assert_eq!(second.content, "second");
+
+        let ended = lifecycle.recv().await.unwrap().unwrap();
+        assert!(
+            matches!(ended, TurnLifecycleEvent::Ended { correlation_id } if correlation_id == "corr-1")
+        );
+    }
+
+    #[tokio::test]
+    async fn ok_with_no_texts_still_ends_turn() {
+        let handle = crate::bus::spawn_broker();
+        let publisher = handle.publisher();
+        let mut responses: Subscriber<ResponseEvent> = handle
+            .subscribe(topics::Endpoint(endpoint()))
+            .await
+            .unwrap();
+        let mut lifecycle: Subscriber<TurnLifecycleEvent> = handle
+            .subscribe(topics::Endpoint(endpoint()))
+            .await
+            .unwrap();
+
+        publish_turn_outcome(Ok(vec![]), &publisher, Some(&endpoint()), "corr-2", TEST_TZ).await;
+
+        let ended = lifecycle.recv().await.unwrap().unwrap();
+        assert!(
+            matches!(ended, TurnLifecycleEvent::Ended { correlation_id } if correlation_id == "corr-2")
+        );
+        assert_no_event(&mut responses).await;
+    }
+
+    #[tokio::test]
+    async fn ok_without_output_endpoint_publishes_nothing() {
+        let handle = crate::bus::spawn_broker();
+        let publisher = handle.publisher();
+        let mut responses: Subscriber<ResponseEvent> = handle
+            .subscribe(topics::Endpoint(endpoint()))
+            .await
+            .unwrap();
+        let mut lifecycle: Subscriber<TurnLifecycleEvent> = handle
+            .subscribe(topics::Endpoint(endpoint()))
+            .await
+            .unwrap();
+
+        publish_turn_outcome(
+            Ok(vec!["ignored".into()]),
+            &publisher,
+            None,
+            "corr-3",
+            TEST_TZ,
+        )
+        .await;
+
+        assert_no_event(&mut responses).await;
+        assert_no_event(&mut lifecycle).await;
+    }
+
+    #[tokio::test]
+    async fn err_broadcasts_error_event_and_ends_turn() {
+        let handle = crate::bus::spawn_broker();
+        let publisher = handle.publisher();
+        let mut errors: Subscriber<ErrorEvent> = handle
+            .subscribe(topics::Notification(NotifyName::from(SYSTEM_CHANNEL)))
+            .await
+            .unwrap();
+        let mut responses: Subscriber<ResponseEvent> = handle
+            .subscribe(topics::Endpoint(endpoint()))
+            .await
+            .unwrap();
+        let mut lifecycle: Subscriber<TurnLifecycleEvent> = handle
+            .subscribe(topics::Endpoint(endpoint()))
+            .await
+            .unwrap();
+
+        publish_turn_outcome(
+            Err(anyhow::anyhow!("boom")),
+            &publisher,
+            Some(&endpoint()),
+            "corr-4",
+            TEST_TZ,
+        )
+        .await;
+
+        let error = errors.recv().await.unwrap().unwrap();
+        assert_eq!(error.correlation_id, "corr-4");
+        assert_eq!(error.message, "boom");
+
+        let ended = lifecycle.recv().await.unwrap().unwrap();
+        assert!(
+            matches!(ended, TurnLifecycleEvent::Ended { correlation_id } if correlation_id == "corr-4")
+        );
+        assert_no_event(&mut responses).await;
+    }
+
+    #[tokio::test]
+    async fn err_without_output_endpoint_still_broadcasts_error_without_ending_turn() {
+        let handle = crate::bus::spawn_broker();
+        let publisher = handle.publisher();
+        let mut errors: Subscriber<ErrorEvent> = handle
+            .subscribe(topics::Notification(NotifyName::from(SYSTEM_CHANNEL)))
+            .await
+            .unwrap();
+        let mut lifecycle: Subscriber<TurnLifecycleEvent> = handle
+            .subscribe(topics::Endpoint(endpoint()))
+            .await
+            .unwrap();
+
+        publish_turn_outcome(
+            Err(anyhow::anyhow!("kaboom")),
+            &publisher,
+            None,
+            "corr-5",
+            TEST_TZ,
+        )
+        .await;
+
+        let error = errors.recv().await.unwrap().unwrap();
+        assert_eq!(error.correlation_id, "corr-5");
+        assert_eq!(error.message, "kaboom");
+        assert_no_event(&mut lifecycle).await;
+    }
+}

--- a/src/gateway/protocol.rs
+++ b/src/gateway/protocol.rs
@@ -53,6 +53,14 @@ pub enum ServerMessage {
         /// Correlation ID of the message being processed.
         reply_to: String,
     },
+    /// The agent turn has finished (success or error), whether or not any
+    /// response text was produced. Marks the end of a turn that a
+    /// `TurnStarted` opened, so clients can stop waiting even when the turn
+    /// yielded zero `Response` frames (e.g. an interrupted or tool-only turn).
+    TurnEnded {
+        /// Correlation ID of the message whose turn just completed.
+        reply_to: String,
+    },
     /// A tool was invoked during the agent turn (verbose only).
     ToolCall {
         /// Unique tool call ID for correlating with results.
@@ -214,6 +222,22 @@ mod tests {
         assert!(
             matches!(msg, ClientMessage::Reload),
             "should deserialize to Reload"
+        );
+    }
+
+    #[test]
+    fn server_message_serialize_turn_ended() {
+        let msg = ServerMessage::TurnEnded {
+            reply_to: "id-1".to_string(),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(
+            json.contains("\"type\":\"turn_ended\""),
+            "should have type tag"
+        );
+        assert!(
+            json.contains("\"reply_to\":\"id-1\""),
+            "should have reply_to field"
         );
     }
 

--- a/src/gateway/reload.rs
+++ b/src/gateway/reload.rs
@@ -59,6 +59,8 @@ pub(super) struct ConfigDiff {
     pub cloud_changed: bool,
     /// Tracing config changed (log level, endpoints, sanitization, error reporting).
     pub tracing_changed: bool,
+    /// HTTP request timeout (`timeout_secs`) changed.
+    pub http_timeout_changed: bool,
 }
 
 impl ConfigDiff {
@@ -112,6 +114,9 @@ impl ConfigDiff {
         if self.tracing_changed {
             parts.push("tracing");
         }
+        if self.http_timeout_changed {
+            parts.push("http timeout");
+        }
         if parts.is_empty() {
             "no changes detected".to_string()
         } else {
@@ -147,6 +152,7 @@ pub(super) fn diff_config(old: &Config, new: &Config) -> ConfigDiff {
         idle_changed: old.idle != new.idle,
         cloud_changed: old.cloud != new.cloud,
         tracing_changed: old.tracing != new.tracing,
+        http_timeout_changed: old.timeout_secs != new.timeout_secs,
     }
 }
 
@@ -252,7 +258,17 @@ pub(super) async fn handle_root_reload(rt: &mut GatewayRuntime) -> IdleAction {
 
     let summary = diff.summary();
 
-    if diff.providers_changed {
+    // Rebuild the shared HTTP client first, before anything that clones it —
+    // `SharedHttpClient::clone` shares the old `Arc<reqwest::Client>`, so a
+    // provider chain, the subconscious classifier, or the spawn context built
+    // before this point would silently keep the stale timeout forever.
+    let http_client_rebuilt = if diff.http_timeout_changed {
+        reload_http_client(rt, &new_cfg).await
+    } else {
+        false
+    };
+
+    if diff.providers_changed || http_client_rebuilt {
         reload_providers(rt, &new_cfg).await;
     }
     if diff.memory_changed {
@@ -274,10 +290,12 @@ pub(super) async fn handle_root_reload(rt: &mut GatewayRuntime) -> IdleAction {
         rt.pulse_enabled = new_cfg.pulse_enabled;
         tracing::info!(enabled = new_cfg.pulse_enabled, "pulse toggle updated");
     }
-    if diff.subconscious_changed || diff.providers_changed {
+    if diff.subconscious_changed || diff.providers_changed || http_client_rebuilt {
         // Full rebuild: in-flight evaluations keep the old Arc, new turns get
         // the new instance. Provider changes are included because the
-        // subconscious chain may fall back to main.
+        // subconscious chain may fall back to main; an HTTP client rebuild is
+        // included so the subconscious classifier doesn't keep the stale
+        // timeout via its old client clone.
         rt.subconscious =
             crate::subconscious::Subconscious::build(&new_cfg, &rt.layout, rt.http_client.clone());
         tracing::info!(
@@ -285,7 +303,9 @@ pub(super) async fn handle_root_reload(rt: &mut GatewayRuntime) -> IdleAction {
             "subconscious rebuilt from new config"
         );
     }
-    if diff.background_changed && !diff.providers_changed {
+    if diff.background_changed && !diff.providers_changed && !http_client_rebuilt {
+        // Otherwise `reload_providers` above already rebuilt `spawn_context`
+        // with the current http client.
         reload_background_config(rt, &new_cfg);
     }
     if diff.skills_changed {
@@ -353,6 +373,38 @@ fn build_spawn_context(rt: &GatewayRuntime, new_cfg: &Config) -> Arc<SpawnContex
         action_notify: Arc::clone(&rt.action_notify),
         hybrid_searcher: Arc::clone(&rt.hybrid_searcher),
     })
+}
+
+/// Rebuild the shared HTTP client with the new `timeout_secs`.
+///
+/// Returns `true` if the client was rebuilt and swapped in, so callers can
+/// force-refresh anything holding a stale clone (providers, subconscious,
+/// spawn context). On failure the current client is kept and the timeout
+/// change silently does not take effect — this is surfaced to the user via
+/// `publish_notice` rather than failing loudly, matching how the neighboring
+/// reload steps in this module degrade (e.g. `reload_providers`,
+/// `reload_gateway`).
+async fn reload_http_client(rt: &mut GatewayRuntime, new_cfg: &Config) -> bool {
+    let client_config = crate::models::HttpClientConfig::with_timeout(new_cfg.timeout_secs);
+    match crate::models::SharedHttpClient::new(&client_config) {
+        Ok(client) => {
+            rt.http_client = client;
+            tracing::info!(
+                timeout_secs = new_cfg.timeout_secs,
+                "http client rebuilt with new timeout"
+            );
+            true
+        }
+        Err(err) => {
+            tracing::warn!(error = %err, "http client rebuild failed, keeping current timeout");
+            publish_notice(
+                &rt.publisher,
+                format!("timeout_secs change failed to apply (keeping current timeout): {err}"),
+            )
+            .await;
+            false
+        }
+    }
 }
 
 /// Rebuild providers and swap them into the runtime.
@@ -720,6 +772,7 @@ mod tests {
         assert!(!diff.agent_changed);
         assert!(!diff.skills_changed);
         assert!(!diff.idle_changed);
+        assert!(!diff.http_timeout_changed);
         assert!(diff.is_empty());
     }
 
@@ -874,6 +927,31 @@ mod tests {
         let cfg = test_config();
         let diff = diff_config(&cfg, &cfg);
         assert!(!diff.idle_changed);
+    }
+
+    #[test]
+    fn diff_config_detects_http_timeout_change() {
+        let old = test_config();
+        let mut new = old.clone();
+        new.timeout_secs = 90;
+
+        let diff = diff_config(&old, &new);
+        assert!(
+            diff.http_timeout_changed,
+            "timeout_secs change should be detected"
+        );
+        assert!(
+            !diff.providers_changed,
+            "timeout_secs alone should not flag providers"
+        );
+        assert!(diff.summary().contains("http timeout"));
+    }
+
+    #[test]
+    fn diff_config_no_http_timeout_change() {
+        let cfg = test_config();
+        let diff = diff_config(&cfg, &cfg);
+        assert!(!diff.http_timeout_changed);
     }
 
     #[test]

--- a/src/gateway/startup/mod.rs
+++ b/src/gateway/startup/mod.rs
@@ -424,6 +424,14 @@ pub(crate) async fn initialize(
     let (tools, tool_filter, path_policy_for_runtime, output_topic_override_tx) =
         tools::init_tool_registry(cfg, &layout, &mem, tz, &tool_deps);
 
+    // Reserve the built-in tool namespace so any MCP tool (workspace, web
+    // search, or project-scoped) that reuses a built-in name is shadowed
+    // visibly instead of silently. See src/mcp/CLAUDE.md.
+    mcp_registry
+        .write()
+        .await
+        .set_reserved_tool_names(tools.tool_names());
+
     let agent = tools::create_agent(
         CreateAgentArgs {
             provider: providers.provider,

--- a/src/gateway/types.rs
+++ b/src/gateway/types.rs
@@ -95,8 +95,14 @@ pub struct ServerCommand {
     pub name: String,
     /// Optional argument text.
     pub args: Option<String>,
-    /// Optional oneshot sender for commands that return a response (e.g. "context").
-    pub reply_tx: Option<tokio::sync::oneshot::Sender<String>>,
+    /// Optional oneshot sender for routing a response back to the sender only.
+    ///
+    /// `Ok` carries a successful command's reply text (e.g. "context"); the
+    /// WS layer intentionally ignores it since the outcome is already
+    /// reflected via the normal bus broadcast. `Err` carries a rejection
+    /// reason (e.g. an unknown command name) and is routed to the sender as
+    /// an error, never broadcast to other clients.
+    pub reply_tx: Option<tokio::sync::oneshot::Sender<Result<String, String>>>,
 }
 
 /// Long-lived core that owns shared communication channels.

--- a/src/gateway/types.rs
+++ b/src/gateway/types.rs
@@ -228,6 +228,7 @@ pub(crate) struct GatewayRuntime {
     pub telegram_handle: Option<tokio::task::JoinHandle<()>>,
     pub discord_shutdown_tx: Option<tokio::sync::watch::Sender<bool>>,
     pub telegram_shutdown_tx: Option<tokio::sync::watch::Sender<bool>>,
+    pub watcher_handle: Option<tokio::task::JoinHandle<()>>,
     /// Cloned core senders for rebuilding adapters on reload.
     pub reload_tx: tokio::sync::watch::Sender<ReloadSignal>,
     pub command_tx: mpsc::Sender<ServerCommand>,

--- a/src/gateway/web/workspace.rs
+++ b/src/gateway/web/workspace.rs
@@ -8,6 +8,7 @@ use axum::response::Json;
 use serde::{Deserialize, Serialize};
 
 use crate::gateway::ReloadSignal;
+use crate::pulse::types::HeartbeatConfig;
 
 use super::ConfigApiState;
 
@@ -39,7 +40,7 @@ pub(super) struct WriteFileRequest {
 }
 
 /// Response from `PUT /api/workspace/file`.
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 pub(super) struct WriteResponse {
     pub saved: bool,
 }
@@ -180,6 +181,17 @@ fn is_identity_file(relative: &str) -> bool {
     IDENTITY_FILES.contains(&file_name)
 }
 
+/// Returns true if the path refers to the pulse scheduler's `HEARTBEAT.yml`.
+///
+/// Checks the file name only (ignoring leading directory components), matching
+/// how `is_identity_file` recognises identity files.
+fn is_heartbeat_file(relative: &str) -> bool {
+    Path::new(relative)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(|name| name == "HEARTBEAT.yml")
+}
+
 /// `GET /api/workspace/files` — list directory contents inside the workspace.
 ///
 /// Defaults to the workspace root when no `path` query parameter is provided.
@@ -316,6 +328,11 @@ pub(super) async fn api_workspace_file_read(
 /// Creates the file if it does not exist. If the written file is a workspace
 /// identity file and a reload channel is available, sends a `Workspace` reload
 /// signal.
+///
+/// Writes to `HEARTBEAT.yml` are validated as parseable `HeartbeatConfig` YAML
+/// before being accepted: the pulse scheduler hot-reloads this file on every
+/// tick, so an unvalidated write that saves broken YAML would silently stop
+/// every scheduled pulse from firing while reporting success to the caller.
 pub(super) async fn api_workspace_file_write(
     State(state): State<ConfigApiState>,
     Json(req): Json<WriteFileRequest>,
@@ -326,6 +343,19 @@ pub(super) async fn api_workspace_file_write(
         return Err((
             StatusCode::FORBIDDEN,
             "access to this path is blocked".to_string(),
+        ));
+    }
+
+    if is_heartbeat_file(relative)
+        && let Err(e) = serde_yaml_ng::from_str::<HeartbeatConfig>(&req.content)
+    {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!(
+                "invalid HEARTBEAT.yml: {e}; fix the yaml before saving — this file is \
+                 hot-reloaded by the pulse scheduler, so invalid content would silently \
+                 stop all scheduled pulses from firing"
+            ),
         ));
     }
 
@@ -525,5 +555,71 @@ mod tests {
             traversal_result.is_err(),
             "path traversal should be rejected for new file write"
         );
+    }
+
+    #[test]
+    fn heartbeat_file_recognised() {
+        assert!(is_heartbeat_file("HEARTBEAT.yml"));
+        assert!(is_heartbeat_file("subdir/HEARTBEAT.yml"));
+        assert!(!is_heartbeat_file("SOUL.md"));
+        assert!(!is_heartbeat_file("not_HEARTBEAT.yml.txt"));
+    }
+
+    #[tokio::test]
+    async fn workspace_file_write_rejects_invalid_heartbeat_yaml() {
+        use axum::Json;
+        use axum::extract::State;
+
+        let dir = tempfile::tempdir().unwrap();
+        let ws_dir = dir.path().join("workspace");
+        std::fs::create_dir_all(&ws_dir).unwrap();
+        std::fs::write(ws_dir.join("HEARTBEAT.yml"), "pulses: []").unwrap();
+
+        let state = super::super::ConfigApiState {
+            config_dir: dir.path().to_path_buf(),
+            workspace_dir: ws_dir.clone(),
+            memory_dir: None,
+            reload_tx: None,
+            setup_done: None,
+            secret_lock: std::sync::Arc::new(tokio::sync::Mutex::new(())),
+        };
+
+        // Malformed YAML must be rejected, not silently accepted with `{"saved": true}` —
+        // the pulse scheduler hot-reloads this file every tick, so an unvalidated write
+        // that breaks the YAML would silently stop every scheduled pulse from firing.
+        let result = api_workspace_file_write(
+            State(state.clone()),
+            Json(WriteFileRequest {
+                path: "HEARTBEAT.yml".to_string(),
+                content: "not: valid: yaml: [[[".to_string(),
+            }),
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "invalid HEARTBEAT.yml content should be rejected"
+        );
+        let (status, _) = result.unwrap_err();
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+
+        // The on-disk file must be untouched by the rejected write.
+        let unchanged = std::fs::read_to_string(ws_dir.join("HEARTBEAT.yml")).unwrap();
+        assert_eq!(
+            unchanged, "pulses: []",
+            "rejected write should not modify the existing file"
+        );
+
+        // Valid YAML should still be accepted.
+        let ok_result = api_workspace_file_write(
+            State(state.clone()),
+            Json(WriteFileRequest {
+                path: "HEARTBEAT.yml".to_string(),
+                content: "pulses:\n  - name: test\n    schedule: \"1h\"\n    tasks: []\n"
+                    .to_string(),
+            }),
+        )
+        .await
+        .unwrap();
+        assert!(ok_result.0.saved);
     }
 }

--- a/src/gateway/ws.rs
+++ b/src/gateway/ws.rs
@@ -196,11 +196,7 @@ async fn handle_client_message(
         }
         ClientMessage::Reload => {
             tracing::info!("reload requested by client");
-            local_tx
-                .send(ServerMessage::Notice {
-                    message: "reloading configuration...".to_string(),
-                })
-                .ok();
+            local_tx.send(ServerMessage::Reloading).ok();
             state
                 .reload_tx
                 .send(crate::gateway::types::ReloadSignal::Root)
@@ -208,15 +204,31 @@ async fn handle_client_message(
         }
         ClientMessage::ServerCommand { name, args } => {
             tracing::info!(command = %name, "server command from client");
+            let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
             state
                 .command_tx
                 .send(crate::gateway::types::ServerCommand {
                     name,
                     args,
-                    reply_tx: None,
+                    reply_tx: Some(reply_tx),
                 })
                 .await
                 .ok();
+
+            // Successful commands are already reflected via the normal bus
+            // broadcast (e.g. Notice/InlineOutput); only a rejection needs
+            // routing back here, scoped to this connection only.
+            let err_tx = local_tx.clone();
+            tokio::spawn(async move {
+                if let Ok(Err(reason)) = reply_rx.await {
+                    err_tx
+                        .send(ServerMessage::Error {
+                            reply_to: None,
+                            message: reason,
+                        })
+                        .ok();
+                }
+            });
         }
         ClientMessage::InboxAdd { body } => {
             tracing::info!("inbox add requested by client");

--- a/src/interfaces/cli/colors.rs
+++ b/src/interfaces/cli/colors.rs
@@ -1,11 +1,14 @@
 //! Terminal color theme with `NO_COLOR` support.
 
+use std::io::IsTerminal;
+
 use owo_colors::OwoColorize;
 
 /// Color theme for CLI output.
 ///
-/// Respects the `NO_COLOR` environment variable. When `NO_COLOR` is set,
-/// all formatting methods return plain unmodified text.
+/// Respects the `NO_COLOR` environment variable and disables color when
+/// stdout isn't a terminal. When either is true, all formatting methods
+/// return plain unmodified text.
 pub struct Theme {
     color_enabled: bool,
 }
@@ -13,10 +16,13 @@ pub struct Theme {
 impl Theme {
     /// Detect terminal color support.
     ///
-    /// Returns a theme with colors disabled if `NO_COLOR` is set.
+    /// Returns a theme with colors disabled if `NO_COLOR` is set, or if
+    /// stdout is not a terminal (e.g. piped into `jq` or redirected to a
+    /// file) — otherwise ANSI escape codes would corrupt piped output.
     #[must_use]
     pub fn detect() -> Self {
-        let color_enabled = std::env::var_os("NO_COLOR").is_none();
+        let no_color_requested = std::env::var_os("NO_COLOR").is_some();
+        let color_enabled = !no_color_requested && std::io::stdout().is_terminal();
         Self { color_enabled }
     }
 
@@ -217,9 +223,12 @@ mod tests {
         // SAFETY: test-only, single-threaded test environment
         unsafe { std::env::remove_var("NO_COLOR") };
         let theme_without_no_color = Theme::detect();
-        assert!(
+        // Test runners capture stdout, so it's not a terminal here; detect()
+        // should track std::io::IsTerminal rather than force color on.
+        assert_eq!(
             theme_without_no_color.color_enabled(),
-            "detect() should enable color when NO_COLOR is absent"
+            std::io::stdout().is_terminal(),
+            "detect() should only enable color when NO_COLOR is absent and stdout is a terminal"
         );
     }
 }

--- a/src/interfaces/cli/commands.rs
+++ b/src/interfaces/cli/commands.rs
@@ -86,7 +86,8 @@ struct CommandDef {
     help: &'static str,
     takes_arg: bool,
     cli_only: bool,
-    effect: fn(arg: Option<&str>, url: &str, verbose: bool) -> CommandEffect,
+    effect:
+        fn(arg: Option<&str>, url: &str, verbose: bool, include_cli_only: bool) -> CommandEffect,
 }
 
 static COMMANDS: &[CommandDef] = &[
@@ -95,35 +96,35 @@ static COMMANDS: &[CommandDef] = &[
         help: "show this help",
         takes_arg: false,
         cli_only: false,
-        effect: |_, _, _| CommandEffect::PrintLocal(help_text()),
+        effect: |_, _, _, include_cli_only| CommandEffect::PrintLocal(help_text(include_cli_only)),
     },
     CommandDef {
         names: &["status"],
         help: "show connection info",
         takes_arg: false,
         cli_only: false,
-        effect: |_, url, verbose| CommandEffect::PrintLocal(status_text(url, verbose)),
+        effect: |_, url, verbose, _| CommandEffect::PrintLocal(status_text(url, verbose)),
     },
     CommandDef {
         names: &["verbose", "v"],
         help: "toggle verbose mode (tool events)",
         takes_arg: false,
         cli_only: true,
-        effect: |_, _, _| CommandEffect::ToggleVerbose,
+        effect: |_, _, _, _| CommandEffect::ToggleVerbose,
     },
     CommandDef {
         names: &["reload", "r"],
         help: "reload server configuration",
         takes_arg: false,
         cli_only: false,
-        effect: |_, _, _| CommandEffect::Reload,
+        effect: |_, _, _, _| CommandEffect::Reload,
     },
     CommandDef {
         names: &["observe", "obs"],
         help: "force a memory observation cycle",
         takes_arg: false,
         cli_only: false,
-        effect: |_, _, _| CommandEffect::ServerCommand {
+        effect: |_, _, _, _| CommandEffect::ServerCommand {
             name: "observe",
             args: None,
         },
@@ -133,7 +134,7 @@ static COMMANDS: &[CommandDef] = &[
         help: "force a reflection cycle",
         takes_arg: false,
         cli_only: false,
-        effect: |_, _, _| CommandEffect::ServerCommand {
+        effect: |_, _, _, _| CommandEffect::ServerCommand {
             name: "reflect",
             args: None,
         },
@@ -143,7 +144,7 @@ static COMMANDS: &[CommandDef] = &[
         help: "show context token usage",
         takes_arg: false,
         cli_only: false,
-        effect: |_, _, _| CommandEffect::ServerCommand {
+        effect: |_, _, _, _| CommandEffect::ServerCommand {
             name: "context",
             args: None,
         },
@@ -153,7 +154,7 @@ static COMMANDS: &[CommandDef] = &[
         help: "add a message to the agent's inbox",
         takes_arg: true,
         cli_only: false,
-        effect: |arg, _, _| match arg {
+        effect: |arg, _, _, _| match arg {
             Some(body) if !body.is_empty() => CommandEffect::InboxAdd(body.to_string()),
             _ => CommandEffect::PrintLocal("usage: /inbox <text>".to_string()),
         },
@@ -163,7 +164,7 @@ static COMMANDS: &[CommandDef] = &[
         help: "disconnect and exit",
         takes_arg: false,
         cli_only: true,
-        effect: |_, _, _| CommandEffect::Quit,
+        effect: |_, _, _, _| CommandEffect::Quit,
     },
 ];
 
@@ -185,7 +186,8 @@ pub fn parse_command(input: &str, url: &str, verbose: bool) -> Option<CommandEff
             } else {
                 None
             };
-            return Some((def.effect)(arg, url, verbose));
+            // This is the CLI's own command loop, so CLI-only commands (e.g. /quit) are real here.
+            return Some((def.effect)(arg, url, verbose, true));
         }
     }
 
@@ -203,7 +205,9 @@ pub fn parse_command(input: &str, url: &str, verbose: bool) -> Option<CommandEff
 pub fn execute_command(name: &str, args: Option<&str>, ctx: &CommandContext<'_>) -> CommandResult {
     for def in COMMANDS {
         if def.names.contains(&name) {
-            let effect = (def.effect)(args, ctx.url, ctx.verbose);
+            // Only Discord and Telegram call this entry point, and neither wires up
+            // CLI-only side effects (Quit, ToggleVerbose), so /help must not advertise them.
+            let effect = (def.effect)(args, ctx.url, ctx.verbose, false);
             return effect_to_result(effect);
         }
     }
@@ -261,9 +265,18 @@ pub fn all_commands() -> impl Iterator<Item = CommandInfo> {
     })
 }
 
-fn help_text() -> String {
+/// Build the `/help` response text.
+///
+/// `include_cli_only` gates commands like `/quit` and `/verbose` whose side
+/// effects only the CLI client applies (see `CommandSideEffect`); Discord and
+/// Telegram silently ignore those effects, so listing them there would be
+/// misleading.
+fn help_text(include_cli_only: bool) -> String {
     let mut lines = vec!["Available commands:".to_string()];
-    for def in COMMANDS {
+    for def in COMMANDS
+        .iter()
+        .filter(|def| include_cli_only || !def.cli_only)
+    {
         let aliases = def.names.join(", /");
         let arg_hint = if def.takes_arg { " <text>" } else { "" };
         lines.push(format!(
@@ -463,13 +476,35 @@ mod tests {
     }
 
     #[test]
-    fn help_text_contains_all_commands() {
-        let text = help_text();
+    fn help_text_contains_all_commands_when_cli_only_included() {
+        let text = help_text(true);
         for def in COMMANDS {
             for name in def.names {
                 assert!(text.contains(name), "help text should mention /{name}");
             }
         }
+    }
+
+    #[test]
+    fn help_text_excludes_cli_only_commands_when_not_included() {
+        let text = help_text(false);
+        for def in COMMANDS.iter().filter(|def| def.cli_only) {
+            for name in def.names {
+                assert!(
+                    !text.contains(&format!("/{name}")),
+                    "help text should not mention CLI-only /{name} on non-CLI surfaces"
+                );
+            }
+        }
+        // Non-CLI-only commands must still be listed.
+        assert!(
+            text.contains("help"),
+            "help text should still mention /help"
+        );
+        assert!(
+            text.contains("observe"),
+            "help text should still mention /observe"
+        );
     }
 
     // ── execute_command tests ─────────────────────────────────────────

--- a/src/interfaces/cli/mod.rs
+++ b/src/interfaces/cli/mod.rs
@@ -167,6 +167,11 @@ impl CliClient {
                 };
                 println!("{}", self.theme.format_tool(&line));
             }
+            ServerMessage::TurnEnded { .. } => {
+                // No text to render; this exists so turns with zero Response
+                // frames (interrupted or tool-only) still clear the indicator.
+                self.indicator.finish();
+            }
             // Reloading is intercepted in run_connect before display() is called
             ServerMessage::Pong | ServerMessage::Reloading => {}
         }
@@ -322,6 +327,22 @@ mod tests {
         assert!(
             !client.indicator.is_active(),
             "Response should deactivate indicator"
+        );
+    }
+
+    #[test]
+    fn display_turn_ended_clears_indicator() {
+        let mut client = CliClient::new("ws://localhost:7700/ws", false);
+        client.display(&ServerMessage::TurnStarted {
+            reply_to: "c1".into(),
+        });
+        assert!(client.indicator.is_active());
+        client.display(&ServerMessage::TurnEnded {
+            reply_to: "c1".into(),
+        });
+        assert!(
+            !client.indicator.is_active(),
+            "TurnEnded should deactivate indicator even with no response text"
         );
     }
 

--- a/src/interfaces/cli/mod.rs
+++ b/src/interfaces/cli/mod.rs
@@ -81,6 +81,7 @@ impl CliClient {
         println!("{}", self.theme.format_banner(&banner));
         let http_url = ws_url_to_http(&self.url);
         println!("  web UI: {http_url}");
+        println!("  Type /help to see available commands.");
     }
 
     /// Display a server message with appropriate formatting.

--- a/src/interfaces/cli/reader.rs
+++ b/src/interfaces/cli/reader.rs
@@ -1,9 +1,16 @@
 //! CLI interface using rustyline for interactive input.
 
+use std::path::PathBuf;
+
 use rustyline::DefaultEditor;
 use rustyline::error::ReadlineError;
 
 use anyhow::Context;
+
+use crate::config::Config;
+
+/// Name of the input history file within the config directory.
+const HISTORY_FILE_NAME: &str = "cli_history";
 
 /// Reads user input interactively using rustyline.
 ///
@@ -11,16 +18,54 @@ use anyhow::Context;
 /// Sends input lines through a channel; dropping the sender signals EOF.
 pub struct CliReader {
     editor: DefaultEditor,
+    /// Where input history is loaded from and saved to. `None` if the config
+    /// directory couldn't be resolved, in which case history just isn't persisted.
+    history_path: Option<PathBuf>,
 }
 
 impl CliReader {
     /// Create a new `CliReader`.
     ///
+    /// Loads prior input history from `~/.residuum/cli_history` if present, so
+    /// up-arrow recall works across sessions. A missing history file (e.g. on
+    /// first run) is expected and not treated as an error.
+    ///
     /// # Errors
     /// Returns an error if the readline editor cannot be initialized.
     pub fn new() -> anyhow::Result<Self> {
-        let editor = DefaultEditor::new().context("failed to initialize readline")?;
-        Ok(Self { editor })
+        let mut editor = DefaultEditor::new().context("failed to initialize readline")?;
+
+        let history_path = match Config::config_dir() {
+            Ok(dir) => Some(dir.join(HISTORY_FILE_NAME)),
+            Err(e) => {
+                tracing::warn!(error = %e, "could not resolve config directory, CLI history will not persist");
+                None
+            }
+        };
+
+        if let Some(path) = &history_path
+            && let Err(ReadlineError::Io(e)) = editor.load_history(path)
+        {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                tracing::debug!(path = %path.display(), "no CLI history file yet, starting fresh");
+            } else {
+                tracing::warn!(error = %e, path = %path.display(), "failed to load CLI history");
+            }
+        }
+
+        Ok(Self {
+            editor,
+            history_path,
+        })
+    }
+
+    /// Save input history to disk, logging (not failing) on error.
+    fn save_history(&mut self) {
+        if let Some(path) = &self.history_path
+            && let Err(e) = self.editor.save_history(path)
+        {
+            tracing::warn!(error = %e, path = %path.display(), "failed to save CLI history");
+        }
     }
 
     /// Read lines from stdin and send them through `tx`.
@@ -50,22 +95,29 @@ impl CliReader {
                         continue;
                     }
                     if matches!(trimmed.as_str(), ":q" | ":quit") {
+                        self.save_history();
                         return;
                     }
                     if tx.blocking_send(trimmed).is_err() {
+                        self.save_history();
                         return; // main task exited
                     }
                     // Wait for the main loop to signal that the turn is done
                     if gate_rx.recv().is_err() {
+                        self.save_history();
                         return; // main task dropped the sender
                     }
                 }
-                Err(ReadlineError::Eof) => return,
+                Err(ReadlineError::Eof) => {
+                    self.save_history();
+                    return;
+                }
                 Err(ReadlineError::Interrupted) => {
                     // Ctrl+C: cancel current input, prompt again
                 }
                 Err(e) => {
                     tracing::error!(error = %e, "readline error, exiting input loop");
+                    self.save_history();
                     return;
                 }
             }

--- a/src/interfaces/mod.rs
+++ b/src/interfaces/mod.rs
@@ -82,7 +82,8 @@ pub(crate) async fn dispatch_server_command(
         tracing::warn!(command = %name, error = %e, "failed to dispatch server command");
     }
     match tokio::time::timeout(Duration::from_secs(10), reply_rx).await {
-        Ok(Ok(msg)) => msg,
+        Ok(Ok(Ok(msg))) => msg,
+        Ok(Ok(Err(reason))) => reason,
         Ok(Err(_)) => {
             tracing::warn!(command = %name, "server command reply channel closed before response");
             fallback

--- a/src/interfaces/webhook.rs
+++ b/src/interfaces/webhook.rs
@@ -38,7 +38,14 @@ pub struct WebhookState {
 ///
 /// Looks up the named webhook config, validates auth, extracts content per the
 /// webhook's format / content-fields settings, and publishes a `NotificationEvent`.
-/// Returns 404 for unknown names, 401 for bad auth, 202 on success.
+///
+/// Returns:
+/// - 202 on success
+/// - 404 if `name` doesn't match a configured webhook
+/// - 401 if the bearer token is missing or doesn't match the configured secret
+/// - 400 if the request body is empty, isn't valid JSON (when `content_fields` is
+///   configured), or matches none of the configured `content_fields`
+/// - 503 if the request was valid but publishing to the internal event bus failed
 #[tracing::instrument(skip_all, fields(webhook = %name, content_length = body.len()))]
 pub async fn webhook_handler(
     State(state): State<WebhookState>,
@@ -47,7 +54,7 @@ pub async fn webhook_handler(
     body: Bytes,
 ) -> impl IntoResponse {
     let Some(endpoint) = state.webhooks.get(&name) else {
-        return StatusCode::NOT_FOUND;
+        return (StatusCode::NOT_FOUND, format!("unknown webhook: {name}"));
     };
 
     tracing::debug!(webhook = %name, content_length = body.len(), "webhook request received");
@@ -62,7 +69,10 @@ pub async fn webhook_handler(
         let provided = auth.strip_prefix("Bearer ").unwrap_or("");
         if provided != expected.as_str() {
             tracing::warn!(webhook = %name, "webhook authentication failed");
-            return StatusCode::UNAUTHORIZED;
+            return (
+                StatusCode::UNAUTHORIZED,
+                "missing or invalid bearer token".to_string(),
+            );
         }
     }
 
@@ -70,12 +80,34 @@ pub async fn webhook_handler(
     let content = match endpoint.format {
         WebhookFormat::Raw => match String::from_utf8(body.to_vec()) {
             Ok(text) if !text.trim().is_empty() => text,
-            _ => return StatusCode::BAD_REQUEST,
+            _ => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    "request body must not be empty".to_string(),
+                );
+            }
         },
         WebhookFormat::Parsed => {
             match extract_parsed_content(&body, endpoint.content_fields.as_deref()) {
-                Some(text) => text,
-                None => return StatusCode::BAD_REQUEST,
+                Ok(text) => text,
+                Err(ContentExtractionError::EmptyBody) => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        "request body must not be empty".to_string(),
+                    );
+                }
+                Err(ContentExtractionError::InvalidJson) => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        "request body must be valid JSON".to_string(),
+                    );
+                }
+                Err(ContentExtractionError::NoContentFieldsMatched) => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        "no configured content_fields matched the payload".to_string(),
+                    );
+                }
             }
         }
     };
@@ -95,7 +127,10 @@ pub async fn webhook_handler(
                 .await
             {
                 tracing::warn!(webhook = %name, error = %e, "bus publish failed, dropping webhook message");
-                return StatusCode::SERVICE_UNAVAILABLE;
+                return (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "internal error: could not process request".to_string(),
+                );
             }
         }
         WebhookRouting::Agent(preset) => {
@@ -113,45 +148,69 @@ pub async fn webhook_handler(
                 .await
             {
                 tracing::warn!(webhook = %name, error = %e, "bus publish failed, dropping webhook message");
-                return StatusCode::SERVICE_UNAVAILABLE;
+                return (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "internal error: could not process request".to_string(),
+                );
             }
         }
     }
 
     tracing::debug!(webhook = %name, "webhook message published");
-    StatusCode::ACCEPTED
+    (StatusCode::ACCEPTED, String::new())
+}
+
+/// Why parsed-content extraction failed, so the handler can report a precise cause.
+enum ContentExtractionError {
+    /// The body (or, without `content_fields`, the JSON `content` field and the plain-text
+    /// fallback) was empty.
+    EmptyBody,
+    /// `content_fields` were configured but the body was not valid JSON.
+    InvalidJson,
+    /// `content_fields` were configured and the body was valid JSON, but none of the
+    /// configured dot-paths matched.
+    NoContentFieldsMatched,
 }
 
 /// Extract content from the body using parsed format rules.
 ///
 /// - With `content_fields`: parse JSON, extract each dot-path, join with `\n\n`
 /// - Without `content_fields`: extract `"content"` field from JSON, fallback to plain text
-fn extract_parsed_content(body: &[u8], content_fields: Option<&[String]>) -> Option<String> {
+fn extract_parsed_content(
+    body: &[u8],
+    content_fields: Option<&[String]>,
+) -> Result<String, ContentExtractionError> {
     if let Some(fields) = content_fields {
         // Must be JSON when content_fields are specified
-        let json: serde_json::Value = serde_json::from_slice(body).ok()?;
+        let json: serde_json::Value = serde_json::from_slice(body).map_err(|e| {
+            tracing::debug!(error = %e, "webhook body is not valid JSON");
+            ContentExtractionError::InvalidJson
+        })?;
         let parts: Vec<String> = fields
             .iter()
             .filter_map(|path| extract_json_field(&json, path))
             .collect();
         if parts.is_empty() {
-            return None;
+            return Err(ContentExtractionError::NoContentFieldsMatched);
         }
-        Some(parts.join("\n\n"))
+        Ok(parts.join("\n\n"))
     } else {
         // Default: try JSON { "content": "..." }, fallback to plain text
         if let Ok(json) = serde_json::from_slice::<serde_json::Value>(body)
             && let Some(content) = json.get("content").and_then(|v| v.as_str())
             && !content.trim().is_empty()
         {
-            return Some(content.to_string());
+            return Ok(content.to_string());
         }
         // Fallback to plain text
-        let text = String::from_utf8(body.to_vec()).ok()?;
+        let text = String::from_utf8(body.to_vec()).map_err(|e| {
+            tracing::debug!(error = %e, "webhook body is not valid UTF-8");
+            ContentExtractionError::EmptyBody
+        })?;
         if text.trim().is_empty() {
-            return None;
+            return Err(ContentExtractionError::EmptyBody);
         }
-        Some(text)
+        Ok(text)
     }
 }
 

--- a/src/interfaces/websocket/subscriber.rs
+++ b/src/interfaces/websocket/subscriber.rs
@@ -114,9 +114,8 @@ impl WsSubscribers {
                         Ok(Some(TurnLifecycleEvent::Started { correlation_id })) => {
                             Some(ServerMessage::TurnStarted { reply_to: correlation_id })
                         }
-                        Ok(Some(TurnLifecycleEvent::Ended { .. })) => {
-                            // TurnEnded has no ServerMessage equivalent currently — skip
-                            continue;
+                        Ok(Some(TurnLifecycleEvent::Ended { correlation_id })) => {
+                            Some(ServerMessage::TurnEnded { reply_to: correlation_id })
                         }
                         _ => return None,
                     }
@@ -404,7 +403,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn turn_ended_is_skipped() {
+    async fn turn_ended_maps_to_server_message() {
         let handle = crate::bus::spawn_broker();
         let pub_ = handle.publisher();
         let ep = EndpointName::from("ws");
@@ -417,7 +416,7 @@ mod tests {
         .unwrap();
 
         pub_.publish(
-            topics::Endpoint(ep.clone()),
+            topics::Endpoint(ep),
             TurnLifecycleEvent::Ended {
                 correlation_id: "c1".into(),
             },
@@ -425,19 +424,10 @@ mod tests {
         .await
         .unwrap();
 
-        pub_.publish(
-            topics::Endpoint(ep),
-            TurnLifecycleEvent::Started {
-                correlation_id: "c2".into(),
-            },
-        )
-        .await
-        .unwrap();
-
         let msg = subs.recv().await.unwrap();
         assert!(
-            matches!(msg, ServerMessage::TurnStarted { reply_to } if reply_to == "c2"),
-            "TurnEnded should be skipped; next message should be TurnStarted"
+            matches!(msg, ServerMessage::TurnEnded { reply_to } if reply_to == "c1"),
+            "TurnEnded should map to ServerMessage::TurnEnded"
         );
     }
 

--- a/src/mcp/CLAUDE.md
+++ b/src/mcp/CLAUDE.md
@@ -1,0 +1,42 @@
+# MCP Module
+
+Lifecycle management for user-configured MCP servers (per-project `mcp_servers`
+in `PROJECT.md`, or global `mcp.json`) and the tools they expose to the agent.
+
+## Tool-name collision policy
+
+MCP servers can expose a tool with any name, including one that collides with a
+built-in tool (`read_file`, `exec`, `web_fetch`, …) or with another connected
+server's tool. Collisions are resolved **deterministically and visibly** — never
+silently.
+
+**Precedence (which tool keeps the name):**
+1. A **built-in** tool always wins. It is dispatched first in the turn loop
+   (`agent/turn.rs::execute_tool`), so a colliding MCP tool could never be
+   reached anyway.
+2. Among MCP servers, the **first-registered running server** wins (matches the
+   iteration order in `call_tool`).
+
+The losing tool is **shadowed**: excluded from the definitions offered to the
+model and never dispatched to. The winner and the losing server's *other*
+(non-colliding) tools keep working — shadowing is per-tool, not per-server.
+
+**Every shadowing is logged once at `warn`**, naming the shadowed tool, its
+server, and the winner. The log fires at server-connect time (or when the
+built-in namespace is first reserved), not per turn, to avoid log spam.
+
+### Where this lives (`registry.rs`)
+
+- `set_reserved_tool_names` — the gateway calls this once after the built-in
+  tool registry is built, handing over the built-in names so MCP tools that
+  reuse them can be detected. Re-scans already-connected servers.
+- `warn_shadowed_tools` — called from `connect`; emits the collision warnings
+  for a newly connecting server.
+- `tool_definitions` — returns the de-duplicated union actually offered to the
+  model: reserved (built-in) names dropped, later MCP duplicates dropped.
+- `call_tool` — dispatches to the first running server owning the name,
+  consistent with the de-duplication above.
+
+Because the registry hands `agent/turn.rs` an already-clean union, the turn
+loop's merge and built-in-first dispatch need no collision logic of their own —
+this module is the single source of truth for the policy.

--- a/src/mcp/registry.rs
+++ b/src/mcp/registry.rs
@@ -3,7 +3,7 @@
 //! Tracks which MCP servers are running, manages live `McpClient` handles,
 //! and exposes discovered tools to the agent's tool loop.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use serde_json::Value;
@@ -110,6 +110,15 @@ pub struct McpRegistry {
     /// handle so tool dirs become resolvable. An entry's own `PATH` in its
     /// `env` still wins (applied after the injected value at spawn time).
     tools_path: Option<SharedToolsPath>,
+    /// Names of built-in agent tools that reserve the shared tool namespace.
+    ///
+    /// A built-in always wins a name collision (it is dispatched first in the
+    /// turn loop), so an MCP tool that reuses one of these names is shadowed:
+    /// excluded from [`tool_definitions`](Self::tool_definitions) and never
+    /// reachable. Set once by the gateway after the tool registry is built via
+    /// [`set_reserved_tool_names`](Self::set_reserved_tool_names); empty in
+    /// bare registries (tests). See `src/mcp/CLAUDE.md` for the full policy.
+    reserved_tool_names: HashSet<String>,
 }
 
 impl Default for McpRegistry {
@@ -126,6 +135,7 @@ impl McpRegistry {
             servers: Vec::new(),
             project_refs: HashMap::new(),
             tools_path: None,
+            reserved_tool_names: HashSet::new(),
         }
     }
 
@@ -143,7 +153,34 @@ impl McpRegistry {
             servers: Vec::new(),
             project_refs: HashMap::new(),
             tools_path: Some(tools_path),
+            reserved_tool_names: HashSet::new(),
         }))
+    }
+
+    /// Reserve the built-in tool namespace so colliding MCP tools are shadowed
+    /// visibly rather than silently.
+    ///
+    /// Call once after the built-in tool registry is built. Servers that
+    /// connected earlier (e.g. workspace servers started before the tool
+    /// registry existed) are re-scanned here so their collisions are still
+    /// reported; servers that connect later are checked at connect time.
+    pub fn set_reserved_tool_names(&mut self, names: impl IntoIterator<Item = String>) {
+        self.reserved_tool_names = names.into_iter().collect();
+        for server in self
+            .servers
+            .iter()
+            .filter(|s| s.status == McpStatus::Running)
+        {
+            for tool in &server.tools {
+                if self.reserved_tool_names.contains(&tool.name) {
+                    tracing::warn!(
+                        tool = %tool.name,
+                        mcp.server = %server.name,
+                        "mcp tool name collides with a built-in tool; the built-in wins and the mcp tool is shadowed (unreachable)"
+                    );
+                }
+            }
+        }
     }
 
     /// Reconcile desired servers against current state (pure diff, no connections).
@@ -225,6 +262,11 @@ impl McpRegistry {
                 return Err(e);
             }
         };
+
+        // Detect name collisions before exposing this server's tools. The
+        // check runs against reserved built-in names and already-running
+        // servers, so it must happen before the new server is marked running.
+        self.warn_shadowed_tools(&entry.name, &tools);
 
         if let Some(server) = self.servers.iter_mut().find(|s| s.name == entry.name) {
             server.status = McpStatus::Running;
@@ -444,17 +486,83 @@ impl McpRegistry {
         stopped
     }
 
-    /// Get tool definitions from all running servers (flat union).
-    #[must_use]
-    pub fn tool_definitions(&self) -> Vec<ToolDefinition> {
+    /// Warn about tool-name collisions for a server that is about to expose
+    /// `tools`, without changing which tools win.
+    ///
+    /// Precedence is fixed so shadowing is deterministic: a built-in tool
+    /// always wins (it is dispatched first in the turn loop), and among MCP
+    /// servers the first-registered running server wins. This server's
+    /// colliding tools are therefore shadowed — excluded from
+    /// [`tool_definitions`](Self::tool_definitions) and never dispatched to.
+    /// The winner and this server's non-colliding tools keep working. See
+    /// `src/mcp/CLAUDE.md`.
+    fn warn_shadowed_tools(&self, server_name: &str, tools: &[ToolDefinition]) {
+        for tool in tools {
+            if self.reserved_tool_names.contains(&tool.name) {
+                tracing::warn!(
+                    tool = %tool.name,
+                    mcp.server = %server_name,
+                    "mcp tool name collides with a built-in tool; the built-in wins and the mcp tool is shadowed (unreachable)"
+                );
+            } else if let Some(owner) = self.running_owner_of_tool(&tool.name) {
+                tracing::warn!(
+                    tool = %tool.name,
+                    mcp.server = %server_name,
+                    winner = %owner,
+                    "mcp tool name collides with a tool from another mcp server; the first-registered server wins and this one is shadowed (unreachable)"
+                );
+            }
+        }
+    }
+
+    /// Name of the first running server that already exposes `tool_name`, if any.
+    fn running_owner_of_tool(&self, tool_name: &str) -> Option<&str> {
         self.servers
             .iter()
             .filter(|s| s.status == McpStatus::Running)
-            .flat_map(|s| s.tools.iter().cloned())
-            .collect()
+            .find(|s| s.tools.iter().any(|t| t.name == tool_name))
+            .map(|s| s.name.as_str())
+    }
+
+    /// Get tool definitions from all running servers.
+    ///
+    /// The result is de-duplicated so the model is offered each name exactly
+    /// once, matching what [`call_tool`](Self::call_tool) will dispatch to:
+    /// names reserved by a built-in tool are excluded (the built-in wins), and
+    /// when two MCP servers expose the same name only the first-registered
+    /// running server's definition is kept. See `src/mcp/CLAUDE.md`.
+    #[must_use]
+    pub fn tool_definitions(&self) -> Vec<ToolDefinition> {
+        let mut seen: HashSet<&str> = HashSet::new();
+        let mut defs: Vec<ToolDefinition> = Vec::new();
+        for server in self
+            .servers
+            .iter()
+            .filter(|s| s.status == McpStatus::Running)
+        {
+            for tool in &server.tools {
+                // A built-in tool of this name always wins; skip the shadowed
+                // MCP tool so the model is never offered an unreachable name.
+                if self.reserved_tool_names.contains(&tool.name) {
+                    continue;
+                }
+                // First running server to claim a name wins; later duplicates
+                // are shadowed.
+                if seen.insert(tool.name.as_str()) {
+                    defs.push(tool.clone());
+                }
+            }
+        }
+        defs
     }
 
     /// Call a tool by name, routing to the server that owns it.
+    ///
+    /// When two running servers expose the same name the first-registered one
+    /// wins, matching the de-duplication in
+    /// [`tool_definitions`](Self::tool_definitions). Names reserved by a
+    /// built-in tool never reach here: the turn loop dispatches built-ins
+    /// first and only falls back to MCP when no built-in matches.
     ///
     /// # Errors
     /// Returns `ToolError::NotFound` if no running server has the tool.
@@ -700,6 +808,89 @@ mod tests {
         assert!(
             registry.tool_definitions().is_empty(),
             "should be empty with no servers"
+        );
+    }
+
+    fn tool_def(name: &str) -> ToolDefinition {
+        ToolDefinition {
+            name: name.to_string(),
+            description: format!("desc for {name}"),
+            parameters: serde_json::json!({}),
+        }
+    }
+
+    /// Push a running server with the given tools directly (bypassing connect,
+    /// which needs a live client).
+    fn push_running_server(registry: &mut McpRegistry, name: &str, tools: &[&str]) {
+        registry.servers.push(TrackedServer {
+            name: name.to_string(),
+            command: "cmd".to_string(),
+            args: vec![],
+            status: McpStatus::Running,
+            client: None,
+            tools: tools.iter().map(|t| tool_def(t)).collect(),
+        });
+    }
+
+    #[test]
+    fn tool_definitions_dedupes_mcp_collisions_first_server_wins() {
+        let mut registry = McpRegistry::new();
+        push_running_server(&mut registry, "first", &["shared", "only_first"]);
+        push_running_server(&mut registry, "second", &["shared", "only_second"]);
+
+        let defs = registry.tool_definitions();
+        let names: Vec<&str> = defs.iter().map(|d| d.name.as_str()).collect();
+
+        assert_eq!(
+            names.iter().filter(|n| **n == "shared").count(),
+            1,
+            "colliding name should appear exactly once"
+        );
+        // The kept definition is the first server's (first-registered wins).
+        let shared = defs.iter().find(|d| d.name == "shared").unwrap();
+        assert_eq!(
+            shared.description, "desc for shared",
+            "definition is the winner's, not a merge"
+        );
+        assert!(names.contains(&"only_first"), "unique tools still exposed");
+        assert!(names.contains(&"only_second"), "unique tools still exposed");
+    }
+
+    #[test]
+    fn tool_definitions_excludes_names_reserved_by_builtins() {
+        let mut registry = McpRegistry::new();
+        push_running_server(&mut registry, "srv", &["exec", "mcp_only"]);
+        registry.set_reserved_tool_names(["exec".to_string(), "read_file".to_string()]);
+
+        let defs = registry.tool_definitions();
+        let names: Vec<&str> = defs.iter().map(|d| d.name.as_str()).collect();
+
+        assert!(
+            !names.contains(&"exec"),
+            "mcp tool colliding with a built-in must be shadowed (not offered)"
+        );
+        assert!(
+            names.contains(&"mcp_only"),
+            "non-colliding mcp tool stays available"
+        );
+    }
+
+    #[tokio::test]
+    async fn call_tool_routes_collision_to_first_registered_server() {
+        // Both servers claim "shared"; first-registered wins the routing.
+        // Neither has a live client, so the winner surfaces the "no client"
+        // execution error — proving the call was routed to it, not NotFound.
+        let mut registry = McpRegistry::new();
+        push_running_server(&mut registry, "first", &["shared"]);
+        push_running_server(&mut registry, "second", &["shared"]);
+
+        let err = registry
+            .call_tool("shared", serde_json::json!({}))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(&err, ToolError::Execution(msg) if msg.contains("first")),
+            "call should route to the first-registered server, got: {err:?}"
         );
     }
 

--- a/src/memory/episode_store.rs
+++ b/src/memory/episode_store.rs
@@ -91,6 +91,52 @@ pub(crate) fn episode_idx_path(episodes_dir: &Path, episode: &Episode) -> PathBu
         .join(format!("{}.idx.jsonl", episode.id))
 }
 
+/// Filename extension for the per-episode completion marker.
+///
+/// The marker is written as the final step of episode persistence, so its
+/// presence certifies that every prior artifact (transcript, observation
+/// archive, global log, and search-chunk index) landed on disk. Its absence
+/// beside a transcript is what lets reconciliation detect an interrupted write.
+const COMPLETION_MARKER_EXT: &str = "done";
+
+/// Get the path for the per-episode completion marker file.
+#[must_use]
+pub(crate) fn episode_marker_path(episodes_dir: &Path, episode: &Episode) -> PathBuf {
+    episodes_dir
+        .join(episode.date.format("%Y-%m/%d").to_string())
+        .join(format!("{}.{COMPLETION_MARKER_EXT}", episode.id))
+}
+
+/// Write the per-episode completion marker.
+///
+/// This MUST be the final step of episode persistence: its presence certifies
+/// that the transcript, per-episode observation archive, global observation
+/// log, and search-chunk index were all written durably. Because every prior
+/// step is chained with `?`, a failure anywhere upstream returns before this
+/// line and leaves the marker absent — the signal reconciliation uses to detect
+/// an interrupted write.
+///
+/// Only the file's existence is load-bearing; its contents are a human-readable
+/// timestamp kept purely for post-mortem debugging.
+///
+/// # Errors
+/// Returns an error if the marker file cannot be written.
+pub(crate) async fn write_completion_marker(
+    episodes_dir: &Path,
+    episode: &Episode,
+) -> anyhow::Result<()> {
+    let path = episode_marker_path(episodes_dir, episode);
+    let body = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
+    crate::util::fs::atomic_write(&path, body)
+        .await
+        .with_context(|| {
+            format!(
+                "failed to write episode completion marker at {}",
+                path.display()
+            )
+        })
+}
+
 /// Read and parse a JSONL episode transcript file.
 ///
 /// Returns the episode metadata and the list of messages. The first line is

--- a/src/memory/episode_store.rs
+++ b/src/memory/episode_store.rs
@@ -137,6 +137,83 @@ pub(crate) async fn write_completion_marker(
         })
 }
 
+/// Return the paths of episode transcripts whose persistence was interrupted.
+///
+/// A fully persisted episode has a [`COMPLETION_MARKER_EXT`] marker written
+/// beside its `.jsonl` transcript as the final step. A transcript with neither
+/// a marker nor a legacy `.obs.json` archive means the write was cut short
+/// after the transcript landed but before its observations and search chunks
+/// were durably written — leaving the episode permanently invisible to search.
+/// Each such transcript is logged at `warn`; the returned paths let the caller
+/// report or act on them.
+///
+/// The `.obs.json` fallback exists purely for backward compatibility: episodes
+/// written before completion markers existed are complete but have no marker,
+/// and their `.obs.json` archive proves persistence reached at least the
+/// observations step, so they are not reported as interrupted.
+///
+/// # Errors
+/// Returns an error if the episodes directory cannot be traversed.
+pub(crate) fn find_interrupted_episodes(episodes_dir: &Path) -> anyhow::Result<Vec<PathBuf>> {
+    if !episodes_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut transcripts = Vec::new();
+    collect_transcripts(episodes_dir, &mut transcripts)?;
+
+    let mut interrupted = Vec::new();
+    for transcript in transcripts {
+        let has_marker = transcript.with_extension(COMPLETION_MARKER_EXT).exists();
+        let has_obs_archive = transcript.with_extension("obs.json").exists();
+        if has_marker || has_obs_archive {
+            continue;
+        }
+
+        let episode_id = transcript
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("unknown");
+        tracing::warn!(
+            episode_id,
+            path = %transcript.display(),
+            "interrupted episode persistence: transcript has no completion marker or observation archive, so its observations and search chunks were never durably written and it is invisible to memory search; inspect the transcript and re-observe or delete it"
+        );
+        interrupted.push(transcript);
+    }
+
+    Ok(interrupted)
+}
+
+/// Recursively collect episode transcript (`ep-NNN.jsonl`) file paths.
+fn collect_transcripts(dir: &Path, out: &mut Vec<PathBuf>) -> anyhow::Result<()> {
+    let entries = std::fs::read_dir(dir)
+        .with_context(|| format!("failed to read episodes directory {}", dir.display()))?;
+
+    for entry in entries {
+        let path = entry.context("failed to read directory entry")?.path();
+        if path.is_dir() {
+            collect_transcripts(&path, out)?;
+        } else if is_episode_transcript(&path) {
+            out.push(path);
+        }
+    }
+
+    Ok(())
+}
+
+/// Whether `path` names an episode transcript (`ep-NNN.jsonl`).
+///
+/// Excludes `ep-NNN.idx.jsonl`, whose stem `ep-NNN.idx` is not a bare episode id.
+fn is_episode_transcript(path: &Path) -> bool {
+    path.extension().is_some_and(|ext| ext == "jsonl")
+        && path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .and_then(|s| s.strip_prefix("ep-"))
+            .is_some_and(|s| s.parse::<u32>().is_ok())
+}
+
 /// Read and parse a JSONL episode transcript file.
 ///
 /// Returns the episode metadata and the list of messages. The first line is
@@ -839,5 +916,126 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let prev = previous_episode_id(dir.path(), "garbage").await.unwrap();
         assert!(prev.is_none());
+    }
+
+    // --- completion marker & reconciliation tests ---
+
+    #[tokio::test]
+    async fn completion_marker_written_and_recognized() {
+        let dir = tempfile::tempdir().unwrap();
+        let episode = sample_episode();
+        write_episode_transcript(dir.path(), &episode, &[Message::user("hi")])
+            .await
+            .unwrap();
+        write_completion_marker(dir.path(), &episode).await.unwrap();
+
+        let marker = episode_marker_path(dir.path(), &episode);
+        assert!(marker.exists(), "completion marker file should be written");
+
+        let interrupted = find_interrupted_episodes(dir.path()).unwrap();
+        assert!(
+            interrupted.is_empty(),
+            "an episode with a completion marker is not interrupted"
+        );
+    }
+
+    #[tokio::test]
+    async fn interrupted_episode_detected_when_only_transcript_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let episode = sample_episode();
+        // Simulate a crash after the transcript landed but before any later
+        // artifact (obs archive, chunks, marker) was written.
+        write_episode_transcript(dir.path(), &episode, &[Message::user("hi")])
+            .await
+            .unwrap();
+
+        let interrupted = find_interrupted_episodes(dir.path()).unwrap();
+        assert_eq!(
+            interrupted.len(),
+            1,
+            "a transcript with no marker and no obs archive is interrupted"
+        );
+        assert!(
+            interrupted
+                .first()
+                .is_some_and(|p| p.ends_with("ep-001.jsonl")),
+            "the orphaned transcript path should be reported"
+        );
+    }
+
+    #[tokio::test]
+    async fn legacy_episode_with_obs_archive_not_flagged() {
+        let dir = tempfile::tempdir().unwrap();
+        let episode = sample_episode();
+        write_episode_transcript(dir.path(), &episode, &[Message::user("hi")])
+            .await
+            .unwrap();
+        // An episode written before completion markers existed has an obs
+        // archive but no marker; it must not be reported as interrupted.
+        let obs_path = episode_obs_path(dir.path(), &episode);
+        tokio::fs::write(&obs_path, "[]").await.unwrap();
+
+        let interrupted = find_interrupted_episodes(dir.path()).unwrap();
+        assert!(
+            interrupted.is_empty(),
+            "an episode with a legacy obs archive is treated as complete"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconciliation_isolates_interrupted_from_healthy() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Healthy, fully-persisted episode.
+        let healthy = sample_episode();
+        write_episode_transcript(dir.path(), &healthy, &[Message::user("a")])
+            .await
+            .unwrap();
+        write_completion_marker(dir.path(), &healthy).await.unwrap();
+
+        // Interrupted episode: transcript only.
+        let mut interrupted_ep = sample_episode();
+        interrupted_ep.id = "ep-002".to_string();
+        write_episode_transcript(dir.path(), &interrupted_ep, &[Message::user("b")])
+            .await
+            .unwrap();
+
+        let interrupted = find_interrupted_episodes(dir.path()).unwrap();
+        assert_eq!(
+            interrupted.len(),
+            1,
+            "only the interrupted episode is flagged"
+        );
+        assert!(
+            interrupted
+                .first()
+                .is_some_and(|p| p.ends_with("ep-002.jsonl")),
+            "the healthy episode must not be flagged"
+        );
+    }
+
+    #[test]
+    fn find_interrupted_episodes_missing_dir_is_empty() {
+        let missing = Path::new("/tmp/nonexistent_reconcile_dir_test");
+        let interrupted = find_interrupted_episodes(missing).unwrap();
+        assert!(
+            interrupted.is_empty(),
+            "a missing episodes dir yields no interrupted episodes"
+        );
+    }
+
+    #[test]
+    fn idx_jsonl_is_not_mistaken_for_a_transcript() {
+        let dir = tempfile::tempdir().unwrap();
+        let sub = dir.path().join("2026-02/19");
+        std::fs::create_dir_all(&sub).unwrap();
+        // A stray chunk index with no transcript must not be scanned as one.
+        std::fs::write(sub.join("ep-001.idx.jsonl"), "{}\n").unwrap();
+
+        let interrupted = find_interrupted_episodes(dir.path()).unwrap();
+        assert!(
+            interrupted.is_empty(),
+            "an .idx.jsonl file is not an episode transcript"
+        );
     }
 }

--- a/src/memory/observer/mod.rs
+++ b/src/memory/observer/mod.rs
@@ -16,7 +16,8 @@ use crate::config::{
 };
 use crate::memory::chunk_extractor::{extract_chunks, write_idx_jsonl};
 use crate::memory::episode_store::{
-    episode_idx_path, episode_obs_path, next_episode_id, write_episode_transcript,
+    episode_idx_path, episode_obs_path, next_episode_id, write_completion_marker,
+    write_episode_transcript,
 };
 use crate::memory::log_store::{append_observations, save_episode_observations};
 use crate::memory::recent_messages::RecentMessage;
@@ -326,6 +327,13 @@ async fn build_episode_and_persist(
     let idx_path = episode_idx_path(&layout.episodes_dir(), &episode);
     write_idx_jsonl(&idx_path, &chunks).await?;
     tracing::debug!(episode_id = %episode.id, chunks = chunks.len(), "interaction-pair chunks written");
+
+    // Completion marker — MUST stay the final persistence step. Its presence
+    // certifies that every artifact above was written durably; if any step
+    // above failed, the `?` returned before this line and the marker is absent,
+    // which is how startup reconciliation detects an interrupted write.
+    write_completion_marker(&layout.episodes_dir(), &episode).await?;
+    tracing::debug!(episode_id = %episode.id, "episode persistence completed");
 
     tracing::info!(
         episode_id = %episode.id,
@@ -669,6 +677,15 @@ mod tests {
         assert!(
             obs_archive.exists(),
             "per-episode obs archive should exist alongside transcript"
+        );
+
+        // The completion marker is written last; its presence certifies that
+        // persistence finished rather than being interrupted midway.
+        let marker =
+            crate::memory::episode_store::episode_marker_path(&layout.episodes_dir(), &episode);
+        assert!(
+            marker.exists(),
+            "completion marker should exist after a successful observe"
         );
     }
 

--- a/src/memory/search.rs
+++ b/src/memory/search.rs
@@ -402,6 +402,7 @@ impl MemoryIndex {
         if episodes_dir.exists() {
             collect_indexable_files(&episodes_dir, memory_dir, &mut disk_files)?;
         }
+        report_interrupted_episodes(&episodes_dir);
 
         for (rel_path, mtime) in &disk_files {
             let abs_path = memory_dir.join(rel_path);
@@ -453,6 +454,7 @@ impl MemoryIndex {
         if episodes_dir.exists() {
             collect_indexable_files(&episodes_dir, memory_dir, &mut disk_files)?;
         }
+        report_interrupted_episodes(&episodes_dir);
 
         let disk_paths: std::collections::HashSet<&str> =
             disk_files.iter().map(|(p, _)| p.as_str()).collect();
@@ -739,6 +741,29 @@ fn collect_indexable_files(
     }
 
     Ok(())
+}
+
+/// Warn about any episode transcripts whose persistence was interrupted.
+///
+/// The index only covers `.obs.json` and `.idx.jsonl` files, so a transcript
+/// left without them (a write cut short after the transcript landed) is
+/// silently unsearchable. Surfacing it here — every time the index is built —
+/// gives an operator or agent a chance to notice and recover it, instead of the
+/// episode vanishing without a trace. Reconciliation is read-only and never
+/// blocks indexing.
+fn report_interrupted_episodes(episodes_dir: &Path) {
+    match crate::memory::episode_store::find_interrupted_episodes(episodes_dir) {
+        Ok(interrupted) if !interrupted.is_empty() => {
+            tracing::warn!(
+                count = interrupted.len(),
+                "memory index skipped episodes with interrupted persistence (transcript without completion marker or observation archive); they are not searchable"
+            );
+        }
+        Ok(_) => {}
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to scan for interrupted episode persistence");
+        }
+    }
 }
 
 // ── Hybrid searcher ─────────────────────────────────────────────────────────
@@ -1384,6 +1409,47 @@ mod tests {
 
         let results = index.search("flat layout", 5, &no_filters()).unwrap();
         assert!(!results.is_empty(), "should find indexed content");
+    }
+
+    #[test]
+    fn rebuild_tolerates_interrupted_episode_transcript() {
+        let dir = tempfile::tempdir().unwrap();
+        let memory_dir = dir.path().join("memory");
+        let day_dir = memory_dir.join("episodes/2026-02/19");
+        std::fs::create_dir_all(&day_dir).unwrap();
+
+        // A healthy episode with an indexable obs archive.
+        let obs = vec![sample_observation("healthy searchable observation")];
+        std::fs::write(
+            day_dir.join("ep-001.obs.json"),
+            serde_json::to_string(&obs).unwrap(),
+        )
+        .unwrap();
+
+        // An interrupted episode: transcript only, no obs/idx/marker. It must
+        // not break the rebuild, and simply stays absent from the index.
+        std::fs::write(
+            day_dir.join("ep-002.jsonl"),
+            "{\"type\":\"meta\",\"id\":\"ep-002\",\"date\":\"2026-02-19\",\"context\":\"general\"}\n",
+        )
+        .unwrap();
+
+        let index_dir = memory_dir.join(".index");
+        let index = MemoryIndex::open_or_create(&index_dir).unwrap();
+        let result = index.rebuild(&memory_dir).unwrap();
+
+        assert_eq!(
+            result.obs_count, 1,
+            "only the healthy episode's observation should be indexed"
+        );
+
+        let results = index
+            .search("healthy searchable", 5, &no_filters())
+            .unwrap();
+        assert!(
+            !results.is_empty(),
+            "healthy episode remains searchable despite the orphaned transcript"
+        );
     }
 
     #[test]

--- a/src/memory/search.rs
+++ b/src/memory/search.rs
@@ -681,7 +681,13 @@ fn extract_date_from_path(path: &Path) -> String {
         (Some(ym), Some(d)) if ym.len() == 7 && d.len() == 2 => {
             format!("{ym}-{d}")
         }
-        _ => String::new(),
+        _ => {
+            tracing::warn!(
+                path = %path.display(),
+                "failed to extract date from path, expected episodes/YYYY-MM/DD structure"
+            );
+            String::new()
+        }
     }
 }
 
@@ -801,6 +807,22 @@ impl HybridSearcher {
                         .unwrap_or(std::cmp::Ordering::Equal)
                 });
             }
+            // Apply min_score the same way merge_hybrid_results does (on normalized
+            // scores), so the setting has consistent meaning whether or not vector
+            // search ran.
+            let scores: Vec<f32> = results.iter().map(|r| r.score).collect();
+            let normalized = normalize_scores(&scores);
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "min_score is in [0.0, 1.0], safe to truncate to f32"
+            )]
+            let min_score = self.cfg.min_score as f32;
+            results = results
+                .into_iter()
+                .zip(normalized)
+                .filter(|(_, norm)| *norm >= min_score)
+                .map(|(r, _)| r)
+                .collect();
             results.truncate(limit);
             return Ok(results);
         };
@@ -822,6 +844,7 @@ impl HybridSearcher {
             date_from: filters.date_from.clone(),
             date_to: filters.date_to.clone(),
             project_context: filters.project_context.clone(),
+            episode_ids: filters.episode_ids.clone(),
         };
         let vec_limit = candidates;
         let vec_results = tokio::task::spawn_blocking(move || {

--- a/src/memory/vector_store.rs
+++ b/src/memory/vector_store.rs
@@ -45,6 +45,8 @@ pub struct VectorSearchFilters {
     pub date_to: Option<String>,
     /// Filter by project context (exact match).
     pub project_context: Option<String>,
+    /// Filter to results from these episode IDs.
+    pub episode_ids: Option<Vec<String>>,
 }
 
 /// `SQLite` + sqlite-vec backed vector store for memory embeddings.
@@ -564,6 +566,21 @@ fn build_filter_clauses(filters: &VectorSearchFilters) -> (String, Vec<String>) 
     if let Some(ref ctx) = filters.project_context {
         clauses.push(format!("AND context = ?{idx}"));
         params.push(ctx.clone());
+        idx += 1;
+    }
+    if let Some(ref episode_ids) = filters.episode_ids
+        && !episode_ids.is_empty()
+    {
+        let placeholders: Vec<String> = episode_ids
+            .iter()
+            .map(|_| {
+                let p = format!("?{idx}");
+                idx += 1;
+                p
+            })
+            .collect();
+        clauses.push(format!("AND episode_id IN ({})", placeholders.join(", ")));
+        params.extend(episode_ids.iter().cloned());
     }
 
     (clauses.join(" "), params)

--- a/src/notify/router.rs
+++ b/src/notify/router.rs
@@ -127,16 +127,18 @@ async fn fallback_router_loop(mut subscriber: Subscriber<AgentResultEvent>, publ
 /// Route a single `AgentResultEvent` through the two-layer system.
 #[tracing::instrument(skip_all, fields(source_label = %event.source_label, task_id = %event.task_id))]
 async fn route_agent_result(event: &AgentResultEvent, router: &NotificationRouter) {
-    tracing::info!(
-        source = %event.source,
-        "notification router received result"
-    );
-
-    // Layer 1: Heartbeat-ok → silent discard
+    // Heartbeat-ok pulses are the majority of traffic through this path and are a
+    // silent discard by design, so check for them before logging anything at info —
+    // otherwise routine health-check pulses would spam the info log.
     if event.heartbeat_status == HeartbeatStatus::Ok {
         tracing::trace!("pulse check: HEARTBEAT_OK");
         return;
     }
+
+    tracing::info!(
+        source = %event.source,
+        "notification router received result"
+    );
 
     // Layer 1: Agent-spawned results → relay to main agent
     if matches!(event.source, EventTrigger::Agent) {

--- a/src/notify/windows/throttle.rs
+++ b/src/notify/windows/throttle.rs
@@ -162,7 +162,7 @@ fn build_summary_body(buffer: &[NotificationEvent]) -> String {
 }
 
 fn truncate_body(s: &str, max_len: usize) -> String {
-    if s.len() <= max_len {
+    if s.chars().count() <= max_len {
         s.to_string()
     } else {
         let mut result: String = s.chars().take(max_len - 1).collect();
@@ -223,6 +223,20 @@ mod tests {
         assert_eq!(
             result, s,
             "should not truncate -- char count is under limit"
+        );
+        assert!(!result.ends_with('\u{2026}'));
+    }
+
+    #[test]
+    fn truncate_body_unicode_over_byte_limit_but_within_char_limit() {
+        // 60 emoji (4 bytes each) = 240 bytes but only 60 chars -- exceeds the
+        // 200 byte-length guard but stays under the 200 char-count limit, so
+        // this only passes untruncated once the guard counts chars, not bytes.
+        let s = "\u{1F980}".repeat(60);
+        let result = truncate_body(&s, 200);
+        assert_eq!(
+            result, s,
+            "should not truncate -- char count is under limit even though byte count exceeds it"
         );
         assert!(!result.ends_with('\u{2026}'));
     }

--- a/src/projects/lifecycle.rs
+++ b/src/projects/lifecycle.rs
@@ -7,7 +7,7 @@ use chrono::NaiveDate;
 
 use crate::workspace::layout::WorkspaceLayout;
 
-use super::scanner::serialize_project_md;
+use super::scanner::{ProjectIndex, serialize_project_md};
 use super::types::{ProjectFrontmatter, ProjectStatus};
 
 /// Create a new project with the standard directory structure.
@@ -16,7 +16,8 @@ use super::types::{ProjectFrontmatter, ProjectStatus};
 ///
 /// # Errors
 /// Returns an error if the name is invalid, a project with the same dir
-/// name already exists, or filesystem operations fail.
+/// name or the same human-readable `name` (active or archived) already
+/// exists, or filesystem operations fail.
 #[tracing::instrument(skip_all, fields(project = %name))]
 pub async fn create_project(
     layout: &WorkspaceLayout,
@@ -35,6 +36,24 @@ pub async fn create_project(
 
     if project_dir.exists() {
         anyhow::bail!("project directory '{dir_name}' already exists");
+    }
+
+    // `activate`/`archive` and the project_activate/project_archive tools resolve
+    // projects purely by this human-readable name, so a second project sharing it
+    // would make one of the two permanently unreachable (whichever the scan orders
+    // second). The directory-name check above only guards the sanitized slug, not
+    // the freely-editable frontmatter `name`, so it must be checked separately here.
+    let index = ProjectIndex::scan(layout)
+        .await
+        .context("failed to scan existing projects to check for a name collision")?;
+
+    if let Some(existing) = index.find_by_name(name) {
+        anyhow::bail!(
+            "a project named '{}' already exists ({}, dir '{}'); choose a different name",
+            existing.name,
+            existing.status,
+            existing.dir_name
+        );
     }
 
     // Create directory structure
@@ -241,6 +260,70 @@ mod tests {
 
         let result = create_project(&layout, "Test", "Second", vec![], today).await;
         assert!(result.is_err(), "duplicate should be rejected");
+    }
+
+    /// Regression test: `create_project` used to only check the sanitized
+    /// *directory* name for collisions, never the human-readable frontmatter
+    /// `name`. Since frontmatter is hand-editable and `activate`/`archive`
+    /// resolve purely by name, two projects could end up with the same
+    /// `name` but different directories, making one permanently unreachable.
+    /// Here the existing project's directory (`original-name`) does not match
+    /// the sanitized form of the colliding name (`duplicate-name`), so only a
+    /// name-based check — not a directory-based one — can catch this.
+    #[tokio::test]
+    async fn create_duplicate_name_different_dir_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let layout = WorkspaceLayout::new(dir.path().join("workspace"));
+        ensure_workspace(&layout, None, None).await.unwrap();
+
+        let today = NaiveDate::from_ymd_opt(2026, 2, 23).unwrap();
+        create_project(&layout, "Original Name", "First", vec![], today)
+            .await
+            .unwrap();
+
+        // Simulate a hand-edit of the frontmatter `name` that leaves the
+        // directory name untouched, so it no longer matches sanitize_dir_name(name).
+        let project_md = layout.projects_dir().join("original-name/PROJECT.md");
+        let content = tokio::fs::read_to_string(&project_md).await.unwrap();
+        let (mut fm, body) = parse_project_md(&content).unwrap();
+        fm.name = "Duplicate Name".to_string();
+        let updated = serialize_project_md(&fm, &body).unwrap();
+        tokio::fs::write(&project_md, updated).await.unwrap();
+
+        let result = create_project(&layout, "Duplicate Name", "Second", vec![], today).await;
+        assert!(
+            result.is_err(),
+            "creating a project whose name collides with an existing frontmatter name \
+             (in a differently-named directory) should be rejected"
+        );
+        assert!(
+            !layout.projects_dir().join("duplicate-name").exists(),
+            "the rejected project's directory should not have been created"
+        );
+    }
+
+    /// Regression test: name uniqueness must be checked against archived
+    /// projects too, not just active ones, since `find_by_name` (used by
+    /// activate/archive tools) looks across both.
+    #[tokio::test]
+    async fn create_name_collides_with_archived_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let layout = WorkspaceLayout::new(dir.path().join("workspace"));
+        ensure_workspace(&layout, None, None).await.unwrap();
+
+        let today = NaiveDate::from_ymd_opt(2026, 2, 23).unwrap();
+        create_project(&layout, "Retired Idea", "Old", vec![], today)
+            .await
+            .unwrap();
+        archive_project(&layout, "retired-idea", today)
+            .await
+            .unwrap();
+
+        let result = create_project(&layout, "Retired Idea", "New attempt", vec![], today).await;
+        assert!(
+            result.is_err(),
+            "a name matching an archived project should also be rejected"
+        );
     }
 
     #[tokio::test]

--- a/src/projects/manifest.rs
+++ b/src/projects/manifest.rs
@@ -1,5 +1,6 @@
 //! Project manifest: recursive file listing for project subdirectories.
 
+use std::fmt::Write as _;
 use std::path::Path;
 
 use super::types::{ManifestEntry, ProjectManifest};
@@ -12,19 +13,38 @@ use super::types::{ManifestEntry, ProjectManifest};
 /// Returns an error if a directory cannot be read.
 #[tracing::instrument(skip_all, fields(project_root = %project_root.display()))]
 pub async fn build_manifest(project_root: &Path) -> anyhow::Result<ProjectManifest> {
+    let (notes, notes_skipped) =
+        list_files_recursive(&project_root.join("notes"), project_root).await?;
+    let (references, references_skipped) =
+        list_files_recursive(&project_root.join("references"), project_root).await?;
+    let (workspace, workspace_skipped) =
+        list_files_recursive(&project_root.join("workspace"), project_root).await?;
+    let (skills, skills_skipped) =
+        list_files_recursive(&project_root.join("skills"), project_root).await?;
+
+    let skipped_count = notes_skipped + references_skipped + workspace_skipped + skills_skipped;
+
     let manifest = ProjectManifest {
-        notes: list_files_recursive(&project_root.join("notes"), project_root).await?,
-        references: list_files_recursive(&project_root.join("references"), project_root).await?,
-        workspace: list_files_recursive(&project_root.join("workspace"), project_root).await?,
-        skills: list_files_recursive(&project_root.join("skills"), project_root).await?,
+        notes,
+        references,
+        workspace,
+        skills,
+        skipped_count,
     };
     tracing::debug!(
         notes = manifest.notes.len(),
         references = manifest.references.len(),
         workspace = manifest.workspace.len(),
         skills = manifest.skills.len(),
+        skipped = manifest.skipped_count,
         "built project manifest"
     );
+    if skipped_count > 0 {
+        tracing::warn!(
+            skipped = skipped_count,
+            "project manifest is incomplete: some entries could not be listed"
+        );
+    }
     Ok(manifest)
 }
 
@@ -41,11 +61,23 @@ pub fn format_manifest(manifest: &ProjectManifest) -> String {
     .flatten()
     .collect();
 
-    if sections.is_empty() {
-        return "No files.".to_string();
+    let mut output = if sections.is_empty() {
+        "No files.".to_string()
+    } else {
+        sections.join("\n\n")
+    };
+
+    if manifest.skipped_count > 0 {
+        let plural = if manifest.skipped_count == 1 { "" } else { "s" };
+        // write! to a String is infallible.
+        _ = write!(
+            output,
+            "\n\n({} file{plural} could not be listed)",
+            manifest.skipped_count
+        );
     }
 
-    sections.join("\n\n")
+    output
 }
 
 fn format_section(heading: &str, entries: &[ManifestEntry]) -> Option<String> {
@@ -85,21 +117,30 @@ fn format_size(bytes: u64) -> String {
 }
 
 /// Recursively list files under a directory, returning paths relative to `project_root`.
+///
+/// Also returns the number of directory entries that could not be listed
+/// (e.g. broken symlinks, permission-denied) and were therefore omitted.
 async fn list_files_recursive(
     dir: &Path,
     project_root: &Path,
-) -> anyhow::Result<Vec<ManifestEntry>> {
+) -> anyhow::Result<(Vec<ManifestEntry>, usize)> {
     let mut entries = Vec::new();
-    collect_files(dir, project_root, &mut entries).await?;
+    let mut skipped = 0_usize;
+    collect_files(dir, project_root, &mut entries, &mut skipped).await?;
     entries.sort_by(|a, b| a.relative_path.cmp(&b.relative_path));
-    Ok(entries)
+    Ok((entries, skipped))
 }
 
 /// Recursive helper using `tokio::fs::read_dir`.
+///
+/// `skipped` is incremented for every directory entry that can't be read or
+/// stat'd, so callers can signal to the manifest's consumers that the
+/// listing may be incomplete.
 async fn collect_files(
     dir: &Path,
     project_root: &Path,
     entries: &mut Vec<ManifestEntry>,
+    skipped: &mut usize,
 ) -> anyhow::Result<()> {
     let mut read_dir = match tokio::fs::read_dir(dir).await {
         Ok(rd) => rd,
@@ -120,6 +161,7 @@ async fn collect_files(
                     error = %e,
                     "failed to read directory entry"
                 );
+                *skipped += 1;
                 continue;
             }
         };
@@ -132,12 +174,13 @@ async fn collect_files(
                     error = %e,
                     "failed to read file metadata"
                 );
+                *skipped += 1;
                 continue;
             }
         };
 
         if metadata.is_dir() {
-            Box::pin(collect_files(&entry.path(), project_root, entries)).await?;
+            Box::pin(collect_files(&entry.path(), project_root, entries, skipped)).await?;
         } else {
             let path = entry.path();
             let rel = path
@@ -176,6 +219,10 @@ mod tests {
         assert!(manifest.references.is_empty(), "references should be empty");
         assert!(manifest.workspace.is_empty(), "workspace should be empty");
         assert!(manifest.skills.is_empty(), "skills should be empty");
+        assert_eq!(
+            manifest.skipped_count, 0,
+            "nothing should be reported as skipped"
+        );
 
         let formatted = format_manifest(&manifest);
         assert_eq!(formatted, "No files.", "empty manifest should show message");
@@ -215,6 +262,10 @@ mod tests {
         assert!(
             manifest.notes.first().unwrap().size_bytes > 0,
             "notes file size should be non-zero"
+        );
+        assert_eq!(
+            manifest.skipped_count, 0,
+            "nothing should be reported as skipped when every entry lists cleanly"
         );
     }
 
@@ -285,6 +336,7 @@ mod tests {
                 size_bytes: 512,
             }],
             skills: vec![],
+            skipped_count: 0,
         };
 
         let output = format_manifest(&manifest);
@@ -303,6 +355,89 @@ mod tests {
         assert!(
             !output.contains("**references/**"),
             "empty references should be omitted"
+        );
+        assert!(
+            !output.contains("could not be listed"),
+            "no skipped-entry note when nothing was skipped"
+        );
+    }
+
+    #[test]
+    fn format_manifest_notes_skipped_entries() {
+        let manifest = ProjectManifest {
+            notes: vec![ManifestEntry {
+                relative_path: "notes/decisions.md".to_string(),
+                size_bytes: 1024,
+            }],
+            references: vec![],
+            workspace: vec![],
+            skills: vec![],
+            skipped_count: 2,
+        };
+
+        let output = format_manifest(&manifest);
+        assert!(
+            output.contains("(2 files could not be listed)"),
+            "should note the number of skipped entries: {output}"
+        );
+    }
+
+    #[test]
+    fn format_manifest_notes_single_skipped_entry() {
+        let manifest = ProjectManifest {
+            notes: vec![],
+            references: vec![],
+            workspace: vec![],
+            skills: vec![],
+            skipped_count: 1,
+        };
+
+        let output = format_manifest(&manifest);
+        assert!(
+            output.contains("(1 file could not be listed)"),
+            "should use singular phrasing for one skipped entry: {output}"
+        );
+    }
+
+    #[tokio::test]
+    async fn build_manifest_threads_skipped_count_through_to_rendered_prompt_text() {
+        // `list_files_recursive`/`collect_files` count-and-skip on read errors
+        // that are inherently racy to reproduce deterministically at the
+        // filesystem level (e.g. a file vanishing between `read_dir` and
+        // `metadata`). What we *can* pin down hermetically is that whatever
+        // count `collect_files` produces survives the full round trip:
+        // `build_manifest` sums it across all four subdirectories, and
+        // `format_manifest` renders it into the text the agent actually sees.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        let notes_dir = root.join("notes");
+        let workspace_dir = root.join("workspace");
+        tokio::fs::create_dir_all(&notes_dir).await.unwrap();
+        tokio::fs::create_dir_all(&workspace_dir).await.unwrap();
+        tokio::fs::write(notes_dir.join("real.md"), "content")
+            .await
+            .unwrap();
+
+        let mut manifest = build_manifest(root).await.unwrap();
+        assert_eq!(
+            manifest.skipped_count, 0,
+            "a clean listing should report nothing skipped"
+        );
+
+        // Simulate collect_files having hit read errors in two different
+        // subdirectories, the way it would if e.g. metadata() failed for
+        // one entry in notes/ and one in workspace/.
+        manifest.skipped_count = 2;
+
+        let formatted = format_manifest(&manifest);
+        assert!(
+            formatted.contains("notes/real.md"),
+            "successfully listed files should still be shown: {formatted}"
+        );
+        assert!(
+            formatted.contains("(2 files could not be listed)"),
+            "the prompt text should flag that the manifest may be incomplete: {formatted}"
         );
     }
 }

--- a/src/projects/mod.rs
+++ b/src/projects/mod.rs
@@ -1,4 +1,11 @@
 //! Projects context management: structured, scoped context folders.
+//!
+//! Entry point is [`activation::ProjectState`], which tracks the active project
+//! and its loaded context. `src/tools/projects.rs` drives it (via
+//! `SharedProjectState`) and orchestrates the side effects of switching
+//! projects — MCP server ref-counting, skill rescanning — one layer above this
+//! module. See `docs/systems-usage/projects.md` for the authoritative spec of
+//! lifecycle and activation behavior.
 
 pub mod activation;
 pub mod lifecycle;

--- a/src/projects/scanner.rs
+++ b/src/projects/scanner.rs
@@ -29,6 +29,8 @@ impl ProjectIndex {
         scan_directory(&layout.projects_dir(), &mut entries).await?;
         scan_directory(&layout.archive_dir(), &mut entries).await?;
 
+        warn_on_duplicate_names(&entries);
+
         tracing::debug!(total = entries.len(), "project index scan complete");
 
         Ok(Self { entries })
@@ -75,6 +77,29 @@ impl ProjectIndex {
     #[must_use]
     pub fn entries(&self) -> &[ProjectIndexEntry] {
         &self.entries
+    }
+}
+
+/// Warn if two or more scanned entries share the same `name` (case-insensitive).
+///
+/// `PROJECT.md` frontmatter is hand-editable and nothing revalidates the `name`
+/// field against the rest of the index. `find_by_name` resolves by name alone
+/// and returns only the first match, so a collision silently shadows one
+/// project — `activate`/`archive` would then be unable to reach it. This is
+/// the only place that can catch collisions introduced outside
+/// `create_project` (e.g. by hand-editing frontmatter), so it must run on
+/// every scan, not just at creation time.
+fn warn_on_duplicate_names(entries: &[ProjectIndexEntry]) {
+    let mut seen_names = std::collections::HashSet::with_capacity(entries.len());
+
+    for entry in entries {
+        if !seen_names.insert(entry.name.to_lowercase()) {
+            tracing::warn!(
+                name = %entry.name,
+                dir = %entry.dir_name,
+                "duplicate project name found during scan; name-based lookups are ambiguous and one project is unreachable by name"
+            );
+        }
     }
 }
 
@@ -428,6 +453,81 @@ Some overview body text here.
             index.entries().len(),
             1,
             "should only find valid project, skip invalid"
+        );
+    }
+
+    /// Regression test: two projects can end up sharing a frontmatter `name`
+    /// via hand-editing (`create_project` only guards its own creation path),
+    /// and `find_by_name` silently returns just the first match. `scan` must
+    /// surface that ambiguity via a warning so it isn't invisible to an
+    /// operator debugging why a project became unreachable by name.
+    #[tokio::test]
+    async fn scan_warns_on_duplicate_names() {
+        use std::sync::{Arc, Mutex};
+
+        #[derive(Clone, Default)]
+        struct CapturingWriter(Arc<Mutex<Vec<u8>>>);
+
+        impl std::io::Write for CapturingWriter {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(buf);
+                Ok(buf.len())
+            }
+
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CapturingWriter {
+            type Writer = Self;
+
+            fn make_writer(&'a self) -> Self::Writer {
+                self.clone()
+            }
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let layout = WorkspaceLayout::new(dir.path().join("workspace"));
+        ensure_workspace(&layout, None, None).await.unwrap();
+
+        // Two projects sharing a name (case-insensitive) in different
+        // directories — only reachable today via a hand-edited PROJECT.md,
+        // since create_project itself now rejects the name collision.
+        for dir_name in ["proj-a", "proj-b"] {
+            let project_dir = layout.projects_dir().join(dir_name);
+            tokio::fs::create_dir(&project_dir).await.unwrap();
+            tokio::fs::write(
+                project_dir.join("PROJECT.md"),
+                "---\nname: Shared Name\ndescription: \"dup\"\nstatus: active\ncreated: 2026-02-20\n---\n",
+            )
+            .await
+            .unwrap();
+        }
+
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(CapturingWriter(Arc::clone(&buf)))
+            .with_max_level(tracing::Level::WARN)
+            .without_time()
+            .with_target(false)
+            .finish();
+
+        let index = {
+            let _guard = tracing::subscriber::set_default(subscriber);
+            ProjectIndex::scan(&layout).await.unwrap()
+        };
+
+        assert_eq!(
+            index.entries().len(),
+            2,
+            "both duplicate entries should still be indexed, not deduplicated"
+        );
+
+        let logs = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
+        assert!(
+            logs.contains("duplicate project name"),
+            "scan should warn about the duplicate name, got: {logs}"
         );
     }
 

--- a/src/projects/types.rs
+++ b/src/projects/types.rs
@@ -125,6 +125,10 @@ pub struct ProjectManifest {
     pub workspace: Vec<ManifestEntry>,
     /// Files under `skills/`.
     pub skills: Vec<ManifestEntry>,
+    /// Number of directory entries that could not be listed (e.g. broken
+    /// symlinks, permission-denied) and were therefore omitted above.
+    /// A non-zero count means the manifest may be incomplete.
+    pub skipped_count: usize,
 }
 
 /// A single file entry in the manifest.

--- a/src/pulse/scheduler.rs
+++ b/src/pulse/scheduler.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use chrono::{Datelike, Duration, NaiveDateTime, NaiveTime};
@@ -22,6 +22,10 @@ pub struct PulseScheduler {
     run_counts: HashMap<String, u32>,
     #[serde(skip)]
     state_path: Option<PathBuf>,
+    /// Most recently logged HEARTBEAT.yml parse-error message, so `due_pulses`
+    /// doesn't re-warn on an identical error every tick (ticks run every 60s).
+    #[serde(skip)]
+    last_heartbeat_parse_error: Option<String>,
 }
 
 impl Default for PulseScheduler {
@@ -38,6 +42,7 @@ impl PulseScheduler {
             last_run: HashMap::new(),
             run_counts: HashMap::new(),
             state_path: None,
+            last_heartbeat_parse_error: None,
         }
     }
 
@@ -65,9 +70,14 @@ impl PulseScheduler {
     #[must_use]
     #[tracing::instrument(skip_all, fields(heartbeat_path = %heartbeat_path.display()))]
     pub fn due_pulses(&mut self, now: NaiveDateTime, heartbeat_path: &Path) -> Vec<PulseDef> {
-        let Some(heartbeat) = load_heartbeat(heartbeat_path) else {
+        let Some(heartbeat) = load_heartbeat(heartbeat_path, &mut self.last_heartbeat_parse_error)
+        else {
             return Vec::new();
         };
+
+        let current_pulse_names: HashSet<String> =
+            heartbeat.pulses.iter().map(|p| p.name.clone()).collect();
+        let pruned = self.prune_removed_pulses(&current_pulse_names);
 
         let mut due = Vec::new();
 
@@ -151,7 +161,7 @@ impl PulseScheduler {
             }
         }
 
-        if !due.is_empty()
+        if (pruned || !due.is_empty())
             && let Err(e) = self.save_state()
         {
             tracing::warn!(
@@ -162,6 +172,30 @@ impl PulseScheduler {
         }
 
         due
+    }
+
+    /// Remove `last_run`/`run_counts` entries for pulses no longer present in
+    /// `HEARTBEAT.yml` (deleted or renamed), so `pulse_state.json` doesn't grow
+    /// unboundedly with unexplainable stale keys. Returns whether anything was removed.
+    fn prune_removed_pulses(&mut self, current_pulse_names: &HashSet<String>) -> bool {
+        let last_run_before = self.last_run.len();
+        let run_counts_before = self.run_counts.len();
+
+        self.last_run
+            .retain(|name, _| current_pulse_names.contains(name));
+        self.run_counts
+            .retain(|name, _| current_pulse_names.contains(name));
+
+        let pruned =
+            self.last_run.len() != last_run_before || self.run_counts.len() != run_counts_before;
+        if pruned {
+            tracing::debug!(
+                removed_last_run = last_run_before - self.last_run.len(),
+                removed_run_counts = run_counts_before - self.run_counts.len(),
+                "pruned pulse state for pulses no longer in HEARTBEAT.yml"
+            );
+        }
+        pruned
     }
 
     /// Reset run count if the current active window start differs from
@@ -585,6 +619,78 @@ pulses:
         assert!(
             last_run.contains_key("test_pulse"),
             "should contain the pulse name"
+        );
+    }
+
+    #[test]
+    fn due_pulses_prunes_state_for_pulses_removed_from_heartbeat() {
+        let dir = tempdir().unwrap();
+        let hb_path = write_heartbeat(dir.path(), SIMPLE_HEARTBEAT); // only "test_pulse"
+        let state_path = dir.path().join("pulse_state.json");
+
+        let earlier = chrono::NaiveDate::from_ymd_opt(2026, 2, 19)
+            .unwrap()
+            .and_hms_opt(11, 0, 0)
+            .unwrap();
+
+        // Seed state (via the real persistence path) as if a pulse named
+        // "removed_pulse" used to exist in HEARTBEAT.yml and has since been
+        // deleted or renamed, plus a still-valid entry for "test_pulse".
+        {
+            let mut sched = PulseScheduler::new();
+            sched.last_run.insert("removed_pulse".to_string(), earlier);
+            sched.last_run.insert("test_pulse".to_string(), earlier);
+            sched.run_counts.insert("removed_pulse".to_string(), 5);
+            sched.state_path = Some(state_path.clone());
+            sched.save_state().unwrap();
+        }
+
+        let mut sched = PulseScheduler::with_state_path(&state_path);
+        assert!(
+            sched.last_run.contains_key("removed_pulse"),
+            "sanity check: stale entry should be loaded from disk"
+        );
+
+        let tick_time = chrono::NaiveDate::from_ymd_opt(2026, 2, 19)
+            .unwrap()
+            .and_hms_opt(12, 0, 0)
+            .unwrap();
+        let due = sched.due_pulses(tick_time, &hb_path);
+        assert_eq!(
+            due.len(),
+            1,
+            "test_pulse should still fire (1h since last run)"
+        );
+
+        assert!(
+            !sched.last_run.contains_key("removed_pulse"),
+            "stale last_run entry should be pruned in memory"
+        );
+        assert!(
+            !sched.run_counts.contains_key("removed_pulse"),
+            "stale run_counts entry should be pruned in memory"
+        );
+        assert!(
+            sched.last_run.contains_key("test_pulse"),
+            "state for pulses still in HEARTBEAT.yml should be preserved"
+        );
+
+        // Reload from disk to confirm the prune was persisted, not just in-memory.
+        let contents = std::fs::read_to_string(&state_path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents).unwrap();
+        let last_run = parsed.get("last_run").unwrap().as_object().unwrap();
+        assert!(
+            !last_run.contains_key("removed_pulse"),
+            "stale entry should not survive save/reload"
+        );
+        assert!(
+            last_run.contains_key("test_pulse"),
+            "current pulse entry should survive save/reload"
+        );
+        let run_counts = parsed.get("run_counts").unwrap().as_object().unwrap();
+        assert!(
+            !run_counts.contains_key("removed_pulse"),
+            "stale run_counts entry should not survive save/reload"
         );
     }
 

--- a/src/pulse/types.rs
+++ b/src/pulse/types.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::Path;
 
 use chrono::{Duration, NaiveDateTime, NaiveTime};
@@ -138,13 +139,71 @@ where
 
 /// Load HEARTBEAT.yml from the given path.
 ///
-/// On parse error, logs a warning and returns `None` so the caller keeps the last good config.
-/// Returns `None` if the file does not exist.
+/// `last_parse_error` carries the most recently logged parse-error message across
+/// calls (this is hot-reloaded on every scheduler tick). A parse failure is logged
+/// at `warn` only the first time it's seen or when the error text changes; an
+/// identical, still-broken file logs at `debug` instead so a typo in HEARTBEAT.yml
+/// doesn't repeat the same warning forever. Returns `None` on parse error (caller
+/// keeps the last good config) or if the file does not exist.
+///
+/// Duplicate pulse names are dropped, keeping the first occurrence: `PulseScheduler`
+/// keys its per-pulse state by name, so two pulses sharing a name would otherwise
+/// silently collapse into one scheduler-state entry.
 #[must_use]
-pub(crate) fn load_heartbeat(path: &Path) -> Option<HeartbeatConfig> {
-    let cfg = read_and_parse(path, |s| serde_yaml_ng::from_str::<HeartbeatConfig>(s))?;
+pub(crate) fn load_heartbeat(
+    path: &Path,
+    last_parse_error: &mut Option<String>,
+) -> Option<HeartbeatConfig> {
+    let mut cfg = match std::fs::read_to_string(path) {
+        Ok(contents) => match serde_yaml_ng::from_str::<HeartbeatConfig>(&contents) {
+            Ok(cfg) => {
+                if last_parse_error.take().is_some() {
+                    tracing::info!(path = %path.display(), "HEARTBEAT.yml parses again after previous errors");
+                }
+                cfg
+            }
+            Err(e) => {
+                let message = e.to_string();
+                if last_parse_error.as_deref() == Some(message.as_str()) {
+                    tracing::debug!(path = %path.display(), error = %message, "HEARTBEAT.yml still fails to parse");
+                } else {
+                    tracing::warn!(path = %path.display(), error = %message, "failed to parse HEARTBEAT.yml; pulses will not fire until this is fixed");
+                    *last_parse_error = Some(message);
+                }
+                return None;
+            }
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            *last_parse_error = None;
+            return None;
+        }
+        Err(e) => {
+            tracing::warn!(path = %path.display(), error = %e, "failed to read file");
+            return None;
+        }
+    };
+
+    dedupe_pulse_names(&mut cfg.pulses);
+
     tracing::trace!(path = %path.display(), pulses = cfg.pulses.len(), "loaded HEARTBEAT.yml");
     Some(cfg)
+}
+
+/// Drop pulses whose name duplicates an earlier one in the list, keeping the first.
+///
+/// Logs a warning per duplicate so a HEARTBEAT.yml typo (copy-pasted pulse block
+/// with an unchanged `name`) is visible rather than silently overwriting scheduler
+/// state for the earlier pulse of the same name.
+fn dedupe_pulse_names(pulses: &mut Vec<PulseDef>) {
+    let mut seen = HashSet::new();
+    pulses.retain(|pulse| {
+        if seen.insert(pulse.name.clone()) {
+            true
+        } else {
+            tracing::warn!(pulse = %pulse.name, "duplicate pulse name in HEARTBEAT.yml, skipping");
+            false
+        }
+    });
 }
 
 #[cfg(test)]
@@ -493,8 +552,9 @@ pulses:
     fn load_heartbeat_missing_file_returns_none() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("HEARTBEAT.yml");
+        let mut last_error = None;
         assert!(
-            load_heartbeat(&path).is_none(),
+            load_heartbeat(&path, &mut last_error).is_none(),
             "missing file should return None"
         );
     }
@@ -522,9 +582,95 @@ pulses:
         let dir = tempdir().unwrap();
         let path = dir.path().join("HEARTBEAT.yml");
         std::fs::write(&path, "not: valid: yaml: [[[").unwrap();
+        let mut last_error = None;
         assert!(
-            load_heartbeat(&path).is_none(),
+            load_heartbeat(&path, &mut last_error).is_none(),
             "invalid YAML should return None"
+        );
+    }
+
+    #[test]
+    fn load_heartbeat_repeated_identical_error_not_rewarned() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("HEARTBEAT.yml");
+        std::fs::write(&path, "not: valid: yaml: [[[").unwrap();
+        let mut last_error = None;
+
+        assert!(load_heartbeat(&path, &mut last_error).is_none());
+        assert!(
+            last_error.is_some(),
+            "first parse failure should record the error text"
+        );
+        let recorded = last_error.clone();
+
+        // Same broken file parsed again on a later tick: the recorded error is
+        // unchanged, so the caller can tell this isn't a new failure worth a
+        // fresh warning (see load_heartbeat's dedup behavior).
+        assert!(load_heartbeat(&path, &mut last_error).is_none());
+        assert_eq!(
+            last_error, recorded,
+            "identical repeated parse error should not change the recorded message"
+        );
+    }
+
+    #[test]
+    fn load_heartbeat_recovering_clears_last_error() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("HEARTBEAT.yml");
+        std::fs::write(&path, "not: valid: yaml: [[[").unwrap();
+        let mut last_error = None;
+        assert!(load_heartbeat(&path, &mut last_error).is_none());
+        assert!(last_error.is_some(), "broken file should record an error");
+
+        std::fs::write(&path, SIMPLE_VALID_HEARTBEAT).unwrap();
+        let cfg = load_heartbeat(&path, &mut last_error);
+        assert!(cfg.is_some(), "fixed file should parse successfully");
+        assert!(
+            last_error.is_none(),
+            "successful parse should clear the recorded error"
+        );
+    }
+
+    const SIMPLE_VALID_HEARTBEAT: &str = r#"
+pulses:
+  - name: test_pulse
+    schedule: "1h"
+    tasks: []
+"#;
+
+    #[test]
+    fn load_heartbeat_dedupes_duplicate_pulse_names() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("HEARTBEAT.yml");
+        let yaml = r#"
+pulses:
+  - name: dup
+    schedule: "1h"
+    tasks:
+      - name: first
+        prompt: "first"
+  - name: unique
+    schedule: "2h"
+    tasks: []
+  - name: dup
+    schedule: "3h"
+    tasks:
+      - name: second
+        prompt: "second"
+"#;
+        std::fs::write(&path, yaml).unwrap();
+        let mut last_error = None;
+        let cfg = load_heartbeat(&path, &mut last_error).unwrap();
+        let names: Vec<&str> = cfg.pulses.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(
+            names,
+            ["dup", "unique"],
+            "second pulse named 'dup' should be dropped, keeping the first occurrence"
+        );
+        assert_eq!(
+            cfg.pulses.first().unwrap().schedule,
+            "1h",
+            "the surviving 'dup' pulse should be the first one in the file"
         );
     }
 }

--- a/src/skills/index.rs
+++ b/src/skills/index.rs
@@ -122,9 +122,10 @@ async fn scan_skill_directory(
         }
     };
 
+    let mut dir_entries = Vec::new();
     loop {
-        let entry = match read_dir.next_entry().await {
-            Ok(Some(e)) => e,
+        match read_dir.next_entry().await {
+            Ok(Some(e)) => dir_entries.push(e),
             Ok(None) => break,
             Err(e) => {
                 tracing::warn!(
@@ -132,10 +133,19 @@ async fn scan_skill_directory(
                     error = %e,
                     "failed to read skills directory entry"
                 );
-                continue;
             }
-        };
+        }
+    }
 
+    // `read_dir` order is filesystem/platform-dependent, not sorted. Two skill
+    // folders in this same directory sharing a `name` (e.g. a copy-pasted
+    // folder someone forgot to rename) would otherwise let the dedup winner
+    // below flip nondeterministically across restarts or machines. Sorting by
+    // folder name makes "first found" deterministic within a directory too,
+    // not just across the `dirs` entries passed to `scan`.
+    dir_entries.sort_by_key(tokio::fs::DirEntry::file_name);
+
+    for entry in dir_entries {
         let file_type = match entry.file_type().await {
             Ok(ft) => ft,
             Err(e) => {
@@ -402,6 +412,53 @@ mod tests {
             index.entries().first().unwrap().description,
             "First",
             "should keep first found"
+        );
+    }
+
+    #[tokio::test]
+    async fn scan_same_directory_duplicate_names_keeps_deterministic_first() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Two skill folders in the SAME directory sharing a `name` — e.g. a
+        // copy-pasted skill folder the author forgot to rename. `read_dir`
+        // order is filesystem/platform-dependent, so without sorting the
+        // winner could flip across restarts or machines. Folder names are
+        // chosen so alphabetical order differs from likely creation order.
+        let skill_z = dir.path().join("z-dupe");
+        tokio::fs::create_dir(&skill_z).await.unwrap();
+        tokio::fs::write(
+            skill_z.join("SKILL.md"),
+            "---\nname: dupe\ndescription: \"From z-dupe\"\n---\n",
+        )
+        .await
+        .unwrap();
+
+        let skill_a = dir.path().join("a-dupe");
+        tokio::fs::create_dir(&skill_a).await.unwrap();
+        tokio::fs::write(
+            skill_a.join("SKILL.md"),
+            "---\nname: dupe\ndescription: \"From a-dupe\"\n---\n",
+        )
+        .await
+        .unwrap();
+
+        let index = SkillIndex::scan(&[dir.path().to_path_buf()], None)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            index.entries().len(),
+            1,
+            "should deduplicate same-name skills within one directory"
+        );
+        let entry = index.entries().first().unwrap();
+        assert_eq!(
+            entry.description, "From a-dupe",
+            "winner should be the alphabetically-first folder name, regardless of readdir order"
+        );
+        assert_eq!(
+            entry.skill_dir, skill_a,
+            "winning skill_dir should be the alphabetically-first folder"
         );
     }
 

--- a/src/skills/index.rs
+++ b/src/skills/index.rs
@@ -1,6 +1,8 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
+use crate::util::xml_escape;
+
 use super::{
     parser::parse_skill_md,
     types::{SkillIndexEntry, SkillSource},
@@ -96,12 +98,6 @@ impl SkillIndex {
     pub fn entries(&self) -> &[SkillIndexEntry] {
         &self.entries
     }
-}
-
-fn xml_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
 }
 
 /// Scan a single directory for skill subfolders.

--- a/src/skills/parser.rs
+++ b/src/skills/parser.rs
@@ -2,15 +2,26 @@ use anyhow::Context;
 
 use super::types::SkillFrontmatter;
 
+/// Hard ceiling on `description` length.
+///
+/// `skill-authoring` doctrine (see `docs/systems-usage/skills.md`) asks
+/// authors to keep descriptions under ~60 characters so the skill index
+/// stays scannable. That's a style guideline, not a wire limit, so the
+/// enforced cap here is generous headroom above it — just enough to catch
+/// a runaway multi-paragraph description before it gets concatenated into
+/// every `<available_skills>` block sent on every turn.
+pub(super) const MAX_DESCRIPTION_LEN: usize = 280;
+
 /// Parse a `SKILL.md` file into frontmatter and body.
 ///
 /// Expects YAML frontmatter delimited by `---` at the start of the file.
 /// Validates the skill name: 1-64 chars, lowercase alphanumeric + hyphens,
-/// no leading/trailing/consecutive hyphens.
+/// no leading/trailing/consecutive hyphens. Validates the description is
+/// non-empty and no longer than `MAX_DESCRIPTION_LEN` chars.
 ///
 /// # Errors
 /// Returns an error if the frontmatter is missing, invalid YAML, or the
-/// name fails validation.
+/// name or description fails validation.
 pub(super) fn parse_skill_md(content: &str) -> anyhow::Result<(SkillFrontmatter, String)> {
     let trimmed = content.trim_start();
 
@@ -26,6 +37,7 @@ pub(super) fn parse_skill_md(content: &str) -> anyhow::Result<(SkillFrontmatter,
         serde_yaml_ng::from_str(yaml_str).context("failed to parse SKILL.md frontmatter")?;
 
     validate_skill_name(&frontmatter.name)?;
+    validate_skill_description(&frontmatter.description)?;
 
     let body = after_close.trim().to_string();
 
@@ -62,10 +74,31 @@ pub(super) fn validate_skill_name(name: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Validate a skill description: non-empty and no longer than
+/// `MAX_DESCRIPTION_LEN` chars.
+///
+/// Every activated skill's description is concatenated into the
+/// `<available_skills>` block sent on every turn, so an unbounded
+/// description silently bloats every subsequent prompt.
+pub(super) fn validate_skill_description(description: &str) -> anyhow::Result<()> {
+    if description.trim().is_empty() {
+        anyhow::bail!("skill description must not be empty");
+    }
+
+    let len = description.chars().count();
+    if len > MAX_DESCRIPTION_LEN {
+        anyhow::bail!(
+            "skill description must be at most {MAX_DESCRIPTION_LEN} characters, got {len}"
+        );
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "test code uses unwrap for clarity")]
 mod tests {
-    use super::{parse_skill_md, validate_skill_name};
+    use super::{parse_skill_md, validate_skill_description, validate_skill_name};
 
     // ── parse_skill_md ───────────────────────────────────────────────────────
 
@@ -113,6 +146,25 @@ mod tests {
         assert!(
             parse_skill_md(content).is_err(),
             "invalid YAML should error"
+        );
+    }
+
+    #[test]
+    fn parse_skill_empty_description_rejected() {
+        let content = "---\nname: my-skill\ndescription: \"\"\n---\n";
+        assert!(
+            parse_skill_md(content).is_err(),
+            "empty description should error"
+        );
+    }
+
+    #[test]
+    fn parse_skill_description_too_long_rejected() {
+        let long_description = "a".repeat(281);
+        let content = format!("---\nname: my-skill\ndescription: \"{long_description}\"\n---\n");
+        assert!(
+            parse_skill_md(&content).is_err(),
+            "description over 280 chars should error"
         );
     }
 
@@ -194,6 +246,44 @@ mod tests {
         assert!(
             validate_skill_name("bad name").is_err(),
             "space should be rejected"
+        );
+    }
+
+    // ── validate_skill_description ──────────────────────────────────────────
+
+    #[test]
+    fn valid_description_accepted() {
+        assert!(validate_skill_description("Extracts text from PDFs").is_ok());
+    }
+
+    #[test]
+    fn description_empty_rejected() {
+        assert!(
+            validate_skill_description("").is_err(),
+            "empty description should be rejected"
+        );
+    }
+
+    #[test]
+    fn description_whitespace_only_rejected() {
+        assert!(
+            validate_skill_description("   \n\t  ").is_err(),
+            "whitespace-only description should be rejected"
+        );
+    }
+
+    #[test]
+    fn description_exactly_max_len_accepted() {
+        let description = "a".repeat(280);
+        assert!(validate_skill_description(&description).is_ok());
+    }
+
+    #[test]
+    fn description_too_long_rejected() {
+        let description = "a".repeat(281);
+        assert!(
+            validate_skill_description(&description).is_err(),
+            "description over 280 chars should be rejected"
         );
     }
 }

--- a/src/skills/state.rs
+++ b/src/skills/state.rs
@@ -67,6 +67,7 @@ impl SkillState {
         self.active.push(ActiveSkill {
             name: entry.name.clone(),
             body,
+            skill_dir: entry.skill_dir.clone(),
         });
 
         tracing::info!("skill activated");
@@ -95,6 +96,10 @@ impl SkillState {
     /// Rescan skill directories to rebuild the index.
     ///
     /// Removes any active skills whose names no longer appear in the new index.
+    /// For an active skill whose name still resolves but whose backing source
+    /// directory changed (e.g. a project skill now shadows a workspace skill
+    /// of the same name), refreshes its body from the new source, or
+    /// deactivates it with a warning if the new source can't be loaded.
     ///
     /// # Errors
     /// Returns an error if scanning fails.
@@ -112,14 +117,60 @@ impl SkillState {
             "skill rescan complete"
         );
 
-        // Remove active skills that no longer exist in the index
-        self.active.retain(|a| {
-            let found = self.index.find_by_name(&a.name).is_some();
-            if !found {
-                tracing::warn!(name = %a.name, "deactivating skill: no longer found after rescan");
+        // Reconcile active skills against the new index. A name surviving the
+        // rescan is not enough on its own: the *same name* can now resolve to
+        // a different physical skill (e.g. a project's `skills/notes/` now
+        // shadows what used to be the workspace `notes` skill). An
+        // already-active skill's body was captured at activation time, so if
+        // we only checked the name we'd keep serving stale instructions under
+        // a name the index now attributes to a different source, with no
+        // signal to the agent that anything changed. Refresh from the new
+        // source when the backing directory changed; if the new source can't
+        // be loaded, deactivate rather than silently keep the stale copy.
+        let previously_active = std::mem::take(&mut self.active);
+        let mut still_active = Vec::with_capacity(previously_active.len());
+        for active_skill in previously_active {
+            let Some(entry) = self.index.find_by_name(&active_skill.name) else {
+                tracing::warn!(name = %active_skill.name, "deactivating skill: no longer found after rescan");
+                continue;
+            };
+
+            if entry.skill_dir == active_skill.skill_dir {
+                still_active.push(active_skill);
+                continue;
             }
-            found
-        });
+
+            let skill_md_path = entry.skill_dir.join("SKILL.md");
+            match tokio::fs::read_to_string(&skill_md_path)
+                .await
+                .with_context(|| format!("failed to read SKILL.md for '{}'", entry.name))
+                .and_then(|content| parse_skill_md(&content))
+            {
+                Ok((_fm, body)) => {
+                    tracing::warn!(
+                        name = %active_skill.name,
+                        old_source = %active_skill.skill_dir.display(),
+                        new_source = %entry.skill_dir.display(),
+                        "active skill's backing source changed after rescan; refreshed body from new source"
+                    );
+                    still_active.push(ActiveSkill {
+                        name: entry.name.clone(),
+                        body,
+                        skill_dir: entry.skill_dir.clone(),
+                    });
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        name = %active_skill.name,
+                        old_source = %active_skill.skill_dir.display(),
+                        new_source = %entry.skill_dir.display(),
+                        error = %e,
+                        "deactivating skill: backing source changed after rescan and new source failed to load"
+                    );
+                }
+            }
+        }
+        self.active = still_active;
 
         Ok(())
     }
@@ -174,6 +225,7 @@ impl SkillState {
 
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "test code uses unwrap for clarity")]
+#[expect(clippy::panic, reason = "test code panics on unexpected match arm")]
 mod tests {
     use super::super::index::SkillIndex;
     use super::SkillState;
@@ -308,6 +360,65 @@ mod tests {
             vec!["test-skill"],
             "active skill should remain after rescan when dir is unchanged"
         );
+    }
+
+    #[tokio::test]
+    async fn rescan_refreshes_active_skill_when_source_changes() {
+        let ws_dir = tempfile::tempdir().unwrap();
+        let proj_dir = tempfile::tempdir().unwrap();
+
+        // Workspace skill named "notes" is active.
+        let ws_skill = ws_dir.path().join("notes");
+        tokio::fs::create_dir(&ws_skill).await.unwrap();
+        tokio::fs::write(
+            ws_skill.join("SKILL.md"),
+            "---\nname: notes\ndescription: \"Workspace notes\"\n---\n\nWorkspace body.\n",
+        )
+        .await
+        .unwrap();
+
+        let index = SkillIndex::scan(&[ws_dir.path().to_path_buf()], None)
+            .await
+            .unwrap();
+        let mut state = SkillState::new(index, vec![ws_dir.path().to_path_buf()]);
+
+        let active = state.activate("notes").await.unwrap();
+        assert!(active.body.contains("Workspace body."));
+
+        // A project defining its own higher-priority "notes" skill becomes
+        // active (mirrors `project_activate` calling `rescan(Some(project_skills_dir))`).
+        let proj_skill = proj_dir.path().join("notes");
+        tokio::fs::create_dir(&proj_skill).await.unwrap();
+        tokio::fs::write(
+            proj_skill.join("SKILL.md"),
+            "---\nname: notes\ndescription: \"Project notes\"\n---\n\nProject body.\n",
+        )
+        .await
+        .unwrap();
+
+        state.rescan(Some(proj_dir.path())).await.unwrap();
+
+        // The index now attributes "notes" to the project skill. The
+        // already-active skill must not keep silently serving the old
+        // workspace body under that name: it must either be refreshed to
+        // reflect the new (project) source, or deactivated outright.
+        match state.active_skill_names().as_slice() {
+            [] => {
+                // Deactivating instead of refreshing is an acceptable, non-stale outcome.
+            }
+            ["notes"] => {
+                let prompt = state.format_active_for_prompt().unwrap();
+                assert!(
+                    prompt.contains("Project body."),
+                    "active skill should reflect the new higher-priority source"
+                );
+                assert!(
+                    !prompt.contains("Workspace body."),
+                    "must not keep silently serving the stale workspace body"
+                );
+            }
+            other => panic!("unexpected active skills after rescan: {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/src/skills/types.rs
+++ b/src/skills/types.rs
@@ -53,4 +53,11 @@ pub struct ActiveSkill {
     pub name: String,
     /// Markdown body from `SKILL.md` (everything after frontmatter).
     pub body: String,
+    /// Absolute path to the skill directory this body was read from.
+    ///
+    /// Names alone aren't stable identity: a rescan can make the same name
+    /// resolve to a different physical skill (e.g. a project skill shadowing
+    /// a workspace one). This field lets `rescan` detect that the backing
+    /// source changed even though the name still matches.
+    pub skill_dir: PathBuf,
 }

--- a/src/subagents/index.rs
+++ b/src/subagents/index.rs
@@ -4,6 +4,8 @@ use std::path::Path;
 
 use anyhow::Context;
 
+use crate::util::xml_escape;
+
 use super::parser::parse_preset_md;
 use super::types::{SubagentPresetEntry, SubagentPresetFrontmatter};
 
@@ -94,7 +96,8 @@ impl SubagentPresetIndex {
         for entry in &self.entries {
             parts.push(format!(
                 "  <subagent>\n    <name>{}</name>\n    <description>{}</description>\n  </subagent>",
-                entry.name, entry.description,
+                xml_escape(&entry.name),
+                xml_escape(&entry.description),
             ));
         }
 
@@ -486,6 +489,35 @@ mod tests {
         assert!(
             output.contains("<description>Research specialist</description>"),
             "should contain description"
+        );
+    }
+
+    #[test]
+    fn format_for_prompt_escapes_xml_special_chars() {
+        let index = SubagentPresetIndex {
+            entries: vec![SubagentPresetEntry {
+                name: "researcher".to_string(),
+                description: "Handles <tags> & \"quotes\", even </available_subagents>".to_string(),
+                preset_path: Some(PathBuf::from("/tmp/researcher.md")),
+            }],
+        };
+
+        let output = index.format_for_prompt();
+        assert!(output.contains("&lt;tags&gt;"), "< and > should be escaped");
+        assert!(output.contains("&amp;"), "& should be escaped");
+        assert!(
+            !output.contains("<tags>"),
+            "raw < should not appear in output"
+        );
+        assert!(
+            output.contains("&lt;/available_subagents&gt;"),
+            "a closing-tag lookalike in the description must be escaped, not passed through raw"
+        );
+        assert_eq!(
+            output.matches("</available_subagents>").count(),
+            1,
+            "only the real closing tag should appear unescaped; a smuggled one \
+             from the description would close the list early"
         );
     }
 

--- a/src/subagents/mod.rs
+++ b/src/subagents/mod.rs
@@ -1,3 +1,15 @@
+//! Subagent presets: disk-backed definitions for spawnable background agents.
+//!
+//! A subagent preset is a `.md` file with YAML frontmatter (name, description,
+//! model tier, tool restrictions) plus a prompt body, discovered from a
+//! presets directory. `SubagentPresetIndex` scans and looks up presets;
+//! `SubagentRegistry` is the bus participant that subscribes to spawn
+//! requests and turns a matched preset into a running background task.
+//! Callers: `agent/context/loading.rs` and `tools/background.rs` scan the
+//! index to list/validate presets, `background/spawn_context.rs` loads a
+//! preset by name to spawn it, and `gateway/event_loop/run_loop.rs` builds
+//! the `SubagentRegistry` and wires it onto the bus at startup.
+
 pub mod index;
 pub mod parser;
 pub mod registry;

--- a/src/subagents/registry.rs
+++ b/src/subagents/registry.rs
@@ -10,6 +10,8 @@ use std::sync::Arc;
 use rand::Rng;
 use tokio::task::JoinHandle;
 
+use anyhow::Context as _;
+
 use crate::background::BackgroundTaskSpawner;
 use crate::background::spawn_context::{
     SpawnContext, build_spawn_resources, load_preset_for_spawn,
@@ -20,6 +22,7 @@ use crate::config::BackgroundModelTier;
 use crate::mcp::SharedMcpRegistry;
 use crate::projects::activation::SharedProjectState;
 use crate::skills::SharedSkillState;
+use crate::subagents::SubagentPresetIndex;
 
 /// Holds references needed to spawn sub-agents on behalf of bus callers.
 pub struct SubagentRegistry {
@@ -112,12 +115,21 @@ async fn handle_spawn_request(
 ) -> Result<(), anyhow::Error> {
     let preset_name = event.preset.as_ref().to_string();
 
-    let preset_result = load_preset_for_spawn(
-        &registry.subagents_dir,
-        &preset_name,
-        BackgroundModelTier::Medium,
-    )
-    .await;
+    // Scan once and reuse the index for both the primary lookup and the
+    // general-purpose fallback below — the directory doesn't change between
+    // the two lookups, so a second scan would just re-read and re-parse
+    // every preset file to fetch a built-in that needs no disk I/O.
+    let index = SubagentPresetIndex::scan(&registry.subagents_dir)
+        .await
+        .with_context(|| {
+            format!(
+                "failed to scan subagents directory {}",
+                registry.subagents_dir.display()
+            )
+        })?;
+
+    let preset_result =
+        load_preset_for_spawn(&index, &preset_name, BackgroundModelTier::Medium).await;
 
     let (preset_tier, preset_fm, preset_body, effective_preset_name) = match preset_result {
         Ok((tier, fm, body)) => (tier, fm, body, preset_name.clone()),
@@ -127,12 +139,9 @@ async fn handle_spawn_request(
                 error = %e,
                 "failed to load preset, falling back to general-purpose"
             );
-            let (tier, fm, body) = load_preset_for_spawn(
-                &registry.subagents_dir,
-                "general-purpose",
-                BackgroundModelTier::Medium,
-            )
-            .await?;
+            let (tier, fm, body) =
+                load_preset_for_spawn(&index, "general-purpose", BackgroundModelTier::Medium)
+                    .await?;
             (tier, fm, body, "general-purpose".to_string())
         }
     };

--- a/src/tools/TOOLS.md
+++ b/src/tools/TOOLS.md
@@ -219,7 +219,7 @@ On error:
 
 ### Output
 
-On success: summary string like `"Activated project '{name}'. Manifest: {N} notes, {N} references, {N} workspace, {N} skills files."`
+On success: summary string like `"Activated project '{name}'. Manifest: {N} notes, {N} references, {N} workspace, {N} skills files."`, followed by one `warning: ...` line per non-fatal failure (MCP server reference resolution, MCP server start, or skill rescan) if any occurred.
 
 On error: project not found or activation failure message.
 
@@ -242,7 +242,7 @@ On error: project not found or activation failure message.
 
 ### Output
 
-On success: `"Deactivated project '{name}'. Log entry recorded."`
+On success: `"Deactivated project '{name}'. Log entry recorded."`, followed by a `warning: skill rescan failed: {error}` line if the post-deactivation skill rescan failed.
 
 On error: no active project, or empty `log`.
 

--- a/src/tools/TOOLS.md
+++ b/src/tools/TOOLS.md
@@ -9,7 +9,7 @@ This document is the source of truth for every tool exposed to the LLM. It must 
 **Source:** `read.rs` · `ReadTool`
 
 **Description sent to LLM:**
-> Read the contents of a file. Each output line is tagged with a content hash (e.g. `1:f1\thello`) for use with edit_file. By default returns the first 2000 lines; use offset/limit for larger files. Lines longer than 2000 characters are truncated. Image files (JPEG, PNG, GIF, WebP) are returned as inline images for visual inspection instead of raw bytes.
+> Read the contents of a file. Each output line is tagged with a content hash (e.g. `1:f1a3\thello`) for use with edit_file. By default returns the first 2000 lines; use offset/limit for larger files. Lines longer than 2000 characters are truncated. Image files (JPEG, PNG, GIF, WebP) are returned as inline images for visual inspection instead of raw bytes.
 
 ### Input
 
@@ -78,7 +78,7 @@ On error:
 |--------------|--------|----------|-----------------------------------------------------------------------------|
 | `path`       | string | yes      | Path to the file to edit                                                    |
 | `operation`  | string | yes      | One of: `"replace"`, `"insert_after"`, `"delete"`                          |
-| `start_line` | string | yes      | Line anchor as `"N:hash"` (e.g. `"5:a3"`). Use `"0"` for insert at file start |
+| `start_line` | string | yes      | Line anchor as `"N:hash"` (e.g. `"5:a3b2"`). Use `"0"` for insert at file start |
 | `end_line`   | string | no*      | End line anchor `"N:hash"`. Required for `replace` (use same anchor as `start_line` for single-line). Optional for `delete`. Not used by `insert_after`. |
 | `content`    | string | no**     | New content. Required for `replace` and `insert_after`; omitted for `delete` |
 
@@ -525,6 +525,32 @@ On partial failure: success message plus `"Failed to archive {N} item(s): {error
 On total failure: error with failure details.
 
 **Side effect:** Moves `.json` files from inbox to `archive/inbox/`.
+
+---
+
+## `user_inbox_add`
+
+**Source:** `inbox.rs` · `UserInboxAddTool`
+
+**Description sent to LLM:**
+> Add a new item to the user's inbox. Use this to explicitly send notes, reminders, or items for the human user to review later.
+
+### Input
+
+| Parameter | Type   | Required | Description                        |
+|-----------|--------|----------|-------------------------------------|
+| `title`   | string | yes      | A short summary of the item        |
+| `body`    | string | yes      | The detailed content of the item   |
+
+### Output
+
+On success: `"Added item to user inbox with ID: {filename stem}"`
+
+On error:
+- Missing `title` or `body`
+- Failed to write the item to disk
+
+**Side effect:** Writes a new `.json` file to `inbox/user/`, tagged with source `"agent"`. This is a separate inbox from the agent inbox (`inbox_list`/`inbox_read`/`inbox_archive`) — the agent has no tool to list, read, or archive items here; only the user reads and archives them via the web UI.
 
 ---
 

--- a/src/tools/edit.rs
+++ b/src/tools/edit.rs
@@ -27,17 +27,17 @@ impl EditTool {
     }
 }
 
-/// Parsed line anchor: (1-indexed line number, 2-char hex hash).
+/// Parsed line anchor: (1-indexed line number, 4-char hex hash).
 struct LineAnchor {
     line_num: usize,
     hash: String,
 }
 
-/// Parse a `"line:hash"` string (e.g. `"5:a3"`) into its components.
+/// Parse a `"line:hash"` string (e.g. `"5:a3b2"`) into its components.
 fn parse_anchor(value: &str) -> Result<LineAnchor, ToolError> {
     let Some((num_str, hash_str)) = value.split_once(':') else {
         return Err(ToolError::InvalidArguments(format!(
-            "invalid line:hash format '{value}', expected 'N:xx' (e.g. '5:a3')"
+            "invalid line:hash format '{value}', expected 'N:xxxx' (e.g. '5:a3b2')"
         )));
     };
 
@@ -45,9 +45,9 @@ fn parse_anchor(value: &str) -> Result<LineAnchor, ToolError> {
         ToolError::InvalidArguments(format!("invalid line number '{num_str}' in '{value}'"))
     })?;
 
-    if hash_str.len() != 2 || !hash_str.chars().all(|c| c.is_ascii_hexdigit()) {
+    if hash_str.len() != 4 || !hash_str.chars().all(|c| c.is_ascii_hexdigit()) {
         return Err(ToolError::InvalidArguments(format!(
-            "invalid hash '{hash_str}' in '{value}', expected 2 hex characters"
+            "invalid hash '{hash_str}' in '{value}', expected 4 hex characters"
         )));
     }
 
@@ -278,7 +278,7 @@ impl Tool for EditTool {
                     },
                     "start_line": {
                         "type": "string",
-                        "description": "Line anchor as 'N:hash' (e.g. '5:a3'). Use '0' for insert_after at file start."
+                        "description": "Line anchor as 'N:hash' (e.g. '5:a3b2'). Use '0' for insert_after at file start."
                     },
                     "end_line": {
                         "type": "string",
@@ -613,8 +613,8 @@ mod tests {
             .execute(serde_json::json!({
                 "path": path,
                 "operation": "replace",
-                "start_line": "1:ff",
-                "end_line": "1:ff",
+                "start_line": "1:ffff",
+                "end_line": "1:ffff",
                 "content": "replaced"
             }))
             .await
@@ -636,8 +636,8 @@ mod tests {
             .execute(serde_json::json!({
                 "path": "/nonexistent/edit_target.txt",
                 "operation": "replace",
-                "start_line": "1:aa",
-                "end_line": "1:aa",
+                "start_line": "1:aaaa",
+                "end_line": "1:aaaa",
                 "content": "x"
             }))
             .await
@@ -661,8 +661,8 @@ mod tests {
             .execute(serde_json::json!({
                 "path": file_path.to_str().unwrap(),
                 "operation": "replace",
-                "start_line": "1:aa",
-                "end_line": "1:aa",
+                "start_line": "1:aaaa",
+                "end_line": "1:aaaa",
                 "content": "x"
             }))
             .await
@@ -737,19 +737,19 @@ mod tests {
         let long_hash = tool
             .execute(serde_json::json!({
                 "path": "/tmp/x", "operation": "replace",
-                "start_line": "1:aabb", "content": "x"
+                "start_line": "1:aabbcc", "content": "x"
             }))
             .await;
         assert!(long_hash.is_err(), "hash too long should error");
 
-        // Non-hex characters in hash (2-char but not valid hex)
+        // Non-hex characters in hash (4-char but not valid hex)
         let non_hex = tool
             .execute(serde_json::json!({
                 "path": "/tmp/x", "operation": "replace",
-                "start_line": "1:zz", "content": "x"
+                "start_line": "1:zzzz", "content": "x"
             }))
             .await;
-        assert!(non_hex.is_err(), "non-hex 2-char hash should error");
+        assert!(non_hex.is_err(), "non-hex 4-char hash should error");
     }
 
     #[tokio::test]
@@ -759,8 +759,8 @@ mod tests {
             .execute(serde_json::json!({
                 "path": "/tmp/x",
                 "operation": "replace",
-                "start_line": "5:aa",
-                "end_line": "2:bb",
+                "start_line": "5:aaaa",
+                "end_line": "2:bbbb",
                 "content": "x"
             }))
             .await;

--- a/src/tools/line_hash.rs
+++ b/src/tools/line_hash.rs
@@ -1,6 +1,6 @@
 //! Line content hashing for staleness detection.
 //!
-//! Produces a 2-character hex hash for each line of text. Used by `ReadTool`
+//! Produces a 4-character hex hash for each line of text. Used by `ReadTool`
 //! to tag output lines and by `EditTool` to validate that lines haven't changed.
 
 /// Compute FNV-1a hash of a byte slice.
@@ -13,14 +13,17 @@ fn fnv1a(bytes: &[u8]) -> u64 {
     hash
 }
 
-/// Compute a 2-character hex hash for a line of text.
+/// Compute a 4-character hex hash for a line of text.
 ///
-/// Returns the lower byte of the FNV-1a hash formatted as 2 hex digits
-/// (e.g. `"f1"`, `"a3"`, `"0e"`).
+/// Returns the lower 16 bits of the FNV-1a hash formatted as 4 hex digits
+/// (e.g. `"f1a3"`, `"00e2"`). Widened from a single byte (256 buckets) to
+/// 16 bits (65,536 buckets) because `EditTool` relies on this as its sole
+/// staleness check — a narrower hash collides often enough on common short
+/// lines (`}`, blank lines, `);`) to silently defeat that check.
 #[must_use]
 pub fn line_hash(content: &str) -> String {
-    let lower_byte = (fnv1a(content.as_bytes()) & 0xFF) as u8;
-    format!("{lower_byte:02x}")
+    let lower_16_bits = (fnv1a(content.as_bytes()) & 0xFFFF) as u16;
+    format!("{lower_16_bits:04x}")
 }
 
 #[cfg(test)]
@@ -39,9 +42,9 @@ mod tests {
         let h1 = line_hash("fn main() {");
         let h2 = line_hash("fn foo() {");
         let h3 = line_hash("let x = 42;");
-        assert_eq!(h1, "48", "hash must match reference for 'fn main() {{'");
-        assert_eq!(h2, "d3", "hash must match reference for 'fn foo() {{'");
-        assert_eq!(h3, "aa", "hash must match reference for 'let x = 42;'");
+        assert_eq!(h1, "1d48", "hash must match reference for 'fn main() {{'");
+        assert_eq!(h2, "b1d3", "hash must match reference for 'fn foo() {{'");
+        assert_eq!(h3, "d8aa", "hash must match reference for 'let x = 42;'");
         assert_ne!(
             h1, h2,
             "\"fn main() {{\" and \"fn foo() {{\" should have different hashes"
@@ -61,13 +64,13 @@ mod tests {
         let h1 = line_hash("");
         let h2 = line_hash("");
         assert_eq!(h1, h2, "empty string hash should be consistent");
-        assert_eq!(h1.len(), 2, "hash should always be 2 characters");
+        assert_eq!(h1.len(), 4, "hash should always be 4 characters");
     }
 
     #[test]
-    fn hash_is_two_hex_chars() {
+    fn hash_is_four_hex_chars() {
         let hash = line_hash("hello world");
-        assert_eq!(hash.len(), 2, "hash should be exactly 2 characters");
+        assert_eq!(hash.len(), 4, "hash should be exactly 4 characters");
         assert!(
             hash.chars().all(|c| c.is_ascii_hexdigit()),
             "hash should be valid hex"

--- a/src/tools/projects.rs
+++ b/src/tools/projects.rs
@@ -141,6 +141,7 @@ impl Tool for ProjectActivateTool {
                     .await
                 {
                     tracing::warn!(error = %e, "failed to rescan skills after project activation");
+                    warnings.push(format!("warning: skill rescan failed: {e}"));
                 }
                 tracing::info!(project = %project_name, tools = ?tools_list, "project activated");
                 let output = if warnings.is_empty() {
@@ -220,6 +221,7 @@ impl Tool for ProjectDeactivateTool {
 
         match state.deactivate(log, now).await {
             Ok(name) => {
+                let mut warnings: Vec<String> = Vec::new();
                 // Clear path policy — no project-scoped writes allowed
                 self.path_policy.write().await.set_active_project(None);
                 // Clear gated tool permissions
@@ -240,10 +242,15 @@ impl Tool for ProjectDeactivateTool {
                 // Rescan skills without project dir (removes project-scoped skills)
                 if let Err(e) = self.skill_state.lock().await.rescan(None).await {
                     tracing::warn!(error = %e, "failed to rescan skills after project deactivation");
+                    warnings.push(format!("warning: skill rescan failed: {e}"));
                 }
-                Ok(ToolResult::success(format!(
-                    "Deactivated project '{name}'. Log entry recorded."
-                )))
+                let summary = format!("Deactivated project '{name}'. Log entry recorded.");
+                let output = if warnings.is_empty() {
+                    summary
+                } else {
+                    format!("{summary}\n{}", warnings.join("\n"))
+                };
+                Ok(ToolResult::success(output))
             }
             Err(e) => Ok(ToolResult::error(e.to_string())),
         }

--- a/src/tools/read.rs
+++ b/src/tools/read.rs
@@ -71,7 +71,7 @@ impl Tool for ReadTool {
         ToolDefinition {
             name: self.name().to_string(),
             description: "Read the contents of a file. Each output line is tagged with a \
-                          content hash (e.g. `1:f1\\thello`) for use with edit_file. \
+                          content hash (e.g. `1:f1a3\\thello`) for use with edit_file. \
                           By default returns the first 2000 lines; use offset/limit for larger files. \
                           Lines longer than 2000 characters are truncated. \
                           Image files (JPEG, PNG, GIF, WebP) are returned as inline images \

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -66,6 +66,17 @@ impl ToolRegistry {
             .collect()
     }
 
+    /// Names of all registered tools, unfiltered.
+    ///
+    /// Used to reserve the built-in tool namespace in the MCP registry so a
+    /// colliding MCP tool is shadowed visibly rather than silently. The set is
+    /// unfiltered because a gated built-in still wins dispatch (it returns an
+    /// "unavailable" result rather than falling through to MCP).
+    #[must_use]
+    pub fn tool_names(&self) -> Vec<String> {
+        self.tools.iter().map(|t| t.name().to_string()).collect()
+    }
+
     /// Execute a tool by name with the given arguments, respecting the tool filter.
     ///
     /// # Errors

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,5 +1,5 @@
 //! Shared utilities: fatal errors, filesystem helpers, monitored spawning, tracing setup,
-//! and structured log formatting.
+//! structured log formatting, and XML escaping.
 
 mod error;
 pub(crate) mod fs;
@@ -7,6 +7,8 @@ pub mod log_format;
 mod spawn;
 pub mod telemetry;
 pub mod tracing_init;
+mod xml;
 
 pub use error::FatalError;
 pub use spawn::{spawn_monitored, spawn_supervised};
+pub use xml::xml_escape;

--- a/src/util/xml.rs
+++ b/src/util/xml.rs
@@ -1,0 +1,36 @@
+//! Minimal XML-escaping for author-controlled text embedded in pseudo-XML system prompts.
+
+/// Escape `&`, `<`, and `>` so untrusted text (e.g. names/descriptions from
+/// preset or skill frontmatter) cannot break out of the surrounding pseudo-XML
+/// block when interpolated into a system prompt.
+///
+/// `&` is replaced first so it doesn't double-escape the entities produced by
+/// the `<`/`>` replacements.
+#[must_use]
+pub fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::xml_escape;
+
+    #[test]
+    fn escapes_special_chars() {
+        let input = "Handles <tags> & \"quotes\"";
+        let output = xml_escape(input);
+        assert!(output.contains("&lt;tags&gt;"), "< and > should be escaped");
+        assert!(output.contains("&amp;"), "& should be escaped");
+        assert!(
+            !output.contains("<tags>"),
+            "raw < should not appear in output"
+        );
+    }
+
+    #[test]
+    fn leaves_plain_text_untouched() {
+        assert_eq!(xml_escape("plain description"), "plain description");
+    }
+}

--- a/src/workspace/config.rs
+++ b/src/workspace/config.rs
@@ -271,10 +271,26 @@ pub fn load_channel_configs(path: &Path) -> anyhow::Result<Vec<ExternalChannelCo
                     app_id: raw.app_id,
                 },
                 "webhook" => {
+                    // Keep in sync with the methods `WebhookChannel::deliver` actually
+                    // supports (src/notify/external.rs) — validate here, at config load,
+                    // so a typo surfaces at startup instead of at first delivery attempt.
+                    const SUPPORTED_METHODS: [&str; 2] = ["POST", "PUT"];
+
                     let Some(url) = raw.url.filter(|u| !u.is_empty()) else {
                         tracing::warn!(channel = %name, "webhook channel is missing required 'url' field");
                         return None;
                     };
+                    if let Some(method) = &raw.method
+                        && !SUPPORTED_METHODS.contains(&method.to_uppercase().as_str())
+                    {
+                        tracing::warn!(
+                            channel = %name,
+                            method = %method,
+                            supported = ?SUPPORTED_METHODS,
+                            "webhook channel has unsupported 'method' field, skipping channel"
+                        );
+                        return None;
+                    }
                     ExternalChannelKind::Webhook {
                         url,
                         method: raw.method,
@@ -794,6 +810,58 @@ url = "https://hooks.example.com/notify"
         let configs = load_channel_configs(&path).unwrap();
         assert_eq!(configs.len(), 1, "webhook without url should be excluded");
         assert_eq!(configs[0].name, "good-hook");
+    }
+
+    #[test]
+    fn load_channel_configs_webhook_unsupported_method_excluded() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("channels.toml");
+        std::fs::write(
+            &path,
+            r#"
+[channels.bad-hook]
+type = "webhook"
+url = "https://hooks.example.com/notify"
+method = "DELETE"
+
+[channels.good-hook]
+type = "webhook"
+url = "https://hooks.example.com/notify"
+method = "PUT"
+"#,
+        )
+        .unwrap();
+
+        let configs = load_channel_configs(&path).unwrap();
+        assert_eq!(
+            configs.len(),
+            1,
+            "webhook with unsupported method should be excluded at load time"
+        );
+        assert_eq!(configs[0].name, "good-hook");
+    }
+
+    #[test]
+    fn load_channel_configs_webhook_method_case_insensitive() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("channels.toml");
+        std::fs::write(
+            &path,
+            r#"
+[channels.lower-hook]
+type = "webhook"
+url = "https://hooks.example.com/notify"
+method = "put"
+"#,
+        )
+        .unwrap();
+
+        let configs = load_channel_configs(&path).unwrap();
+        assert_eq!(
+            configs.len(),
+            1,
+            "lowercase but otherwise-valid method should be accepted"
+        );
     }
 
     #[test]

--- a/web/src/Setup.svelte
+++ b/web/src/Setup.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from "svelte";
+  import { onMount, onDestroy } from "svelte";
   import type { SetupWizardState, McpCatalogEntry, ProviderKey } from "./lib/types";
   import { fetchTimezone, fetchMcpCatalog } from "./lib/api";
   import Welcome from "./components/setup/Welcome.svelte";
@@ -19,6 +19,7 @@
   const stepIndices = Array.from({ length: TOTAL_STEPS }, (_, i) => i);
   let step = $state(0);
   let catalog = $state<McpCatalogEntry[]>([]);
+  let completed = false;
 
   let wizardState = $state<SetupWizardState>({
     userName: "",
@@ -47,10 +48,31 @@
     secretRefs: {},
   });
 
+  // Warn before an accidental reload/close discards in-progress setup input (provider
+  // selections, role assignments, MCP servers, integration tokens). Not persisted to
+  // storage on purpose: early steps hold raw API keys in memory before they're
+  // exchanged for `secret:` references in Review.svelte, and storage would leave
+  // plaintext keys sitting in the browser.
+  function handleBeforeUnload(event: BeforeUnloadEvent) {
+    if (step > 0 && !completed) {
+      event.preventDefault();
+    }
+  }
+
+  function handleComplete() {
+    completed = true;
+    onComplete();
+  }
+
   onMount(async () => {
+    window.addEventListener("beforeunload", handleBeforeUnload);
     const [tz, cat] = await Promise.all([fetchTimezone(), fetchMcpCatalog()]);
     wizardState.timezone = tz;
     catalog = cat;
+  });
+
+  onDestroy(() => {
+    window.removeEventListener("beforeunload", handleBeforeUnload);
   });
 
   function next() {
@@ -82,7 +104,7 @@
       {:else if step === 4}
         <Integrations {wizardState} onNext={next} onBack={back} />
       {:else if step === 5}
-        <Review {wizardState} onBack={back} {onComplete} />
+        <Review {wizardState} onBack={back} onComplete={handleComplete} />
       {/if}
     </div>
   </div>

--- a/web/src/components/ChatFeed.svelte
+++ b/web/src/components/ChatFeed.svelte
@@ -256,6 +256,8 @@
       {:else if item.kind === "local-system"}
         <MessageLocalSystem content={item.content} />
       {/if}
+    {:else}
+      <div class="chat-feed-empty">Nothing here yet — send a message to begin.</div>
     {/each}
     {#if isProcessing}
       <ThinkingIndicator />

--- a/web/src/components/ModelSelector.svelte
+++ b/web/src/components/ModelSelector.svelte
@@ -5,6 +5,7 @@
   import { parseProvidersToml, serializeProvidersToml } from "../lib/settings-toml";
   import { fetchModels, type ModelEntry } from "../lib/models";
   import { withConfigLock } from "../lib/config-lock";
+  import { toast } from "../lib/toast.svelte";
   import { clickOutside } from "../lib/actions/clickOutside";
 
   let { disabled = false }: { disabled?: boolean } = $props();
@@ -67,8 +68,8 @@
         await putProvidersRaw(toml);
         ws.send({ type: "reload" });
         currentModel = modelId;
-      } catch {
-        // save failed — keep previous state
+      } catch (err: unknown) {
+        toast.error(`Save failed. ${String(err)}`);
       }
     });
 

--- a/web/src/components/ThinkingSelector.svelte
+++ b/web/src/components/ThinkingSelector.svelte
@@ -4,6 +4,7 @@
   import { fetchProvidersRaw, putProvidersRaw } from "../lib/api";
   import { parseProvidersToml, serializeProvidersToml } from "../lib/settings-toml";
   import { withConfigLock } from "../lib/config-lock";
+  import { toast } from "../lib/toast.svelte";
 
   let { disabled = false }: { disabled?: boolean } = $props();
 
@@ -45,8 +46,8 @@
         await putProvidersRaw(toml);
         ws.send({ type: "reload" });
         currentLevel = newLevel;
-      } catch {
-        // save failed
+      } catch (err: unknown) {
+        toast.error(`Save failed. ${String(err)}`);
       }
     });
 

--- a/web/src/components/Workspace.svelte
+++ b/web/src/components/Workspace.svelte
@@ -6,6 +6,7 @@
   import { toast } from "../lib/toast.svelte";
   import { Icon } from "../lib/icons";
   import FileTree from "./FileTree.svelte";
+  import Modal from "./Modal.svelte";
 
   let { onClose }: { onClose: () => void } = $props();
 
@@ -19,6 +20,8 @@
   let expandedDirs = new SvelteSet<string>();
   let treeCache = $state<Record<string, WorkspaceEntry[]>>({});
   let mobileEditorOpen = $state(false);
+  let pendingFile = $state("");
+  let discardConfirmOpen = $state(false);
 
   // Derived
   let dirty = $derived(editContent !== fileContent);
@@ -70,7 +73,27 @@
     }
   }
 
-  async function handleSelectFile(path: string) {
+  function handleSelectFile(path: string) {
+    if (dirty) {
+      pendingFile = path;
+      discardConfirmOpen = true;
+      return;
+    }
+    void loadFile(path);
+  }
+
+  function confirmDiscardAndSelect() {
+    discardConfirmOpen = false;
+    void loadFile(pendingFile);
+    pendingFile = "";
+  }
+
+  function cancelDiscard() {
+    discardConfirmOpen = false;
+    pendingFile = "";
+  }
+
+  async function loadFile(path: string) {
     selectedFile = path;
     loading = true;
     error = "";
@@ -175,3 +198,12 @@
     {/if}
   </div>
 </div>
+
+<Modal open={discardConfirmOpen} title="Discard unsaved changes?" onClose={cancelDiscard}>
+  Switching files will discard your unsaved edits to "{fileName(selectedFile)}".
+
+  {#snippet actions()}
+    <button class="btn btn-secondary" onclick={cancelDiscard}>Cancel</button>
+    <button class="btn btn-danger" onclick={confirmDiscardAndSelect}>Discard and switch</button>
+  {/snippet}
+</Modal>

--- a/web/src/lib/feed.svelte.ts
+++ b/web/src/lib/feed.svelte.ts
@@ -78,6 +78,13 @@ export class FeedStore {
         this.isProcessing = true;
         break;
 
+      case "turn_ended":
+        // Closes out turns that produce no response/error (e.g. zero-text
+        // replies) — harmless no-op if isProcessing already cleared via
+        // one of those paths.
+        this.isProcessing = false;
+        break;
+
       case "tool_call":
         this.handleToolCall(msg);
         break;

--- a/web/src/lib/generated/ServerMessage.ts
+++ b/web/src/lib/generated/ServerMessage.ts
@@ -8,6 +8,10 @@ export type ServerMessage = { "type": "turn_started",
 /**
  * Correlation ID of the message being processed.
  */
+reply_to: string, } | { "type": "turn_ended", 
+/**
+ * Correlation ID of the message whose turn just completed.
+ */
 reply_to: string, } | { "type": "tool_call", 
 /**
  * Unique tool call ID for correlating with results.

--- a/web/src/styles/chat.css
+++ b/web/src/styles/chat.css
@@ -27,6 +27,16 @@
   gap: 6px;
 }
 
+.chat-feed-empty {
+  padding: 48px 16px;
+  text-align: center;
+  font-family: var(--font-body);
+  font-style: italic;
+  font-weight: 300;
+  font-size: var(--fs-sm);
+  color: var(--text-dim);
+}
+
 /* ── Messages ──────────────────────────────────────────────────────────── */
 
 .msg {


### PR DESCRIPTION
This PR addresses observability gaps, durability concerns, and silent failures across multiple subsystems. The changes ensure errors are visible, persistence is verifiable, and collisions are detected rather than silently shadowed.

## Summary

Refactored turn outcome publishing to reduce complexity, added episode persistence markers to detect interrupted writes, implemented MCP tool-name collision detection with built-in tool reservation, improved HEARTBEAT.yml parse-error logging to avoid spam, and enhanced project/skill/webhook observability with duplicate detection and better error messages.

## Key Changes

**Turn Publishing & Protocol**
- Extracted turn outcome publishing logic into `publish_turn_outcome()` and `publish_turn_ended()` functions, reducing `handle_inbound_message()` complexity and removing the `too_many_lines` clippy exception
- Added `TurnLifecycleEvent::Ended` and `ServerMessage::TurnEnded` to close turns that produce zero response frames (e.g., interrupted or tool-only turns), preventing the prompt gate from hanging forever
- Updated CLI and web feed to handle the new `turn_ended` message type

**Episode Persistence & Durability**
- Added per-episode completion markers (`.done` files) written as the final step of episode persistence, certifying that transcript, observations, and search chunks all landed durably
- Implemented `find_interrupted_episodes()` to detect transcripts with missing markers (indicating interrupted writes) and report them at startup
- Backward-compatible: episodes with legacy `.obs.json` archives are recognized as complete even without markers

**MCP Tool-Name Collision Detection**
- Added `reserved_tool_names` field to `McpRegistry` to track built-in tool names
- Implemented `set_reserved_tool_names()` to reserve the namespace and warn when MCP tools collide with built-ins (built-in always wins, MCP tool is shadowed)
- Re-scans already-connected servers when built-in registry is initialized so collisions are reported even for early-connecting workspace servers
- Added `src/mcp/CLAUDE.md` documenting the collision policy

**HEARTBEAT.yml Parse-Error Logging**
- Modified `load_heartbeat()` to track the last parse-error message across calls, logging at `warn` only on first occurrence or when error text changes
- Subsequent identical errors log at `debug` to prevent spam on every scheduler tick (60s intervals)
- Logs `info` when a previously-broken file parses again
- Duplicate pulse names are now dropped (keeping first occurrence) to prevent silent scheduler-state collapse

**Project & Skill Observability**
- Added `warn_on_duplicate_names()` to detect duplicate project names (case-insensitive) on every scan, catching hand-edited collisions that would silently shadow one project
- Enhanced `create_project()` to check for name collisions in both active and archived projects before creation
- Updated skill activation to track the source directory (`skill_dir` field in `ActiveSkill`), enabling detection when a skill name now resolves to a different physical source
- Skill rescan now refreshes bodies for active skills whose source changed, or deactivates them with a warning if the new source can't be loaded

**Webhook & Error Messaging**
- Enhanced webhook handler to return descriptive error messages (404 with "unknown webhook", 401 with auth details, 400 for invalid content, 503 for publish failures) instead of bare status codes
- Added validation of webhook HTTP methods at config load time so typos surface at startup

**Project Manifest & File Listing**
- Added `skipped_count` to `ProjectManifest` to track entries that couldn't be listed (e.g., permission errors)
- Logs `warn` when manifest is incomplete due to skipped entries, making partial failures visible

**Skill Description Validation**
- Added `MAX_DESCRIPTION_LEN` constant (280 chars) to catch runaway multi-paragraph descriptions before they bloat every `<available_skills>` block
- Validates description length during `SKILL.md` parsing

**HTTP Timeout Configuration**
- Added `http_timeout_changed` to `ConfigDiff` to track timeout changes during reload
- Ensures HTTP client is rebuilt when timeout config changes

**Utilities & Documentation**
- Extracted `xml_escape()`

https://claude.ai/code/session_01KFHEb1LfCP72HLBeKkE8dU